### PR TITLE
feat(project): add native Task assignment

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -68,17 +68,17 @@
 
 ### Project (9 tools)
 
-| Tool                     | DocType   | Operations                                              | UI Viewer      |
-| ------------------------ | --------- | ------------------------------------------------------- | -------------- |
-| `erpnext_project_list`   | Project   | List + filters (status, company)                        | doclist-viewer |
-| `erpnext_project_get`    | Project   | Get by name                                             | -              |
-| `erpnext_project_create` | Project   | Create (name, status, dates, budget, company)           | -              |
-| `erpnext_task_list`      | Task      | List + filters (project, status, priority)              | doclist-viewer |
-| `erpnext_task_get`       | Task      | Get by name (with dependencies)                         | -              |
-| `erpnext_task_create`    | Task      | Create (project, subject, status, priority, dates)      | -              |
-| `erpnext_task_update`    | Task      | Update (status, priority, progress, dates, description) | -              |
-| `erpnext_timesheet_list` | Timesheet | List + filters (employee, project, status)              | doclist-viewer |
-| `erpnext_timesheet_get`  | Timesheet | Get by name (with time log details)                     | -              |
+| Tool                     | DocType   | Operations                                           | UI Viewer      |
+| ------------------------ | --------- | ---------------------------------------------------- | -------------- |
+| `erpnext_project_list`   | Project   | List + filters (status, company)                     | doclist-viewer |
+| `erpnext_project_get`    | Project   | Get by name                                          | -              |
+| `erpnext_project_create` | Project   | Create (name, status, dates, budget, company)        | -              |
+| `erpnext_task_list`      | Task      | List + filters (project, status, priority)           | doclist-viewer |
+| `erpnext_task_get`       | Task      | Get by name (with dependencies)                      | -              |
+| `erpnext_task_create`    | Task      | Create + native assignment (assignees, ToDo details) | -              |
+| `erpnext_task_update`    | Task      | Update + native assignment (assignees, ToDo details) | -              |
+| `erpnext_timesheet_list` | Timesheet | List + filters (employee, project, status)           | doclist-viewer |
+| `erpnext_timesheet_get`  | Timesheet | Get by name (with time log details)                  | -              |
 
 ### Setup (2 tools)
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -92,17 +92,17 @@ overview.
 
 ## Project (9) → doclist-viewer
 
-| Tool                     | DocType   | Operations                                         |
-| ------------------------ | --------- | -------------------------------------------------- |
-| `erpnext_project_list`   | Project   | List + filters (status, company)                   |
-| `erpnext_project_get`    | Project   | Get by name                                        |
-| `erpnext_project_create` | Project   | Create (name, status, dates, budget, company)      |
-| `erpnext_task_list`      | Task      | List + filters (project, status, priority)         |
-| `erpnext_task_get`       | Task      | Get with dependencies                              |
-| `erpnext_task_create`    | Task      | Create (project, subject, status, priority, dates) |
-| `erpnext_task_update`    | Task      | Update (status, priority, progress, dates)         |
-| `erpnext_timesheet_list` | Timesheet | List + filters (employee, project, status)         |
-| `erpnext_timesheet_get`  | Timesheet | Get with time log details                          |
+| Tool                     | DocType   | Operations                                           |
+| ------------------------ | --------- | ---------------------------------------------------- |
+| `erpnext_project_list`   | Project   | List + filters (status, company)                     |
+| `erpnext_project_get`    | Project   | Get by name                                          |
+| `erpnext_project_create` | Project   | Create (name, status, dates, budget, company)        |
+| `erpnext_task_list`      | Task      | List + filters (project, status, priority)           |
+| `erpnext_task_get`       | Task      | Get with dependencies                                |
+| `erpnext_task_create`    | Task      | Create + native assignment (assignees, ToDo details) |
+| `erpnext_task_update`    | Task      | Update + native assignment (assignees, ToDo details) |
+| `erpnext_timesheet_list` | Timesheet | List + filters (employee, project, status)           |
+| `erpnext_timesheet_get`  | Timesheet | Get with time log details                            |
 
 ## Delivery (5) → doclist-viewer
 

