### PR TITLE
docs: add Deno HTTP mode section and known-issue for Deno is not defined error

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,21 @@ ERPNEXT_API_SECRET=xxx \
 npx -y @casys/mcp-erpnext --http --port=3012
 ```
 
+### Deno (HTTP mode)
+
+```bash
+ERPNEXT_URL=http://localhost:8000 \
+ERPNEXT_API_KEY=xxx \
+ERPNEXT_API_SECRET=xxx \
+deno run -A npm:@casys/mcp-erpnext --http --port=3012
+```
+
+> **Note:** The npm bundle embeds `@casys/mcp-server` which references
+> `Deno.*` APIs in its auth config loader. If you get
+> `ReferenceError: Deno is not defined`, use the Deno runner above
+> until the transitive dependency is patched.
+> See [`docs/known-issues.md`](docs/known-issues.md).
+
 ### Category filtering
 
 Load only the categories you need:

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -100,6 +100,28 @@ le champ est `None`, soit documenter que le setup wizard ERPNext est requis.
 
 ---
 
+### RuntimeError: `Deno is not defined` on Node.js
+
+**Symptom**: Running the npm bundle (`npx @casys/mcp-erpnext --http`) crashes
+with `ReferenceError: Deno is not defined` at `loadYamlAuth`.
+
+**Cause**: The transitive dependency `@casys/mcp-server` (v0.18.x) contains
+`Deno.readTextFile` calls that esbuild inlines into the bundle. The project's
+own runtime adapter (`src/runtime.ts` / `src/runtime.node.ts`) handles the
+swap correctly, but `@casys/mcp-server`'s internal auth-config loader bypasses
+it.
+
+**Workaround**: Run with the Deno runtime instead:
+
+```bash
+deno run -A npm:@casys/mcp-erpnext --http --port=3012
+```
+
+**Fix needed**: Patch the upstream `@casys/mcp-server` to use a runtime adapter
+or a pure-Node YAML reader.
+
+---
+
 ## Améliorations souhaitées
 
 ### Setup wizard automation


### PR DESCRIPTION
## Summary

Add `deno run -A npm:@casys/mcp-erpnext` HTTP mode section and document the`ReferenceError: Deno is not defined` error in `docs/known-issues.md`.

The npm bundle inlines `@casys/mcp-server` which calls `Deno.readTextFile` in its auth config loader — unpatched by the project's own runtime adapter swap. Running with Deno avoids the crash entirely.

## Type of change

- [x] docs

## Related issues

N/A

## How tested

- Verified `deno run -A npm:@casys/mcp-erpnext --http --port=3012` starts without the error
- `deno fmt` — no formatting issues
- `deno lint` — no lint errors

## Checklist

- [x] `deno fmt` — no formatting issues
- [x] `deno lint` — no lint errors
- [x] `deno task check` — type-check passes
- [x] `deno task test` — all tests pass
- [x] PR title follows Conventional Commits (`docs: add Deno HTTP mode section and known-issue for Deno is not defined error`)

## Additional Context

Before:
```bash
ERPNEXT_URL=https://something.com \
ERPNEXT_API_KEY=something \
ERPNEXT_API_SECRET=something \
npx -y @casys/mcp-erpnext --http --port=3012
[mcp-erpnext] Registered 120 tools
[mcp-erpnext] Registered resource: ERPNext Invoice Viewer (ui://mcp-erpnext/invoice-viewer)
[mcp-erpnext] Registered UI resource: ui://mcp-erpnext/invoice-viewer
[mcp-erpnext] Registered resource: ERPNext Stock Viewer (ui://mcp-erpnext/stock-viewer)
[mcp-erpnext] Registered UI resource: ui://mcp-erpnext/stock-viewer
[mcp-erpnext] Registered resource: ERPNext Doclist Viewer (ui://mcp-erpnext/doclist-viewer)
[mcp-erpnext] Registered UI resource: ui://mcp-erpnext/doclist-viewer
[mcp-erpnext] Registered resource: ERPNext Chart Viewer (ui://mcp-erpnext/chart-viewer)
[mcp-erpnext] Registered UI resource: ui://mcp-erpnext/chart-viewer
[mcp-erpnext] Registered resource: ERPNext Kpi Viewer (ui://mcp-erpnext/kpi-viewer)
[mcp-erpnext] Registered UI resource: ui://mcp-erpnext/kpi-viewer
[mcp-erpnext] Registered resource: ERPNext Funnel Viewer (ui://mcp-erpnext/funnel-viewer)
[mcp-erpnext] Registered UI resource: ui://mcp-erpnext/funnel-viewer
[mcp-erpnext] Registered resource: ERPNext Kanban Viewer (ui://mcp-erpnext/kanban-viewer)
[mcp-erpnext] Registered UI resource: ui://mcp-erpnext/kanban-viewer
[mcp-erpnext] Initialized — 120 tools
[mcp-erpnext] Fatal error: ReferenceError: Deno is not defined
    at readTextFile (file:///Users/dennypradipta/.volta/tools/image/node/24.9.0/lib/node_modules/@casys/mcp-erpnext/mcp-erpnext.mjs:24571:24)
    at loadYamlAuth (file:///Users/dennypradipta/.volta/tools/image/node/24.9.0/lib/node_modules/@casys/mcp-erpnext/mcp-erpnext.mjs:29218:22)
    at loadAuthConfig (file:///Users/dennypradipta/.volta/tools/image/node/24.9.0/lib/node_modules/@casys/mcp-erpnext/mcp-erpnext.mjs:29104:26)
    at _McpApp.startHttp (file:///Users/dennypradipta/.volta/tools/image/node/24.9.0/lib/node_modules/@casys/mcp-erpnext/mcp-erpnext.mjs:30296:32)
    at main (file:///Users/dennypradipta/.volta/tools/image/node/24.9.0/lib/node_modules/@casys/mcp-erpnext/mcp-erpnext.mjs:39003:18)
    at file:///Users/dennypradipta/.volta/tools/image/node/24.9.0/lib/node_modules/@casys/mcp-erpnext/mcp-erpnext.mjs:39022:1
    at ModuleJob.run (node:internal/modules/esm/module_job:377:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:689:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
```

After:
```bash
ERPNEXT_URL=https://something.com \
ERPNEXT_API_KEY=something \
ERPNEXT_API_SECRET=something \
deno run -A npm:@casys/mcp-erpnext --http --port=3012
[mcp-erpnext] Registered 120 tools
[mcp-erpnext] Registered resource: ERPNext Invoice Viewer (ui://mcp-erpnext/invoice-viewer)
[mcp-erpnext] Registered UI resource: ui://mcp-erpnext/invoice-viewer
[mcp-erpnext] Registered resource: ERPNext Stock Viewer (ui://mcp-erpnext/stock-viewer)
[mcp-erpnext] Registered UI resource: ui://mcp-erpnext/stock-viewer
[mcp-erpnext] Registered resource: ERPNext Doclist Viewer (ui://mcp-erpnext/doclist-viewer)
[mcp-erpnext] Registered UI resource: ui://mcp-erpnext/doclist-viewer
[mcp-erpnext] Registered resource: ERPNext Chart Viewer (ui://mcp-erpnext/chart-viewer)
[mcp-erpnext] Registered UI resource: ui://mcp-erpnext/chart-viewer
[mcp-erpnext] Registered resource: ERPNext Kpi Viewer (ui://mcp-erpnext/kpi-viewer)
[mcp-erpnext] Registered UI resource: ui://mcp-erpnext/kpi-viewer
[mcp-erpnext] Registered resource: ERPNext Funnel Viewer (ui://mcp-erpnext/funnel-viewer)
[mcp-erpnext] Registered UI resource: ui://mcp-erpnext/funnel-viewer
[mcp-erpnext] Registered resource: ERPNext Kanban Viewer (ui://mcp-erpnext/kanban-viewer)
[mcp-erpnext] Registered UI resource: ui://mcp-erpnext/kanban-viewer
[mcp-erpnext] Initialized — 120 tools
[mcp-erpnext] [WARN] HTTP auth is disabled. Set requireAuth=true or configure auth for production deployments.
[mcp-erpnext] [WARN] CORS wildcard origin ('*') is active. Use corsOrigins: ['https://your-app.example.com'] in production.
[mcp-erpnext] HTTP server listening on http://0.0.0.0:3012
[mcp-erpnext] Server started HTTP mode (max concurrent: 10, strategy: queue, schema validation: on)
[mcp-erpnext] Tools available: 120, Resources: 7
[mcp-erpnext] New session created: 6b7687cceef695ad16a2d0a1d6f97b14
[mcp-erpnext] SSE client connected (session: 6b7687cceef695ad16a2d0a1d6f97b14)
[mcp-erpnext] SSE client disconnected (session: 6b7687cceef695ad16a2d0a1d6f97b14)
