### PR TITLE
feat(kanban): enrich cards, detail modal, and tab navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `@casys/mcp-erpnext` will be documented in this file.
 
+## [0.2.0] - 2026-03-20
+
+### Added
+
+- **Kanban card redesign** — accent-colored top strip (column color), tone-aware badges (error/warning/success/info/neutral with semantic colors), vertical metric layout with micro-caps labels, and integrated action footer with column-colored destination dots.
+- **Column-colored move buttons** — each move action button shows a 6px colored dot matching the destination column's color for instant visual orientation.
+
+### Changed
+
+- **Column focus mode improvements** — drag-and-drop is now disabled in focus mode (narrow viewports ≤920px) since only one column is visible. Cards use button-based moves exclusively. Removed unused `onDragOver`/`onDrop` handlers from the focus panel.
+- **Cursor affordance** — draggable cards in multi-column mode now show `cursor: grab` (and `grabbing` on drag).
+
+### Fixed
+
+- **Horizontal scroll eliminated** — added `overflow-x: hidden` on `html, body` and the `BoardView` root container, plus `minWidth: 0` on flex children (tabs, panel) to prevent content overflow in column focus mode.
+
 ## [0.1.9] - 2026-03-10
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,114 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+MCP server for ERPNext/Frappe ERP — 120 tools across 14 categories with 7 interactive UI viewers. Connects MCP-compatible AI agents to ERPNext via the Model Context Protocol. Published as `@casys/mcp-erpnext` on npm (Node bundle) and JSR (Deno).
+
+## Commands
+
+```bash
+# Run all tests
+deno test --allow-all tests/
+
+# Run a single test file
+deno test --allow-all tests/tools/sales_test.ts
+
+# Type check
+deno check mod.ts server.ts
+
+# Start HTTP server (dev)
+deno task serve
+
+# Build UI viewers (from src/ui/)
+cd src/ui && npm install && node build-all.mjs
+
+# Build Node.js npm bundle
+deno task ui:build && ./scripts/build-node.sh
+
+# Dev a specific UI viewer with HMR
+cd src/ui && npm run dev:kanban   # also: dev:invoice, dev:stock, dev:doclist
+```
+
+## Architecture
+
+### Dual-runtime design
+
+The project runs on **Deno** (development/JSR) and **Node.js** (npm). Platform-specific APIs are abstracted through a runtime adapter:
+- `src/runtime.ts` — Deno implementation (uses `Deno.env`, `Deno.readTextFile`, etc.)
+- `src/runtime.node.ts` — Node.js implementation (uses `process.env`, `node:fs`)
+
+The build script `scripts/build-node.sh` swaps `runtime.ts` with `runtime.node.ts`, strips `.ts` extensions from imports, and produces a single esbuild bundle at `dist-node/bin/mcp-erpnext.mjs`.
+
+**All source code imports `from "./runtime.ts"` — never import Deno or Node APIs directly.**
+
+### Tool architecture
+
+Each tool is an `ErpNextTool` object (`src/tools/types.ts`) with: `name`, `description`, `category`, `inputSchema` (JSON Schema), `handler`, and optional `_meta` (UI viewer binding). Tools are grouped by category in individual files under `src/tools/`, registered in `src/tools/mod.ts`, and exposed through `ErpNextToolsClient` (`src/client.ts`).
+
+Tool naming: `erpnext_{entity}_{operation}` (e.g. `erpnext_customer_list`, `erpnext_sales_order_create`).
+
+The `handler` receives `(input, ctx)` where `ctx.client` is the `FrappeClient` singleton. The client is lazily initialized from env vars on first use.
+
+### Frappe REST client
+
+`src/api/frappe-client.ts` is a zero-dependency HTTP client wrapping the Frappe REST API. Key methods: `list()`, `get()`, `create()`, `update()`, `delete()`, `callMethod()`. All errors throw `FrappeAPIError` with HTTP status and parsed body — no silent fallbacks.
+
+**Submit handlers must GET the doc first** to pass `modified` for Frappe's optimistic locking (see `docs/known-issues.md`). Cancel does not need this.
+
+### Kanban system
+
+The kanban viewer is the canonical read-write MCP App. Architecture:
+- `src/kanban/types.ts` — shared contracts (`KanbanBoard`, `KanbanCard`, `KanbanAdapter`, etc.)
+- `src/kanban/definitions.ts` — board registry (Task, Opportunity, Issue)
+- `src/kanban/adapters/{task,opportunity,issue}.ts` — per-DocType adapters that define columns, transitions, card mapping, and move execution
+- `src/tools/kanban.ts` — two tools (`erpnext_kanban_get_board`, `erpnext_kanban_move_card`) that dispatch to the right adapter
+
+To add a new kanban DocType: create an adapter in `src/kanban/adapters/`, register it in `definitions.ts`, and add it to the `ADAPTERS` map in `src/tools/kanban.ts`.
+
+Card design conventions:
+- **Accent strip**: 3px colored bar at top of each card, color from `card.accent` (matches column color)
+- **Badge tones**: `tone` field maps to semantic colors — `error` (red), `warning` (amber), `success` (green), `info` (blue), `neutral` (muted)
+- **Metrics**: Vertical layout with micro-caps labels (9px uppercase) and mono bold values
+- **Move buttons**: Integrated card footer with column-colored destination dots (6px circles matching target column color)
+- **Column focus mode**: On viewports ≤920px, switches to single-column tab navigation. Drag-and-drop is disabled; only button-based moves are available
+
+### UI viewers
+
+7 React viewers built with Vite, bundled as single HTML files via `vite-plugin-singlefile`. Located under `src/ui/{viewer-name}/`. Built output goes to `src/ui/dist/{viewer-name}/index.html`.
+
+Viewers use the MCP Apps SDK (`@modelcontextprotocol/ext-apps`). Interactive viewers use `app.callServerTool()` for mutations and `app.sendMessage()` for cross-viewer navigation.
+
+All viewers carry a `refreshRequest` payload for safe revalidation (injected by `src/tools/ui-refresh.ts`).
+
+Registered in `src/ui/viewers.ts` — add new viewer names there and in `server.ts`'s resource loop.
+
+### Server bootstrap
+
+`server.ts` creates a `ConcurrentMCPServer` (from `@casys/mcp-server`), registers all tools + UI resources, and starts in stdio or HTTP mode. Supports `--http`, `--port=`, `--hostname=`, and `--categories=` flags.
+
+## Testing patterns
+
+Tests use Deno's built-in test runner with `jsr:@std/assert`. All tests mock `FrappeClient` — no real network calls. Pattern:
+
+```typescript
+function makeMockClient(overrides = {}) {
+  return { list: async () => [], get: async () => ({...}), ...overrides } as unknown as FrappeClient;
+}
+const ctx = { client: makeMockClient({ list: async () => [...] }) };
+const result = await tool.handler(input, ctx);
+```
+
+Test files mirror source structure: `tests/tools/sales_test.ts` tests `src/tools/sales.ts`.
+
+## CI/CD
+
+GitHub Actions workflow (`.github/workflows/publish.yml`) publishes to JSR and npm on push to `main`. It builds UI viewers, then runs `build-node.sh` for the npm bundle.
+
+## Key conventions
+
+- Tool `_meta.ui.resourceUri` binds a tool's output to a specific UI viewer (e.g. `"ui://mcp-erpnext/doclist-viewer"`)
+- `FrappeFilter` is a `[field, operator, value]` tuple for Frappe list queries
+- Generic operations tools (`erpnext_doc_*`) are the escape hatch for any DocType not yet wrapped with dedicated tools
+- Environment variables: `ERPNEXT_URL`, `ERPNEXT_API_KEY`, `ERPNEXT_API_SECRET` (all required)

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Seven interactive [MCP Apps](https://github.com/modelcontextprotocol/ext-apps) v
 | `invoice-viewer` | Single invoice display (header, items, totals, payment status) |
 | `stock-viewer` | Stock balance table with color-coded qty badges |
 | `chart-viewer` | Universal chart renderer (12 chart types via Recharts) |
-| `kanban-viewer` | Canonical read-write kanban board with optimistic updates, AX, and server reconciliation |
+| `kanban-viewer` | Canonical read-write kanban board with accent-colored cards, tone-aware badges, column-colored move actions, optimistic updates, and server reconciliation |
 | `kpi-viewer` | Single metric card with delta, sparkline, trend indicator |
 | `funnel-viewer` | Trapezoid sales funnel with conversion rates between stages |
 
@@ -309,7 +309,7 @@ Seven interactive [MCP Apps](https://github.com/modelcontextprotocol/ext-apps) v
 
 Interactive and long-lived viewers carry their own `refreshRequest` payload so they can safely revalidate through MCP without depending on host-provided `tool-input` echoes.
 
-- `kanban-viewer` revalidates after successful mutations and refreshes on focus
+- `kanban-viewer` revalidates after successful mutations and refreshes on focus. In column focus mode (narrow viewports), drag is disabled and cards use button-based moves with column-colored destination indicators
 - `doclist-viewer`, `stock-viewer`, `invoice-viewer`, `chart-viewer`, `kpi-viewer`, and `funnel-viewer` support focus refresh plus a manual fallback refresh action
 
 ### Building UI viewers

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -88,7 +88,7 @@ The MCP App exists because the user is already inside a host conversation. Keepi
 
 | Interaction | Viewer | Tool Called | Description |
 |-------------|--------|------------|-------------|
-| **Task kanban drag-and-drop** | kanban-viewer | `erpnext_kanban_move_card` | Delivered in V1 with optimistic UI, FIFO mutation queue, AX affordances, and rollback on business errors. |
+| **Task kanban drag-and-drop** | kanban-viewer | `erpnext_kanban_move_card` | Delivered in V1 with optimistic UI, FIFO mutation queue, AX affordances, and rollback on business errors. Drag disabled in column focus mode (narrow viewports); button-based moves with column-colored destination dots instead. |
 | **Opportunity kanban** | kanban-viewer | `erpnext_kanban_get_board` + `erpnext_kanban_move_card` | Delivered. Opportunity boards run on the same canonical kanban viewer and adapter model. |
 | **Issue kanban** | kanban-viewer | `erpnext_kanban_get_board` + `erpnext_kanban_move_card` | Delivered. Issue boards run on the same canonical kanban viewer and adapter model. |
 | **KPI drill-down** | kpi-viewer | `erpnext_sales_invoice_list` (via `sendMessage`) | Click "Outstanding Receivables" KPI card -> injects a message that triggers doclist-viewer filtered on `outstanding_amount > 0`. |
@@ -109,6 +109,8 @@ The MCP App exists because the user is already inside a host conversation. Keepi
 - **Confirmation dialogs**: Destructive actions (Submit, Cancel) must show a confirmation step before calling the tool.
 - **Error surfaces**: `callServerTool` errors (permissions, validation) must be shown inline, not silently swallowed.
 - **Host capability check**: Before enabling interactive features, check `app.getHostCapabilities()?.serverTools` — not all hosts support proxied tool calls.
+- **Column focus mode**: On narrow viewports (≤920px), the board switches to single-column tab navigation. Drag-and-drop is disabled in this mode; cards use button-based moves exclusively with colored destination dots matching target column colors.
+- **Card design**: Accent strip (column color) at top, tone-aware badges (error=red, warning=amber, success=green), vertical metric layout with micro-caps labels, integrated action footer with column-colored destination indicators.
 
 ### TIER 2 — New Viewers & Infrastructure (P1)
 
@@ -142,7 +144,9 @@ The MCP App exists because the user is already inside a host conversation. Keepi
 - Register viewer name in `lib/erpnext/server.ts` UI_VIEWERS array
 - Interactive tool calls use `app.callServerTool()` from `@modelcontextprotocol/ext-apps`
 - Cross-viewer navigation uses `app.sendMessage()` to inject follow-up queries
-- `kanban-viewer` is the canonical read-write viewer
+- `kanban-viewer` is the canonical read-write viewer with accent-colored cards, tone-aware badges, and column-colored move buttons
+- Card `accent` field maps to column color for the top accent strip; badge `tone` maps to semantic colors (error/warning/success/info/neutral)
+- Move action buttons display a colored dot matching the destination column's color for visual orientation
 
 ## Sources
 - [MCP Apps SDK](https://github.com/modelcontextprotocol/ext-apps) — `@modelcontextprotocol/ext-apps`

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -221,7 +221,7 @@ Specific DocTypes also have dedicated submit/cancel tools: `erpnext_sales_order_
 | `invoice-viewer` | `ui://mcp-erpnext/invoice-viewer` | Single invoice display with refresh-aware revalidation |
 | `stock-viewer` | `ui://mcp-erpnext/stock-viewer` | Stock balance table with refresh-aware revalidation |
 | `chart-viewer` | `ui://mcp-erpnext/chart-viewer` | Universal chart renderer for analytics tools |
-| `kanban-viewer` | `ui://mcp-erpnext/kanban-viewer` | Canonical read-write kanban board for Task, Opportunity, and Issue |
+| `kanban-viewer` | `ui://mcp-erpnext/kanban-viewer` | Canonical read-write kanban board for Task, Opportunity, and Issue. Accent-colored cards, tone-aware badges, column-colored move buttons, column focus mode for narrow viewports |
 | `kpi-viewer` | `ui://mcp-erpnext/kpi-viewer` | Metric card with delta, sparkline, and refresh-aware revalidation |
 | `funnel-viewer` | `ui://mcp-erpnext/funnel-viewer` | Sales funnel with conversion stages and refresh-aware revalidation |
 

--- a/server.ts
+++ b/server.ts
@@ -69,7 +69,7 @@ async function main() {
   // Build MCP server
   const server = new ConcurrentMCPServer({
     name: "mcp-erpnext",
-    version: "0.1.9",
+    version: "0.2.0",
     maxConcurrent: 10,
     backpressureStrategy: "queue",
     validateSchema: true,

--- a/src/kanban/adapters/issue.ts
+++ b/src/kanban/adapters/issue.ts
@@ -7,6 +7,7 @@ import type {
   KanbanMoveResult,
   KanbanTransition,
 } from "../types.ts";
+import { formatShortDate, isDateOverdue, parseFirstAssignee, priorityTone } from "../field-utils.ts";
 
 const ISSUE_COLUMNS: Array<{ id: string; label: string; color: string; status: string }> = [
   { id: "open", label: "Open", color: "#60a5fa", status: "Open" },
@@ -26,6 +27,8 @@ const ISSUE_LIST_FIELDS = [
   "priority",
   "customer",
   "raised_by",
+  "resolution_by",
+  "_assign",
 ];
 
 const ISSUE_ALLOWED_TRANSITIONS: KanbanTransition[] = [
@@ -52,21 +55,32 @@ function columnIdForIssueStatus(status: unknown): string {
   return COLUMN_BY_STATUS.get(String(status ?? "Open")) ?? "open";
 }
 
-function priorityTone(priority: string): "neutral" | "warning" | "error" {
-  if (priority === "Urgent") return "error";
-  if (priority === "High") return "warning";
-  return "neutral";
-}
-
 function buildIssueCard(row: Record<string, unknown>): KanbanCard {
   const status = String(row.status ?? "Open");
   const columnId = columnIdForIssueStatus(status);
   const priority = typeof row.priority === "string" ? row.priority : undefined;
-  const subtitle = typeof row.customer === "string" && row.customer.length > 0
-    ? row.customer
-    : typeof row.raised_by === "string" && row.raised_by.length > 0
-    ? row.raised_by
-    : undefined;
+  let subtitle: string | undefined;
+  if (typeof row.customer === "string" && row.customer.length > 0) {
+    subtitle = row.customer;
+  } else if (typeof row.raised_by === "string" && row.raised_by.length > 0) {
+    subtitle = row.raised_by;
+  }
+
+  const badges: KanbanCard["badges"] = [];
+  if (priority) badges.push({ label: priority, tone: priorityTone(priority) });
+  const slaDate = row.resolution_by;
+  if (isDateOverdue(slaDate) && columnId !== "resolved" && columnId !== "closed") {
+    badges.push({ label: "SLA breach", tone: "error" });
+  }
+
+  const metrics: KanbanCard["metrics"] = [];
+  if (typeof row.raised_by === "string" && row.raised_by.length > 0) {
+    metrics.push({ label: "Raised By", value: row.raised_by });
+  }
+  const slaDisplay = formatShortDate(slaDate);
+  if (slaDisplay) metrics.push({ label: "SLA", value: slaDisplay });
+
+  const assignee = parseFirstAssignee(row._assign);
 
   return {
     id: String(row.name ?? ""),
@@ -74,10 +88,10 @@ function buildIssueCard(row: Record<string, unknown>): KanbanCard {
     subtitle,
     columnId,
     accent: ISSUE_COLUMNS.find((column) => column.id === columnId)?.color,
-    badges: priority ? [{ label: priority, tone: priorityTone(priority) }] : [],
-    metrics: typeof row.raised_by === "string" && row.raised_by.length > 0
-      ? [{ label: "Raised By", value: row.raised_by }]
-      : [],
+    badges,
+    metrics,
+    dueDate: typeof slaDate === "string" ? slaDate : undefined,
+    assignee,
   };
 }
 

--- a/src/kanban/adapters/opportunity.ts
+++ b/src/kanban/adapters/opportunity.ts
@@ -7,6 +7,7 @@ import type {
   KanbanMoveResult,
   KanbanTransition,
 } from "../types.ts";
+import { formatShortDate, isDateOverdue } from "../field-utils.ts";
 
 const OPPORTUNITY_COLUMNS: Array<{ id: string; label: string; color: string; status: string }> = [
   { id: "open", label: "Open", color: "#60a5fa", status: "Open" },
@@ -30,6 +31,7 @@ const OPPORTUNITY_LIST_FIELDS = [
   "currency",
   "probability",
   "opportunity_owner",
+  "expected_closing",
 ];
 
 const OPPORTUNITY_ALLOWED_TRANSITIONS: KanbanTransition[] = [
@@ -73,11 +75,33 @@ function buildOpportunityCard(row: Record<string, unknown>): KanbanCard {
   const amountValue = formatOpportunityAmount(row.opportunity_amount, row.currency);
   const probability = Number(row.probability);
   const probabilityValue = Number.isFinite(probability) ? `${probability}%` : null;
-  const title = typeof row.title === "string" && row.title.length > 0
-    ? row.title
-    : typeof row.party_name === "string" && row.party_name.length > 0
-    ? row.party_name
-    : String(row.name ?? "Untitled opportunity");
+  let title: string;
+  if (typeof row.title === "string" && row.title.length > 0) {
+    title = row.title;
+  } else if (typeof row.party_name === "string" && row.party_name.length > 0) {
+    title = row.party_name;
+  } else {
+    title = String(row.name ?? "Untitled opportunity");
+  }
+
+  const badges: KanbanCard["badges"] = [];
+  if (typeof row.opportunity_from === "string" && row.opportunity_from.length > 0) {
+    badges.push({ label: row.opportunity_from, tone: "neutral" });
+  }
+  const closingDate = row.expected_closing;
+  if (isDateOverdue(closingDate) && columnId !== "converted" && columnId !== "closed" && columnId !== "lost") {
+    badges.push({ label: "Overdue", tone: "error" });
+  }
+
+  const metrics: KanbanCard["metrics"] = [];
+  if (amountValue) metrics.push({ label: "Amount", value: amountValue });
+  if (probabilityValue) metrics.push({ label: "Probability", value: probabilityValue });
+  const closingDisplay = formatShortDate(closingDate);
+  if (closingDisplay) metrics.push({ label: "Closing", value: closingDisplay });
+
+  const assignee = typeof row.opportunity_owner === "string" && row.opportunity_owner.length > 0
+    ? row.opportunity_owner
+    : undefined;
 
   return {
     id: String(row.name ?? ""),
@@ -85,13 +109,10 @@ function buildOpportunityCard(row: Record<string, unknown>): KanbanCard {
     subtitle: typeof row.party_name === "string" ? row.party_name : undefined,
     columnId,
     accent: OPPORTUNITY_COLUMNS.find((column) => column.id === columnId)?.color,
-    badges: typeof row.opportunity_from === "string" && row.opportunity_from.length > 0
-      ? [{ label: row.opportunity_from, tone: "neutral" }]
-      : [],
-    metrics: [
-      ...(amountValue ? [{ label: "Amount", value: amountValue }] : []),
-      ...(probabilityValue ? [{ label: "Probability", value: probabilityValue }] : []),
-    ],
+    badges,
+    metrics,
+    dueDate: typeof closingDate === "string" ? closingDate : undefined,
+    assignee,
   };
 }
 

--- a/src/kanban/adapters/task.ts
+++ b/src/kanban/adapters/task.ts
@@ -7,6 +7,13 @@ import type {
   KanbanMoveResult,
   KanbanTransition,
 } from "../types.ts";
+import {
+  formatShortDate,
+  isDateOverdue,
+  parseFirstAssignee,
+  priorityTone,
+  truncateDescription,
+} from "../field-utils.ts";
 
 const TASK_COLUMNS: Array<{ id: string; label: string; color: string; status: string }> = [
   { id: "open", label: "Open", color: "#60a5fa", status: "Open" },
@@ -26,6 +33,9 @@ const TASK_LIST_FIELDS = [
   "status",
   "priority",
   "progress",
+  "exp_end_date",
+  "description",
+  "_assign",
 ];
 
 const TASK_ALLOWED_TRANSITIONS: KanbanTransition[] = [
@@ -50,11 +60,26 @@ function buildTaskCard(row: Record<string, unknown>): KanbanCard {
   const status = String(row.status ?? "Open");
   const columnId = columnIdForTaskStatus(status);
   const priority = typeof row.priority === "string" ? row.priority : undefined;
-  const progress = typeof row.progress === "number"
-    ? row.progress
-    : Number.isFinite(Number(row.progress))
-    ? Number(row.progress)
-    : undefined;
+  let progress: number | undefined;
+  if (typeof row.progress === "number") {
+    progress = row.progress;
+  } else if (Number.isFinite(Number(row.progress))) {
+    progress = Number(row.progress);
+  }
+
+  const badges: KanbanCard["badges"] = [];
+  if (priority) badges.push({ label: priority, tone: priorityTone(priority) });
+  const dueDateStr = row.exp_end_date;
+  if (isDateOverdue(dueDateStr) && columnId !== "completed" && columnId !== "cancelled") {
+    badges.push({ label: "Overdue", tone: "error" });
+  }
+
+  const metrics: KanbanCard["metrics"] = [];
+  if (progress !== undefined) metrics.push({ label: "Progress", value: `${progress}%` });
+  const dueDateDisplay = formatShortDate(dueDateStr);
+  if (dueDateDisplay) metrics.push({ label: "Due", value: dueDateDisplay });
+
+  const assignee = parseFirstAssignee(row._assign);
 
   return {
     id: String(row.name ?? ""),
@@ -62,15 +87,12 @@ function buildTaskCard(row: Record<string, unknown>): KanbanCard {
     subtitle: typeof row.project === "string" ? row.project : undefined,
     columnId,
     accent: TASK_COLUMNS.find((column) => column.id === columnId)?.color,
-    badges: priority ? [{ label: priority, tone: priorityTone(priority) }] : [],
-    metrics: progress === undefined ? [] : [{ label: "Progress", value: `${progress}%` }],
+    badges,
+    metrics,
+    description: truncateDescription(row.description),
+    dueDate: typeof dueDateStr === "string" ? dueDateStr : undefined,
+    assignee,
   };
-}
-
-function priorityTone(priority: string): "neutral" | "warning" | "error" {
-  if (priority === "Urgent") return "error";
-  if (priority === "High") return "warning";
-  return "neutral";
 }
 
 function columnIdForTaskStatus(status: unknown): string {

--- a/src/kanban/field-utils.ts
+++ b/src/kanban/field-utils.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared field utilities for kanban card enrichment.
+ * Parse Frappe-specific field formats into display-ready values.
+ */
+
+/** Extract the first assignee email from Frappe's `_assign` JSON field. */
+export function parseFirstAssignee(assign: unknown): string | undefined {
+  if (typeof assign !== "string" || assign.length === 0) return undefined;
+  try {
+    const parsed = JSON.parse(assign) as unknown;
+    if (Array.isArray(parsed) && parsed.length > 0 && typeof parsed[0] === "string") {
+      return parsed[0];
+    }
+  } catch {
+    // Not valid JSON — ignore
+  }
+  return undefined;
+}
+
+/** Strip HTML tags and &nbsp; entities, then truncate to `maxLen` with trailing ellipsis if needed. */
+export function truncateDescription(desc: unknown, maxLen = 80): string | undefined {
+  if (typeof desc !== "string" || desc.length === 0) return undefined;
+  const plain = desc.replace(/<[^>]*>/g, "").replace(/&nbsp;/g, " ").trim();
+  if (plain.length === 0) return undefined;
+  if (plain.length <= maxLen) return plain;
+  return plain.slice(0, maxLen).trimEnd() + "\u2026";
+}
+
+/** Check whether a date string (YYYY-MM-DD) is strictly before today. Today's date is NOT considered overdue. Uses string comparison to avoid timezone issues. */
+export function isDateOverdue(dateStr: unknown): boolean {
+  if (typeof dateStr !== "string" || !/^\d{4}-\d{2}-\d{2}/.test(dateStr)) return false;
+  const todayStr = new Date().toISOString().slice(0, 10);
+  return dateStr.slice(0, 10) < todayStr;
+}
+
+/** Format a date string for display (e.g. "Mar 20"). */
+export function formatShortDate(dateStr: unknown): string | undefined {
+  if (typeof dateStr !== "string" || dateStr.length === 0) return undefined;
+  const date = new Date(dateStr);
+  if (isNaN(date.getTime())) return undefined;
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+/** Map an ERPNext priority string to a badge tone. */
+export function priorityTone(priority: string): "neutral" | "warning" | "error" {
+  if (priority === "Urgent") return "error";
+  if (priority === "High") return "warning";
+  return "neutral";
+}

--- a/src/kanban/types.ts
+++ b/src/kanban/types.ts
@@ -28,6 +28,9 @@ export interface KanbanCard {
   badges?: KanbanBadge[];
   metrics?: KanbanMetric[];
   pending?: boolean;
+  description?: string;
+  dueDate?: string;
+  assignee?: string;
 }
 
 export interface KanbanTransition {

--- a/src/ui/global.css
+++ b/src/ui/global.css
@@ -93,10 +93,13 @@ html, body {
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  overflow-x: hidden;
 }
 
 #app {
-  /* No min-height: viewers size to their content in the feed iframe */
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--border);
 }
 
 /* Scrollbar */
@@ -135,4 +138,22 @@ html, body {
   background-size: 200% 100%;
   animation: shimmer 1.5s infinite;
   border-radius: var(--radius-sm);
+}
+
+/* Drag-scroll containers — no visible scrollbar */
+.drag-scroll::-webkit-scrollbar {
+  display: none;
+}
+.drag-scroll {
+  scrollbar-width: none;
+}
+
+/* Kanban card action buttons */
+article button:hover:not(:disabled) {
+  background: var(--bg-hover) !important;
+  color: var(--text-primary) !important;
+}
+article[draggable="true"]:active {
+  cursor: grabbing;
+  opacity: 0.85;
 }

--- a/src/ui/global.css
+++ b/src/ui/global.css
@@ -1,8 +1,8 @@
 /**
  * ERPNext MCP Apps UI — Global Styles
  *
- * Dark theme matching the Casys PML project palette.
- * No Tailwind — plain CSS custom properties + utility classes.
+ * Light/dark dual theme with CSS custom properties.
+ * No Tailwind — plain CSS variables + utility classes.
  */
 
 /* ── Shared tokens ──────────────────────────────────────────────── */
@@ -156,4 +156,46 @@ article button:hover:not(:disabled) {
 article[draggable="true"]:active {
   cursor: grabbing;
   opacity: 0.85;
+}
+
+/* Kanban detail modal */
+.kanban-detail-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.kanban-detail-panel {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  max-width: 520px;
+  width: 100%;
+  max-height: 80vh;
+  overflow-y: auto;
+  box-shadow: var(--shadow-md);
+  position: relative;
+}
+
+@media (prefers-color-scheme: dark) {
+  .kanban-detail-backdrop {
+    background: rgba(0, 0, 0, 0.65);
+  }
+}
+
+/* Clickable card title */
+.kanban-card-title-link {
+  cursor: pointer;
+  text-decoration: none;
+  color: inherit;
+}
+.kanban-card-title-link:hover {
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
 }

--- a/src/ui/kanban-viewer/src/KanbanViewer.tsx
+++ b/src/ui/kanban-viewer/src/KanbanViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type CSSProperties, type DragEvent } from "react";
+import { useEffect, useRef, useState, useCallback, type CSSProperties, type DragEvent, type ReactNode, type HTMLAttributes } from "react";
 import { App } from "@modelcontextprotocol/ext-apps";
 import { colors, fonts, styles } from "~/shared/theme";
 import { ErpNextBrandHeader } from "~/shared/ErpNextBrand";
@@ -48,6 +48,83 @@ function hiddenLiveRegionStyle(): CSSProperties {
 
 function extractTextContent(result: { content?: Array<{ type: string; text?: string }> }): string | null {
   return result.content?.find((item) => item.type === "text")?.text ?? null;
+}
+
+function DragScrollContainer({
+  children,
+  style,
+  ...rest
+}: { children: ReactNode; style?: CSSProperties } & HTMLAttributes<HTMLDivElement>) {
+  const ref = useRef<HTMLDivElement>(null);
+  const dragState = useRef({ active: false, startX: 0, scrollLeft: 0 });
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateFades = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(el.scrollLeft < el.scrollWidth - el.clientWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    updateFades();
+    const observer = new ResizeObserver(updateFades);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [updateFades]);
+
+  const onMouseDown = useCallback((e: React.MouseEvent) => {
+    const el = ref.current;
+    if (!el) return;
+    dragState.current = { active: true, startX: e.clientX, scrollLeft: el.scrollLeft };
+    el.style.cursor = "grabbing";
+    el.style.userSelect = "none";
+  }, []);
+
+  const onMouseMove = useCallback((e: React.MouseEvent) => {
+    if (!dragState.current.active) return;
+    const el = ref.current;
+    if (!el) return;
+    const delta = e.clientX - dragState.current.startX;
+    el.scrollLeft = dragState.current.scrollLeft - delta;
+    updateFades();
+  }, [updateFades]);
+
+  const onMouseUp = useCallback(() => {
+    dragState.current.active = false;
+    const el = ref.current;
+    if (el) {
+      el.style.cursor = "grab";
+      el.style.userSelect = "";
+    }
+  }, []);
+
+  const maskImage = canScrollLeft && canScrollRight
+    ? "linear-gradient(to right, transparent, black 24px, black calc(100% - 24px), transparent)"
+    : canScrollRight
+    ? "linear-gradient(to right, black calc(100% - 24px), transparent)"
+    : canScrollLeft
+    ? "linear-gradient(to right, transparent, black 24px)"
+    : undefined;
+
+  return (
+    <div
+      ref={ref}
+      style={{ ...style, WebkitMaskImage: maskImage, maskImage }}
+      onMouseDown={onMouseDown}
+      onMouseMove={onMouseMove}
+      onMouseUp={onMouseUp}
+      onMouseLeave={onMouseUp}
+      onScroll={updateFades}
+      className="drag-scroll"
+      {...rest}
+    >
+      {children}
+    </div>
+  );
 }
 
 function LoadingSkeleton() {
@@ -107,86 +184,242 @@ function ErrorState({ message }: { message: string }) {
   );
 }
 
+function badgeToneColors(tone?: string): { color: string; bg: string } {
+  switch (tone) {
+    case "error":
+      return { color: colors.error, bg: colors.errorDim };
+    case "warning":
+      return { color: colors.warning, bg: colors.warningDim };
+    case "success":
+      return { color: colors.success, bg: colors.successDim };
+    case "info":
+      return { color: colors.info, bg: colors.infoDim };
+    default:
+      return { color: colors.text.secondary, bg: colors.bg.elevated };
+  }
+}
+
 function KanbanCard({
   card,
   allowedTargets,
   onMove,
   onDragStart,
   onDragEnd,
+  enableDrag = true,
 }: {
   card: KanbanCardData;
-  allowedTargets: Array<{ columnId: string; label: string }>;
+  allowedTargets: Array<{ columnId: string; label: string; color?: string }>;
   onMove: (card: KanbanCardData, toColumn: string, label: string) => void;
   onDragStart: (card: KanbanCardData, event: DragEvent<HTMLElement>) => void;
   onDragEnd: () => void;
+  enableDrag?: boolean;
 }) {
+  const isDraggable = enableDrag && !card.pending;
+  const accentColor = card.accent ?? colors.accent;
+
   const cardStyle: CSSProperties = {
     background: colors.bg.surface,
     border: `1px solid ${card.pending ? colors.accent : colors.border}`,
     borderRadius: 8,
-    padding: "12px 12px 10px",
+    padding: 0,
     display: "flex",
     flexDirection: "column",
-    gap: 8,
     opacity: card.pending ? 0.72 : 1,
-    boxShadow: card.pending ? `0 0 0 1px ${colors.accentDim}` : undefined,
+    boxShadow: card.pending
+      ? `0 0 0 1px ${colors.accentDim}`
+      : `0 1px 3px rgba(0,0,0,0.06)`,
+    cursor: isDraggable ? "grab" : undefined,
+    overflow: "hidden",
+    position: "relative" as const,
   };
+
+  const hasMetrics = (card.metrics?.length ?? 0) > 0;
+  const hasBadges = (card.badges?.length ?? 0) > 0;
 
   return (
     <article
       style={cardStyle}
-      draggable={!card.pending}
-      onDragStart={(event) => onDragStart(card, event)}
-      onDragEnd={onDragEnd}
+      draggable={isDraggable}
+      onDragStart={isDraggable ? (event) => onDragStart(card, event) : undefined}
+      onDragEnd={isDraggable ? onDragEnd : undefined}
       className={card.pending ? "animate-pulse" : undefined}
       aria-busy={card.pending}
     >
-      <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
-        <div style={{ fontSize: 13, fontWeight: 700, color: colors.text.primary }}>{card.title}</div>
-        {card.subtitle && (
-          <div style={{ fontSize: 11, color: colors.text.muted }}>{card.subtitle}</div>
+      {/* Accent strip */}
+      <div
+        aria-hidden="true"
+        style={{
+          height: 4,
+          background: accentColor,
+          flexShrink: 0,
+          opacity: card.pending ? 0.5 : 0.85,
+        }}
+      />
+
+      {/* Card body */}
+      <div style={{ padding: "10px 12px 0", display: "flex", flexDirection: "column", gap: 6 }}>
+        {/* Header row: title + badges */}
+        <div style={{ display: "flex", alignItems: "flex-start", gap: 8 }}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div
+              style={{
+                fontSize: 13,
+                fontWeight: 600,
+                color: colors.text.primary,
+                lineHeight: 1.35,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                display: "-webkit-box",
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: "vertical" as const,
+              }}
+            >
+              {card.title}
+            </div>
+            {card.subtitle && (
+              <div
+                style={{
+                  fontSize: 11,
+                  color: colors.text.muted,
+                  marginTop: 2,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {card.subtitle}
+              </div>
+            )}
+          </div>
+          {hasBadges && (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 4, flexShrink: 0 }}>
+              {card.badges?.map((badge) => {
+                const tone = badgeToneColors(badge.tone);
+                return (
+                  <span
+                    key={`${card.id}-${badge.label}`}
+                    style={{
+                      ...styles.badge(tone.color, tone.bg),
+                      fontSize: 10,
+                      padding: "1px 7px",
+                      borderRadius: 3,
+                      fontWeight: 700,
+                      letterSpacing: "0.03em",
+                      textTransform: "uppercase" as const,
+                    }}
+                  >
+                    {badge.label}
+                  </span>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Metrics row */}
+        {hasMetrics && (
+          <div
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: 12,
+              padding: "4px 0 2px",
+              borderTop: `1px solid ${colors.borderSubtle}`,
+            }}
+          >
+            {card.metrics?.map((metric) => (
+              <div
+                key={`${card.id}-${metric.label}`}
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 1,
+                }}
+              >
+                <span
+                  style={{
+                    fontSize: 9,
+                    fontWeight: 600,
+                    color: colors.text.faint,
+                    textTransform: "uppercase" as const,
+                    letterSpacing: "0.06em",
+                  }}
+                >
+                  {metric.label}
+                </span>
+                <span
+                  style={{
+                    fontSize: 13,
+                    fontWeight: 700,
+                    color: colors.text.primary,
+                    fontFamily: fonts.mono,
+                    letterSpacing: "-0.02em",
+                  }}
+                >
+                  {metric.value}
+                </span>
+              </div>
+            ))}
+          </div>
         )}
       </div>
-      {(card.badges?.length ?? 0) > 0 && (
-        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
-          {card.badges?.map((badge) => (
-            <span
-              key={`${card.id}-${badge.label}`}
-              style={styles.badge(colors.text.secondary, colors.bg.elevated)}
-            >
-              {badge.label}
-            </span>
-          ))}
-        </div>
-      )}
-      {(card.metrics?.length ?? 0) > 0 && (
-        <div style={{ display: "flex", flexWrap: "wrap", gap: 10 }}>
-          {card.metrics?.map((metric) => (
-            <div key={`${card.id}-${metric.label}`} style={{ fontSize: 11, color: colors.text.muted }}>
-              <span style={{ color: colors.text.faint }}>{metric.label}</span>{" "}
-              <span style={{ color: colors.text.primary, fontFamily: fonts.mono }}>{metric.value}</span>
-            </div>
-          ))}
-        </div>
-      )}
+
+      {/* Action buttons */}
       {allowedTargets.length > 0 && (
-        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
-          {allowedTargets.map((target) => (
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 0,
+            borderTop: `1px solid ${colors.borderSubtle}`,
+            marginTop: hasMetrics ? 0 : 6,
+          }}
+        >
+          {allowedTargets.map((target, index) => (
             <button
               key={`${card.id}-${target.columnId}`}
               type="button"
               onClick={() => onMove(card, target.columnId, target.label)}
               disabled={card.pending}
               style={{
-                ...styles.button,
-                padding: "5px 10px",
+                flex: 1,
+                minWidth: 0,
+                padding: "7px 6px",
                 fontSize: 11,
-                color: colors.text.primary,
-                opacity: card.pending ? 0.6 : 1,
-                outlineOffset: 2,
+                fontWeight: 500,
+                fontFamily: fonts.sans,
+                color: colors.text.muted,
+                background: "transparent",
+                border: "none",
+                borderRight: index < allowedTargets.length - 1
+                  ? `1px solid ${colors.borderSubtle}`
+                  : "none",
+                cursor: card.pending ? "default" : "pointer",
+                opacity: card.pending ? 0.5 : 1,
+                transition: "color 0.12s, background 0.12s",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                outlineOffset: -2,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: 5,
               }}
               aria-label={`Move ${card.title} to ${target.label}`}
             >
+              {target.color && (
+                <span
+                  aria-hidden="true"
+                  style={{
+                    width: 6,
+                    height: 6,
+                    borderRadius: "50%",
+                    background: target.color,
+                    flexShrink: 0,
+                  }}
+                />
+              )}
               {target.label}
             </button>
           ))}
@@ -224,13 +457,14 @@ function KanbanColumn({
         transition.fromColumn === card.columnId &&
         transition.toColumn !== card.columnId
       )
-      .map((transition) => ({
-        columnId: transition.toColumn,
-        label:
-          transition.label ??
-          board.columns.find((candidate) => candidate.id === transition.toColumn)?.label ??
-          transition.toColumn,
-      }));
+      .map((transition) => {
+        const targetCol = board.columns.find((candidate) => candidate.id === transition.toColumn);
+        return {
+          columnId: transition.toColumn,
+          label: transition.label ?? targetCol?.label ?? transition.toColumn,
+          color: targetCol?.color,
+        };
+      });
 
   return (
     <section
@@ -296,12 +530,13 @@ function ColumnTabs({
   onSelect: (index: number) => void;
 }) {
   return (
-    <div
+    <DragScrollContainer
       style={{
         display: "flex",
         gap: 4,
         overflowX: "auto",
-        paddingBottom: 4,
+        minWidth: 0,
+        cursor: "grab",
       }}
       role="tablist"
       aria-label="Kanban columns"
@@ -318,12 +553,15 @@ function ColumnTabs({
             onClick={() => onSelect(index)}
             style={{
               ...styles.button,
-              padding: "7px 14px",
+              padding: "7px 14px 6px",
               fontSize: 12,
               fontWeight: isActive ? 700 : 500,
               color: isActive ? colors.text.primary : colors.text.muted,
               background: isActive ? colors.bg.surface : "transparent",
-              borderColor: isActive ? colors.accent : colors.border,
+              borderColor: isActive ? "transparent" : colors.border,
+              borderBottomWidth: 2,
+              borderBottomColor: isActive ? column.color : "transparent",
+              borderRadius: isActive ? "6px 6px 0 0" : "6px",
               display: "flex",
               alignItems: "center",
               gap: 6,
@@ -356,7 +594,7 @@ function ColumnTabs({
           </button>
         );
       })}
-    </div>
+    </DragScrollContainer>
   );
 }
 
@@ -397,9 +635,9 @@ function BoardView({
   const focusedColumn = useFocusMode ? board.columns[safeFocusIndex] : null;
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", minHeight: "100vh", background: colors.bg.root }}>
+    <div style={{ display: "flex", flexDirection: "column", minHeight: "100vh", background: colors.bg.root, overflowX: "hidden", width: "100%" }}>
       <ErpNextBrandHeader />
-      <div style={{ padding: "14px 16px", display: "flex", flexDirection: "column", gap: 14 }}>
+      <div style={{ padding: "14px 16px", display: "flex", flexDirection: "column", gap: 14, minWidth: 0 }}>
         <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
           <div style={{ fontSize: 14, fontWeight: 700, color: colors.text.primary }}>
             {board.title}
@@ -423,9 +661,7 @@ function BoardView({
                 id={`kanban-panel-${focusedColumn.id}`}
                 role="tabpanel"
                 aria-label={focusedColumn.label}
-                style={{ display: "flex", flexDirection: "column", gap: 8 }}
-                onDragOver={(event) => onDragOverColumn(focusedColumn.id, event)}
-                onDrop={(event) => onDropCard(focusedColumn.id, event)}
+                style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 0 }}
               >
                 {board.cards
                   .filter((card) => card.columnId === focusedColumn.id)
@@ -437,13 +673,14 @@ function BoardView({
                           t.fromColumn === card.columnId &&
                           t.toColumn !== card.columnId
                       )
-                      .map((t) => ({
-                        columnId: t.toColumn,
-                        label:
-                          t.label ??
-                          board.columns.find((c) => c.id === t.toColumn)?.label ??
-                          t.toColumn,
-                      }));
+                      .map((t) => {
+                        const targetCol = board.columns.find((c) => c.id === t.toColumn);
+                        return {
+                          columnId: t.toColumn,
+                          label: t.label ?? targetCol?.label ?? t.toColumn,
+                          color: targetCol?.color,
+                        };
+                      });
                     return (
                       <KanbanCard
                         key={card.id}
@@ -452,6 +689,7 @@ function BoardView({
                         onMove={onMove}
                         onDragStart={onDragStart}
                         onDragEnd={onDragEnd}
+                        enableDrag={false}
                       />
                     );
                   })}

--- a/src/ui/kanban-viewer/src/KanbanViewer.tsx
+++ b/src/ui/kanban-viewer/src/KanbanViewer.tsx
@@ -9,6 +9,7 @@ import {
 } from "~/shared/kanban/presentation";
 import { useKanbanBoard } from "~/shared/kanban/useKanbanBoard";
 import type { KanbanBoardData, KanbanCardData, KanbanColumnData } from "~/shared/kanban/types";
+import type { CardDetailState } from "~/shared/kanban/state";
 import {
   applyOptimisticMove,
   canDropCardInColumn,
@@ -48,6 +49,26 @@ function hiddenLiveRegionStyle(): CSSProperties {
 
 function extractTextContent(result: { content?: Array<{ type: string; text?: string }> }): string | null {
   return result.content?.find((item) => item.type === "text")?.text ?? null;
+}
+
+function getAvailableTargets(
+  board: KanbanBoardData,
+  columnId: string,
+): Array<{ columnId: string; label: string; color?: string }> {
+  return board.allowedTransitions
+    .filter((transition) =>
+      transition.allowed &&
+      transition.fromColumn === columnId &&
+      transition.toColumn !== columnId
+    )
+    .map((transition) => {
+      const targetCol = board.columns.find((column) => column.id === transition.toColumn);
+      return {
+        columnId: transition.toColumn,
+        label: transition.label ?? targetCol?.label ?? transition.toColumn,
+        color: targetCol?.color,
+      };
+    });
 }
 
 function DragScrollContainer({
@@ -102,13 +123,20 @@ function DragScrollContainer({
     }
   }, []);
 
-  const maskImage = canScrollLeft && canScrollRight
-    ? "linear-gradient(to right, transparent, black 24px, black calc(100% - 24px), transparent)"
-    : canScrollRight
-    ? "linear-gradient(to right, black calc(100% - 24px), transparent)"
-    : canScrollLeft
-    ? "linear-gradient(to right, transparent, black 24px)"
-    : undefined;
+  function computeMaskImage(): string | undefined {
+    if (canScrollLeft && canScrollRight) {
+      return "linear-gradient(to right, transparent, black 24px, black calc(100% - 24px), transparent)";
+    }
+    if (canScrollRight) {
+      return "linear-gradient(to right, black calc(100% - 24px), transparent)";
+    }
+    if (canScrollLeft) {
+      return "linear-gradient(to right, transparent, black 24px)";
+    }
+    return undefined;
+  }
+
+  const maskImage = computeMaskImage();
 
   return (
     <div
@@ -199,12 +227,43 @@ function badgeToneColors(tone?: string): { color: string; bg: string } {
   }
 }
 
+function AssigneeBadge({ email }: { email: string }) {
+  const initial = email.charAt(0).toUpperCase();
+  const atIndex = email.indexOf("@");
+  const displayName = atIndex > 0 ? email.slice(0, atIndex) : email;
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+      <span
+        style={{
+          width: 14,
+          height: 14,
+          borderRadius: "50%",
+          background: colors.accent,
+          color: "#fff",
+          fontSize: 8,
+          fontWeight: 700,
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flexShrink: 0,
+        }}
+      >
+        {initial}
+      </span>
+      <span style={{ fontSize: 10, color: colors.text.muted, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        {displayName}
+      </span>
+    </span>
+  );
+}
+
 function KanbanCard({
   card,
   allowedTargets,
   onMove,
   onDragStart,
   onDragEnd,
+  onTitleClick,
   enableDrag = true,
 }: {
   card: KanbanCardData;
@@ -212,6 +271,7 @@ function KanbanCard({
   onMove: (card: KanbanCardData, toColumn: string, label: string) => void;
   onDragStart: (card: KanbanCardData, event: DragEvent<HTMLElement>) => void;
   onDragEnd: () => void;
+  onTitleClick?: (card: KanbanCardData) => void;
   enableDrag?: boolean;
 }) {
   const isDraggable = enableDrag && !card.pending;
@@ -235,6 +295,18 @@ function KanbanCard({
 
   const hasMetrics = (card.metrics?.length ?? 0) > 0;
   const hasBadges = (card.badges?.length ?? 0) > 0;
+
+  const titleStyle: CSSProperties = {
+    fontSize: 13,
+    fontWeight: 600,
+    color: colors.text.primary,
+    lineHeight: 1.35,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    display: "-webkit-box",
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: "vertical" as const,
+  };
 
   return (
     <article
@@ -261,21 +333,22 @@ function KanbanCard({
         {/* Header row: title + badges */}
         <div style={{ display: "flex", alignItems: "flex-start", gap: 8 }}>
           <div style={{ flex: 1, minWidth: 0 }}>
-            <div
-              style={{
-                fontSize: 13,
-                fontWeight: 600,
-                color: colors.text.primary,
-                lineHeight: 1.35,
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                display: "-webkit-box",
-                WebkitLineClamp: 2,
-                WebkitBoxOrient: "vertical" as const,
-              }}
-            >
-              {card.title}
-            </div>
+            {onTitleClick ? (
+              <span
+                className="kanban-card-title-link"
+                role="button"
+                tabIndex={0}
+                onClick={(e) => { e.stopPropagation(); onTitleClick(card); }}
+                onKeyDown={(e) => { if (e.key === "Enter") onTitleClick(card); }}
+                style={titleStyle}
+              >
+                {card.title}
+              </span>
+            ) : (
+              <div style={titleStyle}>
+                {card.title}
+              </div>
+            )}
             {card.subtitle && (
               <div
                 style={{
@@ -315,6 +388,30 @@ function KanbanCard({
             </div>
           )}
         </div>
+
+        {/* Description */}
+        {card.description && (
+          <div
+            style={{
+              fontSize: 11,
+              fontStyle: "italic",
+              color: colors.text.muted,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              lineHeight: 1.3,
+            }}
+          >
+            {card.description}
+          </div>
+        )}
+
+        {/* Assignee */}
+        {card.assignee && (
+          <div style={{ marginTop: -2 }}>
+            <AssigneeBadge email={card.assignee} />
+          </div>
+        )}
 
         {/* Metrics row */}
         {hasMetrics && (
@@ -439,6 +536,7 @@ function KanbanColumn({
   onDragStart,
   onDragEnd,
   onDragOverColumn,
+  onTitleClick,
 }: {
   column: KanbanColumnData;
   cards: KanbanCardData[];
@@ -449,23 +547,8 @@ function KanbanColumn({
   onDragStart: (card: KanbanCardData, event: DragEvent<HTMLElement>) => void;
   onDragEnd: () => void;
   onDragOverColumn: (columnId: string, event: DragEvent<HTMLElement>) => void;
+  onTitleClick?: (card: KanbanCardData) => void;
 }) {
-  const availableTargets = (card: KanbanCardData) =>
-    board.allowedTransitions
-      .filter((transition) =>
-        transition.allowed &&
-        transition.fromColumn === card.columnId &&
-        transition.toColumn !== card.columnId
-      )
-      .map((transition) => {
-        const targetCol = board.columns.find((candidate) => candidate.id === transition.toColumn);
-        return {
-          columnId: transition.toColumn,
-          label: transition.label ?? targetCol?.label ?? transition.toColumn,
-          color: targetCol?.color,
-        };
-      });
-
   return (
     <section
       style={{
@@ -509,14 +592,36 @@ function KanbanColumn({
           <KanbanCard
             key={card.id}
             card={card}
-            allowedTargets={availableTargets(card)}
+            allowedTargets={getAvailableTargets(board, card.columnId)}
             onMove={onMove}
             onDragStart={onDragStart}
             onDragEnd={onDragEnd}
+            onTitleClick={onTitleClick}
           />
         ))}
       </div>
     </section>
+  );
+}
+
+function ScrollArrow({ direction, onClick }: { direction: "left" | "right"; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={`Scroll ${direction}`}
+      style={{
+        ...styles.button,
+        padding: "6px 4px",
+        fontSize: 12,
+        lineHeight: 1,
+        borderRadius: 6,
+        flexShrink: 0,
+        minWidth: 22,
+      }}
+    >
+      {direction === "left" ? "\u2039" : "\u203a"}
+    </button>
   );
 }
 
@@ -529,72 +634,103 @@ function ColumnTabs({
   focusIndex: number;
   onSelect: (index: number) => void;
 }) {
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [showLeft, setShowLeft] = useState(false);
+  const [showRight, setShowRight] = useState(false);
+
+  const updateArrows = useCallback(() => {
+    const first = tabRefs.current[0];
+    const last = tabRefs.current[columns.length - 1];
+    const container = first?.parentElement;
+    if (!container || !first || !last) return;
+    setShowLeft(container.scrollLeft > 0);
+    setShowRight(container.scrollLeft < container.scrollWidth - container.clientWidth - 1);
+  }, [columns.length]);
+
+  useEffect(updateArrows, [updateArrows]);
+
+  useEffect(() => {
+    const btn = tabRefs.current[focusIndex];
+    if (!btn) return;
+    const container = btn.parentElement;
+    if (!container) return;
+    container.scrollTo({ left: btn.offsetLeft - 40, behavior: "smooth" });
+    requestAnimationFrame(updateArrows);
+  }, [focusIndex, updateArrows]);
+
   return (
-    <DragScrollContainer
-      style={{
-        display: "flex",
-        gap: 4,
-        overflowX: "auto",
-        minWidth: 0,
-        cursor: "grab",
-      }}
-      role="tablist"
-      aria-label="Kanban columns"
-    >
-      {columns.map((column, index) => {
-        const isActive = index === focusIndex;
-        return (
-          <button
-            key={column.id}
-            type="button"
-            role="tab"
-            aria-selected={isActive}
-            aria-controls={`kanban-panel-${column.id}`}
-            onClick={() => onSelect(index)}
-            style={{
-              ...styles.button,
-              padding: "7px 14px 6px",
-              fontSize: 12,
-              fontWeight: isActive ? 700 : 500,
-              color: isActive ? colors.text.primary : colors.text.muted,
-              background: isActive ? colors.bg.surface : "transparent",
-              borderColor: isActive ? "transparent" : colors.border,
-              borderBottomWidth: 2,
-              borderBottomColor: isActive ? column.color : "transparent",
-              borderRadius: isActive ? "6px 6px 0 0" : "6px",
-              display: "flex",
-              alignItems: "center",
-              gap: 6,
-              whiteSpace: "nowrap",
-              flexShrink: 0,
-            }}
-          >
-            <span
-              aria-hidden="true"
+    <div style={{ display: "flex", alignItems: "center", gap: 4, minWidth: 0 }}>
+      {showLeft && <ScrollArrow direction="left" onClick={() => onSelect(Math.max(0, focusIndex - 1))} />}
+      <DragScrollContainer
+        onScroll={updateArrows}
+        style={{
+          display: "flex",
+          gap: 4,
+          overflowX: "auto",
+          minWidth: 0,
+          flex: 1,
+          cursor: "grab",
+        }}
+        role="tablist"
+        aria-label="Kanban columns"
+      >
+        {columns.map((column, index) => {
+          const isActive = index === focusIndex;
+          return (
+            <button
+              key={column.id}
+              ref={(el) => { tabRefs.current[index] = el; }}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              aria-controls={`kanban-panel-${column.id}`}
+              onClick={() => onSelect(index)}
               style={{
-                width: 8,
-                height: 8,
-                borderRadius: "50%",
-                background: column.color,
+                ...styles.button,
+                padding: "7px 14px 6px",
+                fontSize: 12,
+                fontWeight: isActive ? 700 : 500,
+                color: isActive ? colors.text.primary : colors.text.muted,
+                background: isActive ? colors.bg.surface : "transparent",
+                borderColor: isActive ? "transparent" : colors.border,
+                borderBottomWidth: 2,
+                borderBottomColor: isActive ? column.color : "transparent",
+                borderRadius: isActive ? "6px 6px 0 0" : "6px",
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+                whiteSpace: "nowrap",
                 flexShrink: 0,
               }}
-            />
-            {column.label}
-            <span
-              style={{
-                ...styles.badge(
-                  isActive ? colors.text.primary : colors.text.muted,
-                  isActive ? `${column.color}30` : `${colors.text.muted}15`
-                ),
-                fontSize: 10,
-              }}
             >
-              {column.count}
-            </span>
-          </button>
-        );
-      })}
-    </DragScrollContainer>
+              <span
+                aria-hidden="true"
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: "50%",
+                  background: column.color,
+                  flexShrink: 0,
+                }}
+              />
+              {column.label}
+              <span
+                style={{
+                  ...styles.badge(
+                    isActive ? colors.text.primary : colors.text.muted,
+                    isActive ? `${column.color}30` : `${colors.text.muted}15`
+                  ),
+                  fontSize: 10,
+                }}
+              >
+                {column.count}
+              </span>
+            </button>
+          );
+        })}
+      </DragScrollContainer>
+      {showRight && <ScrollArrow direction="right" onClick={() => onSelect(Math.min(columns.length - 1, focusIndex + 1))} />}
+    </div>
   );
 }
 
@@ -607,6 +743,7 @@ function BoardView({
   onDragStart,
   onDragEnd,
   onDragOverColumn,
+  onTitleClick,
 }: {
   board: KanbanBoardData;
   inlineError: string | null;
@@ -616,6 +753,7 @@ function BoardView({
   onDragStart: (card: KanbanCardData, event: React.DragEvent<HTMLElement>) => void;
   onDragEnd: () => void;
   onDragOverColumn: (columnId: string, event: React.DragEvent<HTMLElement>) => void;
+  onTitleClick?: (card: KanbanCardData) => void;
 }) {
   const [viewportWidth, setViewportWidth] = useState(
     typeof window !== "undefined" ? window.innerWidth : 1200
@@ -635,7 +773,7 @@ function BoardView({
   const focusedColumn = useFocusMode ? board.columns[safeFocusIndex] : null;
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", minHeight: "100vh", background: colors.bg.root, overflowX: "hidden", width: "100%" }}>
+    <div style={{ display: "flex", flexDirection: "column", minHeight: "100%", background: colors.bg.root, overflowX: "hidden", width: "100%" }}>
       <ErpNextBrandHeader />
       <div style={{ padding: "14px 16px", display: "flex", flexDirection: "column", gap: 14, minWidth: 0 }}>
         <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
@@ -665,34 +803,18 @@ function BoardView({
               >
                 {board.cards
                   .filter((card) => card.columnId === focusedColumn.id)
-                  .map((card) => {
-                    const availableTargets = board.allowedTransitions
-                      .filter(
-                        (t) =>
-                          t.allowed &&
-                          t.fromColumn === card.columnId &&
-                          t.toColumn !== card.columnId
-                      )
-                      .map((t) => {
-                        const targetCol = board.columns.find((c) => c.id === t.toColumn);
-                        return {
-                          columnId: t.toColumn,
-                          label: t.label ?? targetCol?.label ?? t.toColumn,
-                          color: targetCol?.color,
-                        };
-                      });
-                    return (
-                      <KanbanCard
-                        key={card.id}
-                        card={card}
-                        allowedTargets={availableTargets}
-                        onMove={onMove}
-                        onDragStart={onDragStart}
-                        onDragEnd={onDragEnd}
-                        enableDrag={false}
-                      />
-                    );
-                  })}
+                  .map((card) => (
+                    <KanbanCard
+                      key={card.id}
+                      card={card}
+                      allowedTargets={getAvailableTargets(board, card.columnId)}
+                      onMove={onMove}
+                      onDragStart={onDragStart}
+                      onDragEnd={onDragEnd}
+                      onTitleClick={onTitleClick}
+                      enableDrag={false}
+                    />
+                  ))}
                 {board.cards.filter((card) => card.columnId === focusedColumn.id).length === 0 && (
                   <div
                     style={{
@@ -722,8 +844,372 @@ function BoardView({
                 onDragStart={onDragStart}
                 onDragEnd={onDragEnd}
                 onDragOverColumn={onDragOverColumn}
+                onTitleClick={onTitleClick}
               />
             ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const DETAIL_SKIP_FIELDS = new Set([
+  "doctype", "docstatus", "idx", "modified_by", "owner",
+  "creation", "modified", "_user_tags", "_comments", "_assign",
+  "_liked_by", "_seen", "__last_sync_on",
+]);
+
+const READONLY_FIELDS = new Set([
+  "name", "status", "workflow_state",
+]);
+
+function DetailFieldGrid({
+  detail,
+  editedFields,
+  onFieldChange,
+}: {
+  detail: Record<string, unknown>;
+  editedFields: Record<string, string>;
+  onFieldChange: (key: string, value: string) => void;
+}) {
+  const entries = Object.entries(detail).filter(
+    ([key, value]) =>
+      !DETAIL_SKIP_FIELDS.has(key) &&
+      value !== null &&
+      value !== undefined &&
+      value !== "" &&
+      typeof value !== "object",
+  );
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "minmax(100px, 1fr) 2fr",
+        gap: "1px",
+        fontSize: 12,
+      }}
+    >
+      {entries.map(([key, value]) => {
+        const isReadonly = READONLY_FIELDS.has(key);
+        const isEdited = key in editedFields;
+        const displayValue = isEdited ? editedFields[key] : String(value);
+
+        return (
+          <div key={key} style={{ display: "contents" }}>
+            <div
+              style={{
+                padding: "6px 10px",
+                fontWeight: 600,
+                color: isEdited ? colors.accent : colors.text.muted,
+                background: colors.bg.elevated,
+                borderBottom: `1px solid ${colors.borderSubtle}`,
+                wordBreak: "break-word",
+              }}
+            >
+              {key.replace(/_/g, " ")}
+            </div>
+            {isReadonly ? (
+              <div
+                style={{
+                  padding: "6px 10px",
+                  color: colors.text.primary,
+                  background: colors.bg.surface,
+                  borderBottom: `1px solid ${colors.borderSubtle}`,
+                  wordBreak: "break-word",
+                  fontFamily: typeof value === "number" ? fonts.mono : fonts.sans,
+                }}
+              >
+                {String(value)}
+              </div>
+            ) : (
+              <input
+                type="text"
+                value={displayValue}
+                onChange={(e) => onFieldChange(key, e.target.value)}
+                style={{
+                  ...styles.input,
+                  padding: "5px 10px",
+                  fontSize: 12,
+                  borderRadius: 0,
+                  border: "none",
+                  borderBottom: `1px solid ${isEdited ? colors.accent : colors.borderSubtle}`,
+                  background: isEdited ? colors.accentDim : colors.bg.surface,
+                }}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function CardDetailModal({
+  detail,
+  board,
+  onClose,
+  onMove,
+  onSave,
+  onSendMessage,
+}: {
+  detail: CardDetailState;
+  board: KanbanBoardData;
+  onClose: () => void;
+  onMove: (card: KanbanCardData, toColumn: string, label: string) => void;
+  onSave?: (doctype: string, name: string, data: Record<string, string>) => void;
+  onSendMessage?: (message: string) => void;
+}) {
+  const [editedFields, setEditedFields] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+  const [saveMessage, setSaveMessage] = useState<{ text: string; isError: boolean } | null>(null);
+
+  useEffect(() => {
+    if (!detail.selectedCardId) return;
+    function handleEscape(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [detail.selectedCardId, onClose]);
+
+  useEffect(() => {
+    setEditedFields({});
+    setSaveMessage(null);
+  }, [detail.selectedCardId]);
+
+  if (!detail.selectedCardId) return null;
+
+  const card = board.cards.find((c) => c.id === detail.selectedCardId);
+  const cardTitle = card?.title ?? detail.selectedCardId;
+  const availableTargets = card ? getAvailableTargets(board, card.columnId) : [];
+  const hasEdits = Object.keys(editedFields).length > 0;
+
+  function handleFieldChange(key: string, value: string) {
+    setEditedFields((prev) => {
+      const original = detail.cardDetail ? String(detail.cardDetail[key] ?? "") : "";
+      if (value === original) {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      }
+      return { ...prev, [key]: value };
+    });
+    setSaveMessage(null);
+  }
+
+  async function handleSave() {
+    if (!hasEdits || !onSave || !detail.selectedCardId) return;
+    setSaving(true);
+    setSaveMessage(null);
+    try {
+      await onSave(board.doctype, detail.selectedCardId, editedFields);
+      setSaveMessage({ text: "Saved", isError: false });
+      setEditedFields({});
+    } catch (error) {
+      setSaveMessage({
+        text: error instanceof Error ? error.message : "Save failed",
+        isError: true,
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div
+      className="kanban-detail-backdrop"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Detail: ${cardTitle}`}
+    >
+      <div className="kanban-detail-panel">
+        {/* Header */}
+        <div
+          style={{
+            padding: "14px 16px 12px",
+            display: "flex",
+            alignItems: "flex-start",
+            gap: 10,
+            borderBottom: `1px solid ${colors.border}`,
+          }}
+        >
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 14, fontWeight: 700, color: colors.text.primary }}>
+              {cardTitle}
+            </div>
+            <div style={{ fontSize: 11, color: colors.text.muted, marginTop: 2, fontFamily: fonts.mono }}>
+              {detail.selectedCardId}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              ...styles.button,
+              padding: "4px 10px",
+              fontSize: 13,
+              lineHeight: 1,
+              borderRadius: 4,
+            }}
+            aria-label="Close detail"
+          >
+            x
+          </button>
+        </div>
+
+        {/* Content */}
+        <div>
+          {detail.detailLoading && (
+            <div style={{ padding: 20, display: "flex", flexDirection: "column", gap: 8 }}>
+              {[1, 2, 3, 4, 5].map((i) => (
+                <div key={i} className="skeleton" style={{ height: 28, width: "100%" }} />
+              ))}
+            </div>
+          )}
+
+          {detail.detailError && (
+            <div style={{ padding: 16, color: colors.error, fontSize: 12 }}>
+              {detail.detailError}
+            </div>
+          )}
+
+          {detail.cardDetail && (
+            <DetailFieldGrid
+              detail={detail.cardDetail}
+              editedFields={editedFields}
+              onFieldChange={handleFieldChange}
+            />
+          )}
+        </div>
+
+        {/* Save bar */}
+        {onSave && detail.cardDetail && (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              padding: "10px 16px",
+              borderTop: `1px solid ${colors.border}`,
+            }}
+          >
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={!hasEdits || saving}
+              style={{
+                ...styles.button,
+                padding: "5px 16px",
+                fontSize: 11,
+                fontWeight: 600,
+                background: hasEdits ? colors.accent : colors.bg.elevated,
+                color: hasEdits ? "#fff" : colors.text.muted,
+                borderColor: hasEdits ? colors.accent : colors.border,
+                opacity: saving ? 0.6 : 1,
+              }}
+            >
+              {saving ? "Saving..." : "Save"}
+            </button>
+            {hasEdits && (
+              <button
+                type="button"
+                onClick={() => { setEditedFields({}); setSaveMessage(null); }}
+                style={{ ...styles.button, padding: "5px 12px", fontSize: 11 }}
+              >
+                Reset
+              </button>
+            )}
+            {saveMessage && (
+              <span style={{ fontSize: 11, color: saveMessage.isError ? colors.error : colors.success }}>
+                {saveMessage.text}
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Move actions */}
+        {card && availableTargets.length > 0 && (
+          <div
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: 6,
+              padding: "12px 16px",
+              borderTop: `1px solid ${colors.border}`,
+            }}
+          >
+            {availableTargets.map((target) => (
+              <button
+                key={target.columnId}
+                type="button"
+                onClick={() => { onMove(card, target.columnId, target.label); onClose(); }}
+                style={{
+                  ...styles.button,
+                  padding: "5px 12px",
+                  fontSize: 11,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 5,
+                }}
+              >
+                {target.color && (
+                  <span
+                    aria-hidden="true"
+                    style={{
+                      width: 6,
+                      height: 6,
+                      borderRadius: "50%",
+                      background: target.color,
+                      flexShrink: 0,
+                    }}
+                  />
+                )}
+                {target.label}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* Cross-viewer navigation */}
+        {onSendMessage && (
+          <div
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: 6,
+              padding: "8px 16px 14px",
+              borderTop: `1px solid ${colors.borderSubtle}`,
+            }}
+          >
+            <button
+              type="button"
+              onClick={() => onSendMessage(`Show doclist for ${board.doctype} ${detail.selectedCardId}`)}
+              style={{
+                ...styles.button,
+                padding: "5px 12px",
+                fontSize: 11,
+                color: colors.accent,
+              }}
+            >
+              View in Doclist
+            </button>
+            {board.doctype === "Task" && (
+              <button
+                type="button"
+                onClick={() => onSendMessage(`Show timesheets for task ${detail.selectedCardId}`)}
+                style={{
+                  ...styles.button,
+                  padding: "5px 12px",
+                  fontSize: 11,
+                  color: colors.accent,
+                }}
+              >
+                View timesheets
+              </button>
+            )}
           </div>
         )}
       </div>
@@ -741,7 +1227,7 @@ type ToolResultPayload = {
 };
 
 export function KanbanViewer() {
-  const { state, hydrateBoard, setError, startLoading } = useKanbanBoard();
+  const { state, hydrateBoard, setError, startLoading, selectCard, hydrateDetail, closeDetail, setDetailError } = useKanbanBoard();
   const [liveMessage, setLiveMessage] = useState("");
   const [activeDropColumn, setActiveDropColumn] = useState<string | null>(null);
   const queueRef = useRef<QueuedKanbanMove[]>([]);
@@ -754,6 +1240,7 @@ export function KanbanViewer() {
   const refreshInFlightRef = useRef(false);
   const refreshAfterMutationRef = useRef(false);
   const lastRefreshStartedAtRef = useRef(0);
+  const detailFetchCardIdRef = useRef<string | null>(null);
 
   function updateBoard(board: KanbanBoardData) {
     boardRef.current = board;
@@ -1078,9 +1565,85 @@ export function KanbanViewer() {
     }
   }
 
+  const canFetchDetail = !!app.getHostCapabilities()?.serverTools;
+
+  function handleCardTitleClick(card: KanbanCardData) {
+    if (!boardRef.current) return;
+    const cardId = card.id;
+    detailFetchCardIdRef.current = cardId;
+    selectCard(cardId);
+
+    if (!canFetchDetail) {
+      // No serverTools — show card data as-is (no full doc fetch)
+      hydrateDetail({ name: card.id, title: card.title, subtitle: card.subtitle ?? "", columnId: card.columnId });
+      return;
+    }
+
+    void (async () => {
+      try {
+        const result = await app.callServerTool({
+          name: "erpnext_doc_get",
+          arguments: { doctype: boardRef.current!.doctype, name: cardId },
+        }, { timeout: TOOL_CALL_TIMEOUT_MS });
+
+        if (detailFetchCardIdRef.current !== cardId) return;
+
+        if (result.isError) {
+          setDetailError(extractToolError(result));
+          return;
+        }
+
+        const text = extractTextContent(result);
+        if (!text) {
+          setDetailError("No detail payload returned");
+          return;
+        }
+
+        hydrateDetail(JSON.parse(text) as Record<string, unknown>);
+      } catch (error) {
+        if (detailFetchCardIdRef.current !== cardId) return;
+        setDetailError(error instanceof Error ? error.message : "Failed to fetch detail");
+      }
+    })();
+  }
+
+  function handleSendMessage(message: string) {
+    try {
+      app.sendMessage({ content: [{ type: "text", text: message }] });
+    } catch {
+      // Host may not support cross-viewer messaging — silently ignore
+    }
+  }
+
+  async function handleSaveDetail(doctype: string, name: string, data: Record<string, string>) {
+    if (!canFetchDetail) throw new Error("Host does not support server tool calls");
+    const result = await app.callServerTool({
+      name: "erpnext_doc_update",
+      arguments: { doctype, name, data },
+    }, { timeout: TOOL_CALL_TIMEOUT_MS });
+
+    if (result.isError) {
+      throw new Error(extractToolError(result));
+    }
+
+    // Re-fetch the detail to get the updated values
+    const refreshResult = await app.callServerTool({
+      name: "erpnext_doc_get",
+      arguments: { doctype, name },
+    }, { timeout: TOOL_CALL_TIMEOUT_MS });
+
+    if (!refreshResult.isError) {
+      const text = extractTextContent(refreshResult);
+      if (text) hydrateDetail(JSON.parse(text) as Record<string, unknown>);
+    }
+
+    // Refresh the board to reflect changes on cards
+    void requestBoardRefresh({ ignoreInterval: true });
+  }
+
   if (state.loading) {
     return (
-      <div style={{ minHeight: "100vh", background: colors.bg.root }}>
+      <div style={{ minHeight: "100%", background: colors.bg.root }}>
         <ErpNextBrandHeader />
         <LoadingSkeleton />
       </div>
@@ -1091,7 +1654,7 @@ export function KanbanViewer() {
 
   if (errorPresentation.blockingError) {
     return (
-      <div style={{ minHeight: "100vh", background: colors.bg.root }}>
+      <div style={{ minHeight: "100%", background: colors.bg.root }}>
         <ErpNextBrandHeader />
         <ErrorState message={errorPresentation.blockingError} />
       </div>
@@ -1100,7 +1663,7 @@ export function KanbanViewer() {
 
   if (!state.board) {
     return (
-      <div style={{ minHeight: "100vh", background: colors.bg.root }}>
+      <div style={{ minHeight: "100%", background: colors.bg.root }}>
         <ErpNextBrandHeader />
         <EmptyState />
       </div>
@@ -1121,7 +1684,18 @@ export function KanbanViewer() {
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
         onDragOverColumn={handleDragOverColumn}
+        onTitleClick={handleCardTitleClick}
       />
+      {state.detail.selectedCardId && state.board && (
+        <CardDetailModal
+          detail={state.detail}
+          board={state.board}
+          onClose={closeDetail}
+          onMove={requestMove}
+          onSave={canFetchDetail ? handleSaveDetail : undefined}
+          onSendMessage={handleSendMessage}
+        />
+      )}
     </>
   );
 }

--- a/src/ui/shared/ErpNextBrand.tsx
+++ b/src/ui/shared/ErpNextBrand.tsx
@@ -1,21 +1,16 @@
 /**
  * ERPNext Brand Components
  *
- * Compact header bar and footer watermark to identify ERPNext viewers
- * at a glance alongside other MCP server UIs.
+ * Header bar and footer watermark for ERPNext MCP Apps viewers.
+ * Casys design: surface background + accent text, consistent with mcp-einvoice.
  */
 
 import { CSSProperties } from "react";
 import { colors, fonts } from "./theme";
 
-// ============================================================================
-// ERPNext Icon — 16×16 cube/grid SVG
-// ============================================================================
-
 function ErpNextIcon() {
   return (
     <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      {/* Grid of 4 blocks evocative of ERP modules */}
       <rect x="1" y="1" width="6" height="6" rx="1.5" fill="currentColor" opacity="0.9" />
       <rect x="9" y="1" width="6" height="6" rx="1.5" fill="currentColor" opacity="0.6" />
       <rect x="1" y="9" width="6" height="6" rx="1.5" fill="currentColor" opacity="0.6" />
@@ -24,10 +19,6 @@ function ErpNextIcon() {
   );
 }
 
-// ============================================================================
-// Brand Header — 30px strip at the top of each viewer
-// ============================================================================
-
 export function ErpNextBrandHeader() {
   const headerStyle: CSSProperties = {
     display: "flex",
@@ -35,8 +26,8 @@ export function ErpNextBrandHeader() {
     gap: 7,
     padding: "0 14px",
     height: 30,
-    background: "#0070CC",
-    borderBottom: "1px solid rgba(0,0,0,0.25)",
+    background: colors.bg.surface,
+    borderBottom: `1px solid ${colors.border}`,
     flexShrink: 0,
   };
 
@@ -46,14 +37,14 @@ export function ErpNextBrandHeader() {
     fontWeight: 700,
     letterSpacing: "0.08em",
     textTransform: "uppercase" as const,
-    color: "rgba(255,255,255,0.92)",
+    color: colors.accent,
   };
 
   const dotStyle: CSSProperties = {
     width: 3,
     height: 3,
     borderRadius: "50%",
-    background: "rgba(255,255,255,0.35)",
+    background: colors.text.faint,
     marginLeft: 2,
     marginRight: 2,
     flexShrink: 0,
@@ -62,25 +53,21 @@ export function ErpNextBrandHeader() {
   const taglineStyle: CSSProperties = {
     fontFamily: fonts.sans,
     fontSize: 10,
-    color: "rgba(255,255,255,0.5)",
+    color: colors.text.muted,
     letterSpacing: "0.03em",
   };
 
   return (
     <div style={headerStyle}>
-      <div style={{ color: "rgba(255,255,255,0.85)" }}>
+      <div style={{ color: colors.accent }}>
         <ErpNextIcon />
       </div>
       <span style={wordmarkStyle}>ERPNext</span>
       <div style={dotStyle} />
-      <span style={taglineStyle}>MCP</span>
+      <span style={taglineStyle}>gestion ERP</span>
     </div>
   );
 }
-
-// ============================================================================
-// Brand Footer — subtle watermark at the bottom
-// ============================================================================
 
 export function ErpNextBrandFooter() {
   const footerStyle: CSSProperties = {
@@ -101,7 +88,7 @@ export function ErpNextBrandFooter() {
 
   return (
     <div style={footerStyle}>
-      <span style={textStyle}>ERPNext</span>
+      <span style={textStyle}>Casys AI</span>
     </div>
   );
 }

--- a/src/ui/shared/kanban/presentation.ts
+++ b/src/ui/shared/kanban/presentation.ts
@@ -19,20 +19,26 @@ export function getErrorPresentation(state: Pick<KanbanViewerState, "board" | "e
 export function formatBoardSummary(
   board: Pick<KanbanBoardData, "doctype" | "moveToolName" | "cards" | "pagination">,
 ): string {
-  const countLabel = board.pagination.total !== undefined
-    ? `${board.pagination.total} cards`
-    : board.pagination.hasMore
-    ? `${board.pagination.loadedCount}+ cards loaded`
-    : `${board.pagination.loadedCount} cards`;
+  let countLabel: string;
+  if (board.pagination.total !== undefined) {
+    countLabel = `${board.pagination.total} cards`;
+  } else if (board.pagination.hasMore) {
+    countLabel = `${board.pagination.loadedCount}+ cards loaded`;
+  } else {
+    countLabel = `${board.pagination.loadedCount} cards`;
+  }
   return `${countLabel} · ${board.doctype} · move tool ${board.moveToolName}`;
 }
 
 export function normalizeMoveFailureMessage(error: unknown): string {
-  const raw = error instanceof Error
-    ? error.message
-    : typeof error === "string"
-    ? error
-    : "Move failed";
+  let raw: string;
+  if (error instanceof Error) {
+    raw = error.message;
+  } else if (typeof error === "string") {
+    raw = error;
+  } else {
+    raw = "Move failed";
+  }
 
   if (/timeout|timed out/i.test(raw)) {
     return "La mise a jour a expire, veuillez reessayer.";

--- a/src/ui/shared/kanban/state.ts
+++ b/src/ui/shared/kanban/state.ts
@@ -1,21 +1,41 @@
 import type { KanbanBoardData } from "./types.ts";
 
+export interface CardDetailState {
+  selectedCardId: string | null;
+  cardDetail: Record<string, unknown> | null;
+  detailLoading: boolean;
+  detailError: string | null;
+}
+
 export interface KanbanViewerState {
   board: KanbanBoardData | null;
   loading: boolean;
   error: string | null;
+  detail: CardDetailState;
 }
 
 export type KanbanViewerAction =
   | { type: "tool-input" }
   | { type: "hydrate-board"; board: KanbanBoardData }
-  | { type: "tool-error"; message: string };
+  | { type: "tool-error"; message: string }
+  | { type: "select-card"; cardId: string }
+  | { type: "hydrate-detail"; detail: Record<string, unknown> }
+  | { type: "close-detail" }
+  | { type: "detail-error"; message: string };
+
+const INITIAL_DETAIL: CardDetailState = {
+  selectedCardId: null,
+  cardDetail: null,
+  detailLoading: false,
+  detailError: null,
+};
 
 export function createKanbanInitialState(): KanbanViewerState {
   return {
     board: null,
     loading: true,
     error: null,
+    detail: { ...INITIAL_DETAIL },
   };
 }
 
@@ -27,9 +47,40 @@ export function kanbanStateReducer(
     case "tool-input":
       return { ...state, loading: true, error: null };
     case "hydrate-board":
-      return { board: action.board, loading: false, error: null };
+      return { board: action.board, loading: false, error: null, detail: state.detail };
     case "tool-error":
       return { ...state, loading: false, error: action.message };
+    case "select-card":
+      return {
+        ...state,
+        detail: {
+          selectedCardId: action.cardId,
+          cardDetail: null,
+          detailLoading: true,
+          detailError: null,
+        },
+      };
+    case "hydrate-detail":
+      return {
+        ...state,
+        detail: {
+          ...state.detail,
+          cardDetail: action.detail,
+          detailLoading: false,
+          detailError: null,
+        },
+      };
+    case "close-detail":
+      return { ...state, detail: { ...INITIAL_DETAIL } };
+    case "detail-error":
+      return {
+        ...state,
+        detail: {
+          ...state.detail,
+          detailLoading: false,
+          detailError: action.message,
+        },
+      };
     default:
       return state;
   }

--- a/src/ui/shared/kanban/types.ts
+++ b/src/ui/shared/kanban/types.ts
@@ -25,6 +25,9 @@ export interface KanbanCardData {
   badges?: KanbanBadgeData[];
   metrics?: KanbanMetricData[];
   pending?: boolean;
+  description?: string;
+  dueDate?: string;
+  assignee?: string;
 }
 
 export interface KanbanTransitionData {

--- a/src/ui/shared/kanban/useKanbanBoard.ts
+++ b/src/ui/shared/kanban/useKanbanBoard.ts
@@ -23,5 +23,17 @@ export function useKanbanBoard() {
     setError(message: string) {
       dispatch({ type: "tool-error", message });
     },
+    selectCard(cardId: string) {
+      dispatch({ type: "select-card", cardId });
+    },
+    hydrateDetail(detail: Record<string, unknown>) {
+      dispatch({ type: "hydrate-detail", detail });
+    },
+    closeDetail() {
+      dispatch({ type: "close-detail" });
+    },
+    setDetailError(message: string) {
+      dispatch({ type: "detail-error", message });
+    },
   };
 }

--- a/tests/kanban/issue-adapter_test.ts
+++ b/tests/kanban/issue-adapter_test.ts
@@ -32,6 +32,8 @@ Deno.test("issue kanban adapter - exposes Issue columns and filters", () => {
     "priority",
     "customer",
     "raised_by",
+    "resolution_by",
+    "_assign",
   ]);
   assertEquals(filters, [
     ["status", "=", "Open"],

--- a/tests/kanban/opportunity-adapter_test.ts
+++ b/tests/kanban/opportunity-adapter_test.ts
@@ -35,6 +35,7 @@ Deno.test("opportunity kanban adapter - exposes Opportunity columns and filters"
     "currency",
     "probability",
     "opportunity_owner",
+    "expected_closing",
   ]);
   assertEquals(filters, [
     ["status", "=", "Open"],

--- a/tests/kanban/task-adapter_test.ts
+++ b/tests/kanban/task-adapter_test.ts
@@ -32,6 +32,9 @@ Deno.test("task kanban adapter - exposes Task columns and allowed transitions", 
     "status",
     "priority",
     "progress",
+    "exp_end_date",
+    "description",
+    "_assign",
   ]);
   assertEquals(filters, [
     ["project", "=", "Alpha"],

--- a/tests/tools/kanban_test.ts
+++ b/tests/tools/kanban_test.ts
@@ -88,6 +88,9 @@ Deno.test("erpnext_kanban_get_board - returns a Task board with metadata and pag
     "status",
     "priority",
     "progress",
+    "exp_end_date",
+    "description",
+    "_assign",
   ]);
   assertEquals(capturedFilters, [
     ["project", "=", "Alpha"],
@@ -160,6 +163,7 @@ Deno.test("erpnext_kanban_get_board - returns an Opportunity board", async () =>
     "currency",
     "probability",
     "opportunity_owner",
+    "expected_closing",
   ]);
   assertEquals(capturedFilters, [
     ["opportunity_owner", "=", "alice@example.com"],
@@ -212,6 +216,8 @@ Deno.test("erpnext_kanban_get_board - returns an Issue board", async () => {
     "priority",
     "customer",
     "raised_by",
+    "resolution_by",
+    "_assign",
   ]);
   assertEquals(capturedFilters, [
     ["priority", "=", "High"],
@@ -221,6 +227,85 @@ Deno.test("erpnext_kanban_get_board - returns an Issue board", async () => {
   assertEquals(result.doctype, "Issue");
   assertEquals((result.columns as Array<{ id: string }>)[0].id, "open");
   assertEquals((result.cards as Array<{ title: string }>)[0].title, "Shipment damaged in transit");
+});
+
+Deno.test("erpnext_kanban_get_board - Task cards include enriched fields", async () => {
+  const mockClient = makeMockClient({
+    list: async () => [
+      {
+        name: "TASK-0001",
+        subject: "Draft protocol",
+        project: "Alpha",
+        status: "Open",
+        priority: "High",
+        progress: 20,
+        exp_end_date: "2025-01-01",
+        description: "<p>Some <b>HTML</b> description</p>",
+        _assign: '["alice@example.com"]',
+      },
+    ],
+  });
+
+  const tool = getTool("erpnext_kanban_get_board");
+  const result = await tool.handler({ doctype: "Task" }, makeCtx(mockClient)) as Record<string, unknown>;
+  const cards = result.cards as Array<Record<string, unknown>>;
+  assertEquals(cards[0].assignee, "alice@example.com");
+  assertEquals(cards[0].description, "Some HTML description");
+  assertEquals(cards[0].dueDate, "2025-01-01");
+  const badges = cards[0].badges as Array<{ label: string }>;
+  assert(badges.some((b) => b.label === "Overdue"));
+});
+
+Deno.test("erpnext_kanban_get_board - Opportunity cards include closing date and assignee", async () => {
+  const mockClient = makeMockClient({
+    list: async () => [
+      {
+        name: "CRM-OPP-2026-00001",
+        title: "ACME renewal",
+        opportunity_from: "Customer",
+        party_name: "Acme Corp",
+        status: "Open",
+        opportunity_amount: 12500,
+        currency: "EUR",
+        probability: 70,
+        opportunity_owner: "alice@example.com",
+        expected_closing: "2025-06-15",
+      },
+    ],
+  });
+
+  const tool = getTool("erpnext_kanban_get_board");
+  const result = await tool.handler({ doctype: "Opportunity" }, makeCtx(mockClient)) as Record<string, unknown>;
+  const cards = result.cards as Array<Record<string, unknown>>;
+  assertEquals(cards[0].assignee, "alice@example.com");
+  assertEquals(cards[0].dueDate, "2025-06-15");
+  const badges = cards[0].badges as Array<{ label: string }>;
+  assert(badges.some((b) => b.label === "Overdue"));
+});
+
+Deno.test("erpnext_kanban_get_board - Issue cards include SLA breach badge", async () => {
+  const mockClient = makeMockClient({
+    list: async () => [
+      {
+        name: "ISS-2026-00001",
+        subject: "Shipment damaged",
+        status: "Open",
+        priority: "High",
+        customer: "Acme Corp",
+        raised_by: "alice@example.com",
+        resolution_by: "2025-01-01",
+        _assign: '["bob@example.com"]',
+      },
+    ],
+  });
+
+  const tool = getTool("erpnext_kanban_get_board");
+  const result = await tool.handler({ doctype: "Issue" }, makeCtx(mockClient)) as Record<string, unknown>;
+  const cards = result.cards as Array<Record<string, unknown>>;
+  assertEquals(cards[0].assignee, "bob@example.com");
+  assertEquals(cards[0].dueDate, "2025-01-01");
+  const badges = cards[0].badges as Array<{ label: string }>;
+  assert(badges.some((b) => b.label === "SLA breach"));
 });
 
 Deno.test("erpnext_kanban_move_card - executes an allowed Task move", async () => {

--- a/tests/ui/kanban-presentation_test.ts
+++ b/tests/ui/kanban-presentation_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "jsr:@std/assert";
 import type { KanbanViewerState } from "../../src/ui/shared/kanban/state.ts";
+import { createKanbanInitialState } from "../../src/ui/shared/kanban/state.ts";
 import type { KanbanBoardData } from "../../src/ui/shared/kanban/types.ts";
 import {
   formatBoardSummary,
@@ -33,6 +34,7 @@ function makeBoard(): KanbanBoardData {
 
 Deno.test("kanban presentation - keeps board visible and surfaces inline errors", () => {
   const state: KanbanViewerState = {
+    ...createKanbanInitialState(),
     board: makeBoard(),
     loading: false,
     error: "Move failed",
@@ -46,6 +48,7 @@ Deno.test("kanban presentation - keeps board visible and surfaces inline errors"
 
 Deno.test("kanban presentation - keeps blocking errors for empty boards", () => {
   const state: KanbanViewerState = {
+    ...createKanbanInitialState(),
     board: null,
     loading: false,
     error: "No kanban payload received from tool result",

--- a/tests/ui/kanban-state_test.ts
+++ b/tests/ui/kanban-state_test.ts
@@ -53,3 +53,61 @@ Deno.test("kanban state - marks loading when tool input starts", () => {
   assertEquals(loadingState.loading, true);
   assertEquals(loadingState.board?.boardId, "task-board");
 });
+
+Deno.test("kanban state - select-card sets loading detail state", () => {
+  const state = kanbanStateReducer(createKanbanInitialState(), {
+    type: "select-card",
+    cardId: "TASK-0001",
+  });
+
+  assertEquals(state.detail.selectedCardId, "TASK-0001");
+  assertEquals(state.detail.detailLoading, true);
+  assertEquals(state.detail.cardDetail, null);
+  assertEquals(state.detail.detailError, null);
+});
+
+Deno.test("kanban state - hydrate-detail populates card detail", () => {
+  const selected = kanbanStateReducer(createKanbanInitialState(), {
+    type: "select-card",
+    cardId: "TASK-0001",
+  });
+
+  const detail = { name: "TASK-0001", subject: "Draft protocol", status: "Open" };
+  const state = kanbanStateReducer(selected, {
+    type: "hydrate-detail",
+    detail,
+  });
+
+  assertEquals(state.detail.detailLoading, false);
+  assertEquals(state.detail.cardDetail?.name, "TASK-0001");
+  assertEquals(state.detail.detailError, null);
+});
+
+Deno.test("kanban state - close-detail resets detail state", () => {
+  const selected = kanbanStateReducer(createKanbanInitialState(), {
+    type: "select-card",
+    cardId: "TASK-0001",
+  });
+
+  const state = kanbanStateReducer(selected, { type: "close-detail" });
+
+  assertEquals(state.detail.selectedCardId, null);
+  assertEquals(state.detail.cardDetail, null);
+  assertEquals(state.detail.detailLoading, false);
+});
+
+Deno.test("kanban state - detail-error sets error on detail", () => {
+  const selected = kanbanStateReducer(createKanbanInitialState(), {
+    type: "select-card",
+    cardId: "TASK-0001",
+  });
+
+  const state = kanbanStateReducer(selected, {
+    type: "detail-error",
+    message: "Network error",
+  });
+
+  assertEquals(state.detail.detailLoading, false);
+  assertEquals(state.detail.detailError, "Network error");
+  assertEquals(state.detail.selectedCardId, "TASK-0001");
+});


### PR DESCRIPTION
## Summary
- Enrich kanban cards with dates, assignee, description across Task/Opportunity/Issue adapters
- Add card detail modal with editable fields, save via `erpnext_doc_update`, and cross-viewer navigation
- Improve column focus mode with scroll-reactive arrow indicators and fix iframe height loop

## Test plan
- [ ] `deno test --allow-all tests/` — 134 tests pass
- [ ] `deno check mod.ts server.ts` — type check OK
- [ ] `cd src/ui && node build-all.mjs` — 7 UI viewers build OK
- [ ] Open kanban Task board in Inspector: cards show description, assignee, dates, Overdue badges
- [ ] Click card title: detail modal opens with field grid and move buttons
- [ ] Tab arrows appear/disappear on drag-scroll; click navigates and scrolls tab bar
- [ ] Escape / backdrop click closes the modal
- [ ] Test Opportunity and Issue boards for enriched cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)