--- a/src/tools/project.ts
+++ b/src/tools/project.ts
@@ -10,6 +10,121 @@ import type { FrappeFilter } from "../api/types.ts";
 import type { ErpNextTool } from "./types.ts";
 import { DOCLIST_META } from "./viewer-meta.ts";
 
+const ASSIGNMENT_METHOD = "frappe.desk.form.assign_to.add";
+
+type TaskAssignment = {
+  assignees: string[];
+  args: Record<string, unknown>;
+};
+
+function prepareTaskAssignment(
+  input: Record<string, unknown>,
+  toolName: string,
+): TaskAssignment | undefined {
+  if (input.assign_to === undefined) return undefined;
+
+  if (input.notify_user === false) {
+    throw new Error(
+      `[${toolName}] 'notify_user=false' is not supported for native Task assignments`,
+    );
+  }
+  if (
+    input.notify_user !== undefined && typeof input.notify_user !== "boolean"
+  ) {
+    throw new Error(`[${toolName}] 'notify_user' must be a boolean`);
+  }
+
+  const rawAssignees = typeof input.assign_to === "string"
+    ? [input.assign_to]
+    : Array.isArray(input.assign_to)
+    ? input.assign_to
+    : undefined;
+  if (!rawAssignees || rawAssignees.length === 0) {
+    throw new Error(
+      `[${toolName}] 'assign_to' must be a non-empty string or array of non-empty strings`,
+    );
+  }
+
+  const assignees = [
+    ...new Set(rawAssignees.map((assignee) => {
+      if (typeof assignee !== "string" || !assignee.trim()) {
+        throw new Error(
+          `[${toolName}] 'assign_to' must be a non-empty string or array of non-empty strings`,
+        );
+      }
+      return assignee.trim();
+    })),
+  ];
+
+  const args: Record<string, unknown> = { assign_to: assignees };
+  if (input.assignment_description !== undefined) {
+    if (typeof input.assignment_description !== "string") {
+      throw new Error(
+        `[${toolName}] 'assignment_description' must be a string`,
+      );
+    }
+    args.description = input.assignment_description;
+  }
+  if (input.assignment_priority !== undefined) {
+    if (
+      input.assignment_priority !== "Low" &&
+      input.assignment_priority !== "Medium" &&
+      input.assignment_priority !== "High"
+    ) {
+      throw new Error(
+        `[${toolName}] 'assignment_priority' must be ToDo Low, Medium, or High`,
+      );
+    }
+    args.priority = input.assignment_priority;
+  }
+  if (input.assignment_date !== undefined) {
+    if (
+      typeof input.assignment_date !== "string" ||
+      !/^\d{4}-\d{2}-\d{2}$/.test(input.assignment_date)
+    ) {
+      throw new Error(`[${toolName}] 'assignment_date' must be YYYY-MM-DD`);
+    }
+    args.date = input.assignment_date;
+  }
+
+  return { assignees, args };
+}
+
+async function validateTaskAssignees(
+  assignees: string[],
+  toolName: string,
+  ctx: Parameters<ErpNextTool["handler"]>[1],
+): Promise<void> {
+  for (const assignee of assignees) {
+    const users = await ctx.client.list("User", {
+      fields: ["name", "enabled"],
+      filters: [["name", "=", assignee]],
+      limit: 1,
+    });
+    if (users.length === 0) {
+      throw new Error(
+        `[${toolName}] User '${assignee}' does not exist or is not accessible`,
+      );
+    }
+    if (!users[0].enabled) {
+      throw new Error(`[${toolName}] User '${assignee}' is disabled`);
+    }
+  }
+}
+
+function assignmentResult(
+  assignees: string[],
+  nativeResult: unknown,
+): Record<string, unknown> {
+  const todos = Array.isArray(nativeResult)
+    ? nativeResult.map((todo) => {
+      const record = todo as Record<string, unknown>;
+      return { owner: record.owner, name: record.name };
+    })
+    : [];
+  return { notify_user: true, assignees, todos };
+}
+
 export const projectTools: ErpNextTool[] = [
   // ── Projects ──────────────────────────────────────────────────────────────
 
@@ -157,7 +272,7 @@ export const projectTools: ErpNextTool[] = [
     name: "erpnext_task_create",
     description:
       "Create a new Task in a project. Requires project and subject. " +
-      "Dates in YYYY-MM-DD format.",
+      "Dates in YYYY-MM-DD format. Use assign_to for Frappe's native assignment workflow; native notifications are sent to assigned users.",
     category: "project",
     inputSchema: {
       type: "object",
@@ -189,6 +304,32 @@ export const projectTools: ErpNextTool[] = [
           type: "string",
           description: "Expected end date YYYY-MM-DD",
         },
+        assign_to: {
+          type: ["string", "array"],
+          description: "User email or non-empty array of user emails to assign",
+          minLength: 1,
+          minItems: 1,
+          items: { type: "string", minLength: 1 },
+        },
+        notify_user: {
+          type: "boolean",
+          description: "Notify assigned users (must be true; default true)",
+          default: true,
+        },
+        assignment_description: {
+          type: "string",
+          description: "Description for the native ToDo assignment",
+        },
+        assignment_priority: {
+          type: "string",
+          description: "Native ToDo priority",
+          enum: ["Low", "Medium", "High"],
+        },
+        assignment_date: {
+          type: "string",
+          description: "Native ToDo date YYYY-MM-DD",
+          pattern: "^\\d{4}-\\d{2}-\\d{2}$",
+        },
       },
       required: ["project", "subject"],
     },
@@ -198,6 +339,15 @@ export const projectTools: ErpNextTool[] = [
       }
       if (!input.subject) {
         throw new Error("[erpnext_task_create] 'subject' is required");
+      }
+
+      const assignment = prepareTaskAssignment(input, "erpnext_task_create");
+      if (assignment) {
+        await validateTaskAssignees(
+          assignment.assignees,
+          "erpnext_task_create",
+          ctx,
+        );
       }
 
       const data: Record<string, unknown> = {
@@ -212,9 +362,23 @@ export const projectTools: ErpNextTool[] = [
       if (input.exp_end_date) data.exp_end_date = input.exp_end_date as string;
 
       const doc = await ctx.client.create("Task", data);
+      if (!assignment) {
+        return {
+          data: doc,
+          message: `Task ${doc.name} created successfully`,
+        };
+      }
+
+      const nativeResult = await ctx.client.callMethod(ASSIGNMENT_METHOD, {
+        doctype: "Task",
+        name: doc.name,
+        ...assignment.args,
+      });
+      const freshDoc = await ctx.client.get("Task", doc.name);
       return {
-        data: doc,
+        data: freshDoc,
         message: `Task ${doc.name} created successfully`,
+        assignment: assignmentResult(assignment.assignees, nativeResult),
       };
     },
   },
@@ -245,7 +409,7 @@ export const projectTools: ErpNextTool[] = [
     name: "erpnext_task_update",
     description:
       "Update an existing Task. Pass only the fields you want to change. " +
-      "Commonly used to change status, progress, or dates.",
+      "Commonly used to change status, progress, or dates. Use assign_to for Frappe's native assignment workflow; native notifications are sent to assigned users.",
     category: "project",
     inputSchema: {
       type: "object",
@@ -277,6 +441,32 @@ export const projectTools: ErpNextTool[] = [
           description: "New expected end date YYYY-MM-DD",
         },
         description: { type: "string", description: "New task description" },
+        assign_to: {
+          type: ["string", "array"],
+          description: "User email or non-empty array of user emails to assign",
+          minLength: 1,
+          minItems: 1,
+          items: { type: "string", minLength: 1 },
+        },
+        notify_user: {
+          type: "boolean",
+          description: "Notify assigned users (must be true; default true)",
+          default: true,
+        },
+        assignment_description: {
+          type: "string",
+          description: "Description for the native ToDo assignment",
+        },
+        assignment_priority: {
+          type: "string",
+          description: "Native ToDo priority",
+          enum: ["Low", "Medium", "High"],
+        },
+        assignment_date: {
+          type: "string",
+          description: "Native ToDo date YYYY-MM-DD",
+          pattern: "^\\d{4}-\\d{2}-\\d{2}$",
+        },
       },
       required: ["name"],
     },
@@ -285,22 +475,56 @@ export const projectTools: ErpNextTool[] = [
         throw new Error("[erpnext_task_update] 'name' is required");
       }
 
-      const { name, ...rest } = input;
-      const data: Record<string, unknown> = {};
-      for (const [k, v] of Object.entries(rest)) {
-        if (v !== undefined) data[k] = v;
+      const assignment = prepareTaskAssignment(input, "erpnext_task_update");
+      if (assignment) {
+        await validateTaskAssignees(
+          assignment.assignees,
+          "erpnext_task_update",
+          ctx,
+        );
       }
 
-      if (Object.keys(data).length === 0) {
+      const data: Record<string, unknown> = {};
+      for (
+        const key of [
+          "status",
+          "priority",
+          "progress",
+          "exp_end_date",
+          "description",
+        ]
+      ) {
+        if (input[key] !== undefined) data[key] = input[key];
+      }
+
+      if (Object.keys(data).length === 0 && !assignment) {
         throw new Error(
           "[erpnext_task_update] At least one field to update is required",
         );
       }
 
-      const doc = await ctx.client.update("Task", name as string, data);
+      const name = input.name as string;
+      if (!assignment) {
+        const doc = await ctx.client.update("Task", name, data);
+        return {
+          data: doc,
+          message: `Task ${name} updated successfully`,
+        };
+      }
+
+      if (Object.keys(data).length > 0) {
+        await ctx.client.update("Task", name, data);
+      }
+      const nativeResult = await ctx.client.callMethod(ASSIGNMENT_METHOD, {
+        doctype: "Task",
+        name,
+        ...assignment.args,
+      });
+      const freshDoc = await ctx.client.get("Task", name);
       return {
-        data: doc,
+        data: freshDoc,
         message: `Task ${name} updated successfully`,
+        assignment: assignmentResult(assignment.assignees, nativeResult),
       };
     },
   },

--- a/src/tools/project_test.ts
+++ b/src/tools/project_test.ts
@@ -1,0 +1,300 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import type { FrappeClient } from "../api/frappe-client.ts";
+import { projectTools } from "./project.ts";
+import type { ErpNextToolContext } from "./types.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyFn = (...args: any[]) => any;
+
+function makeMockClient(overrides: Record<string, AnyFn> = {}): FrappeClient {
+  return {
+    list: async () => [{ name: "user@example.com", enabled: 1 }],
+    get: async (_doctype: string, name: string) => ({ name }),
+    create: async (_doctype: string, data: Record<string, unknown>) => ({
+      name: "TASK-001",
+      ...data,
+    }),
+    update: async (
+      _doctype: string,
+      name: string,
+      data: Record<string, unknown>,
+    ) => ({
+      name,
+      ...data,
+    }),
+    delete: async () => {},
+    callMethod: async () => [],
+    ...overrides,
+  } as unknown as FrappeClient;
+}
+
+function getTool(name: string) {
+  const tool = projectTools.find((candidate) => candidate.name === name);
+  if (!tool) throw new Error(`Tool not found: ${name}`);
+  return tool;
+}
+
+function makeCtx(client: FrappeClient): ErpNextToolContext {
+  return { client };
+}
+
+Deno.test("erpnext_task_create preserves the existing response without assignees", async () => {
+  let createCalls = 0;
+  const result = await getTool("erpnext_task_create").handler(
+    { project: "PROJ-001", subject: "Plan release", priority: "High" },
+    makeCtx(makeMockClient({
+      create: async (doctype: string, data: Record<string, unknown>) => {
+        createCalls++;
+        assertEquals(doctype, "Task");
+        assertEquals(data, {
+          project: "PROJ-001",
+          subject: "Plan release",
+          priority: "High",
+        });
+        return { name: "TASK-001", ...data };
+      },
+    })),
+  ) as Record<string, unknown>;
+
+  assertEquals(createCalls, 1);
+  assertEquals(result, {
+    data: {
+      name: "TASK-001",
+      project: "PROJ-001",
+      subject: "Plan release",
+      priority: "High",
+    },
+    message: "Task TASK-001 created successfully",
+  });
+});
+
+Deno.test("erpnext_task_update preserves the existing response without assignees", async () => {
+  const result = await getTool("erpnext_task_update").handler(
+    { name: "TASK-001", status: "Working" },
+    makeCtx(makeMockClient({
+      update: async (
+        doctype: string,
+        name: string,
+        data: Record<string, unknown>,
+      ) => {
+        assertEquals([doctype, name, data], ["Task", "TASK-001", {
+          status: "Working",
+        }]);
+        return { name, ...data };
+      },
+    })),
+  ) as Record<string, unknown>;
+
+  assertEquals(result, {
+    data: { name: "TASK-001", status: "Working" },
+    message: "Task TASK-001 updated successfully",
+  });
+});
+
+Deno.test("erpnext_task_create assigns a trimmed string through the native API", async () => {
+  let assignmentArgs: Record<string, unknown> = {};
+  const result = await getTool("erpnext_task_create").handler(
+    {
+      project: "PROJ-001",
+      subject: "Plan release",
+      assign_to: " user@example.com ",
+      assignment_description: "Review scope",
+      assignment_priority: "High",
+      assignment_date: "2026-07-13",
+    },
+    makeCtx(makeMockClient({
+      callMethod: async (method: string, args: Record<string, unknown>) => {
+        assertEquals(method, "frappe.desk.form.assign_to.add");
+        assignmentArgs = args;
+        return [{ owner: "user@example.com", name: "TODO-001" }];
+      },
+      get: async () => ({ name: "TASK-001", status: "Open" }),
+    })),
+  ) as Record<string, unknown>;
+
+  assertEquals(assignmentArgs, {
+    doctype: "Task",
+    name: "TASK-001",
+    assign_to: ["user@example.com"],
+    description: "Review scope",
+    priority: "High",
+    date: "2026-07-13",
+  });
+  assertEquals(result.data, { name: "TASK-001", status: "Open" });
+  assertEquals(result.assignment, {
+    notify_user: true,
+    assignees: ["user@example.com"],
+    todos: [{ owner: "user@example.com", name: "TODO-001" }],
+  });
+});
+
+Deno.test("erpnext_task_update deduplicates assignees and returns an existing native ToDo", async () => {
+  let updateCalls = 0;
+  let assignmentArgs: Record<string, unknown> = {};
+  const result = await getTool("erpnext_task_update").handler(
+    {
+      name: "TASK-001",
+      status: "Working",
+      assign_to: ["a@example.com", " a@example.com "],
+    },
+    makeCtx(makeMockClient({
+      list: async (_doctype: string, options: { filters?: unknown[][] }) => [{
+        name: options.filters?.[0][2],
+        enabled: 1,
+      }],
+      update: async () => {
+        updateCalls++;
+        return { name: "TASK-001" };
+      },
+      callMethod: async (_method: string, args: Record<string, unknown>) => {
+        assignmentArgs = args;
+        return [{ owner: "a@example.com", name: "TODO-001" }];
+      },
+      get: async () => ({ name: "TASK-001", status: "Working" }),
+    })),
+  ) as Record<string, unknown>;
+
+  assertEquals(updateCalls, 1);
+  assertEquals(assignmentArgs, {
+    doctype: "Task",
+    name: "TASK-001",
+    assign_to: ["a@example.com"],
+  });
+  assertEquals(result.assignment, {
+    notify_user: true,
+    assignees: ["a@example.com"],
+    todos: [{ owner: "a@example.com", name: "TODO-001" }],
+  });
+});
+
+Deno.test("erpnext_task_create rejects nonexistent and disabled assignees before mutation", async () => {
+  const tool = getTool("erpnext_task_create");
+  let createCalls = 0;
+  const nonexistent = makeMockClient({
+    list: async () => [],
+    create: async () => {
+      createCalls++;
+      return { name: "TASK-001" };
+    },
+  });
+  await assertRejects(
+    () =>
+      tool.handler({
+        project: "PROJ-001",
+        subject: "Test",
+        assign_to: "missing@example.com",
+      }, makeCtx(nonexistent)),
+    Error,
+    "does not exist",
+  );
+
+  const disabled = makeMockClient({
+    list: async () => [{ name: "disabled@example.com", enabled: 0 }],
+    create: async () => {
+      createCalls++;
+      return { name: "TASK-001" };
+    },
+  });
+  await assertRejects(
+    () =>
+      tool.handler({
+        project: "PROJ-001",
+        subject: "Test",
+        assign_to: "disabled@example.com",
+      }, makeCtx(disabled)),
+    Error,
+    "disabled",
+  );
+  assertEquals(createCalls, 0);
+});
+
+Deno.test("erpnext_task_update assignment controls without assignees do not update Task", async () => {
+  let updateCalls = 0;
+  await assertRejects(
+    () =>
+      getTool("erpnext_task_update").handler(
+        {
+          name: "TASK-001",
+          notify_user: true,
+          assignment_description: "Review scope",
+          assignment_priority: "High",
+          assignment_date: "2026-07-13",
+        },
+        makeCtx(makeMockClient({
+          update: async () => {
+            updateCalls++;
+            return { name: "TASK-001" };
+          },
+        })),
+      ),
+    Error,
+    "At least one field to update is required",
+  );
+  assertEquals(updateCalls, 0);
+});
+
+Deno.test("erpnext_task_update assign_to schema accepts strings and arrays", () => {
+  const schema = getTool("erpnext_task_update").inputSchema.properties
+    ?.assign_to;
+  assertEquals(schema?.type, ["string", "array"]);
+});
+
+Deno.test("erpnext_task_update rejects notify_user=false before mutation", async () => {
+  let updateCalls = 0;
+  const client = makeMockClient({
+    update: async () => {
+      updateCalls++;
+      return { name: "TASK-001" };
+    },
+  });
+  await assertRejects(
+    () =>
+      getTool("erpnext_task_update").handler(
+        {
+          name: "TASK-001",
+          status: "Working",
+          assign_to: "user@example.com",
+          notify_user: false,
+        },
+        makeCtx(client),
+      ),
+    Error,
+    "notify_user=false",
+  );
+  assertEquals(updateCalls, 0);
+});
+
+Deno.test("erpnext_task_update accepts assignment-only input and refreshes the Task", async () => {
+  let updateCalls = 0;
+  const result = await getTool("erpnext_task_update").handler(
+    { name: "TASK-001", assign_to: "user@example.com" },
+    makeCtx(makeMockClient({
+      update: async () => {
+        updateCalls++;
+        return { name: "TASK-001" };
+      },
+      callMethod: async () => [{ owner: "user@example.com", name: "TODO-001" }],
+      get: async () => ({ name: "TASK-001", subject: "Fresh task" }),
+    })),
+  ) as Record<string, unknown>;
+
+  assertEquals(updateCalls, 0);
+  assertEquals(result.data, { name: "TASK-001", subject: "Fresh task" });
+});
+
+Deno.test("erpnext_task_update propagates native assignment errors", async () => {
+  const nativeError = new Error("Assignment permission denied");
+  await assertRejects(
+    () =>
+      getTool("erpnext_task_update").handler(
+        { name: "TASK-001", assign_to: "user@example.com" },
+        makeCtx(makeMockClient({
+          callMethod: async () => {
+            throw nativeError;
+          },
+        })),
+      ),
+    Error,
+    "Assignment permission denied",
+  );
+});

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -31,7 +31,7 @@ export type ErpNextToolCategory =
 
 /** JSON Schema for tool inputs (MCP wire format) */
 export type JSONSchema = {
-  type: string;
+  type: string | string[];
   properties?: Record<string, JSONSchema>;
   required?: string[];
   description?: string;

--- a/src/ui/global.css
+++ b/src/ui/global.css
@@ -90,7 +90,8 @@ html {
   overflow: hidden;
 }
 
-html, body {
+html,
+body {
   background: var(--bg-root);
   color: var(--text-primary);
   font-family: var(--font-sans);
@@ -124,7 +125,8 @@ body {
 
 /* Animations */
 @keyframes pulse {
-  0%, 100% {
+  0%,
+  100% {
     opacity: 0.4;
   }
   50% {


### PR DESCRIPTION
## Summary

Adds native Frappe assignment support to the existing Task create/update tools.

- accepts `assign_to` as one user or an array, with optional assignment description, priority, and date
- validates that assignees exist and are enabled before mutating a Task
- delegates to `frappe.desk.form.assign_to.add` so Frappe preserves permission checks, sharing, following, ToDo creation, realtime notifications, and assignment email behavior
- supports assignment-only `erpnext_task_update` calls and returns assignees plus native ToDo IDs
- preserves the existing request/response path when `assign_to` is omitted
- rejects `notify_user=false` explicitly because Frappe v15 has no per-call notification suppression that preserves the other native assignment side effects
- documents the expanded Task tools and adds focused regression coverage

The small `src/ui/global.css` formatting commit fixes the only repository-wide Deno 2.x format failure found by the release preflight; it is formatting-only.

## Type of change

- [x] feat
- [ ] fix
- [x] docs
- [ ] refactor
- [ ] chore
- [x] test

## Related issues

N/A — implementation follows a production integration report.

## Compatibility

Calls without `assign_to` retain the previous Task mutation and response behavior. No existing tool is renamed or removed, and no dependency or version is changed.

## Frappe references

- Native assignment implementation: https://github.com/frappe/frappe/blob/v15.113.4/frappe/desk/form/assign_to.py
- Native desk invocation: https://github.com/frappe/frappe/blob/v15.113.4/frappe/public/js/frappe/form/sidebar/assign_to.js

## How tested

### Automated

- `deno fmt --check`
- `deno lint`
- `deno task check`
- focused Task tests: 10 passed
- full suite: 183 passed, 0 failed, 4 environment-dependent integration tests ignored
- all 7 UI viewers built successfully
- Node npm bundle built successfully
- complete `deno task release:check` passed

### Staged ERPNext/Frappe 15 validation

The feature commit `222a79ba0540be17eccb4b573299172843f66c69` was built and deployed as a local package without publishing npm/JSR, then exercised through a real Salesman MCP profile:

- created a temporary Task with `assign_to=mateo.tiedra@hypersimple.ch`
- returned the native ToDo ID and showed the assignee on the Task Kanban card
- confirmed exactly one linked open ToDo
- repeated assignment through assignment-only update and received the same ToDo with no duplicate
- confirmed `notify_user=false` is rejected without mutation
- independently confirmed Frappe `_assign`, the linked ToDo, and native assignment email queue creation/delivery
- removed all temporary Task/ToDo records after validation

## Checklist

- [x] `deno fmt` — no formatting issues
- [x] `deno lint` — no lint errors
- [x] `deno task check` — type-check passes
- [x] `deno task test` — all non-environment integration tests pass
- [x] PR title follows Conventional Commits (`type(scope): description`)
