### PR TITLE
feat(tools,ui): generalize native assignment — doc_assign, user_list, kanban UI (builds on #3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Repository guidelines for AI coding agents working on this codebase.
 
 ## Project Overview
 
-MCP server for ERPNext/Frappe ERP — 120+ tools across 14 categories with 7
+MCP server for ERPNext/Frappe ERP — 122 tools across 14 categories with 7
 interactive UI viewers. Connects MCP-compatible AI agents to ERPNext via the
 Model Context Protocol. Published as `@casys/mcp-erpnext` on npm (Node bundle)
 and JSR (Deno).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![MCP](https://img.shields.io/badge/MCP-server-1f6feb?logo=modelcontextprotocol&logoColor=white)](https://modelcontextprotocol.io)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-MCP server for [ERPNext](https://erpnext.com) / Frappe ERP — **120 tools**
+MCP server for [ERPNext](https://erpnext.com) / Frappe ERP — **122 tools**
 across **14 categories**, with **7 interactive UI viewers**.
 
 Connect any MCP-compatible AI agent (Claude Desktop, Claude Code, VS Code
@@ -220,28 +220,28 @@ npm install
 node build-all.mjs
 ```
 
-## Tools (120)
+## Tools (122)
 
 **14 categories** covering the full ERPNext surface. Each `_list` tool returns
 interactive results in the doclist-viewer with row click, inline detail, and
 cross-viewer navigation.
 
-| Category          | Tools | Viewer               | Key capabilities                                                     |
-| ----------------- | ----- | -------------------- | -------------------------------------------------------------------- |
-| **Sales**         | 17    | doclist / invoice    | Customers, Sales Orders, Invoices, Quotations — CRUD + Submit/Cancel |
-| **Purchasing**    | 11    | doclist / invoice    | Suppliers, Purchase Orders, Invoices, Receipts                       |
-| **Inventory**     | 9     | doclist / stock      | Items, Stock Balance, Warehouses, Stock Entries                      |
-| **Accounting**    | 6     | doclist              | Accounts, Journal Entries, Payment Entries                           |
-| **HR**            | 12    | doclist              | Employees, Attendance, Leave, Salary, Expenses                       |
-| **Project**       | 9     | doclist              | Projects, Tasks, Timesheets                                          |
-| **Delivery**      | 5     | doclist              | Delivery Notes, Shipments                                            |
-| **Manufacturing** | 7     | doclist              | BOMs, Work Orders, Job Cards                                         |
-| **CRM**           | 8     | doclist              | Leads, Opportunities, Contacts, Campaigns                            |
-| **Assets**        | 8     | doclist              | Assets, Movements, Maintenance, Categories                           |
-| **Operations**    | 7     | doclist              | Generic CRUD for **any** DocType (`erpnext_doc_*`)                   |
-| **Kanban**        | 2     | kanban               | Task/Opportunity/Issue boards with drag-and-drop                     |
-| **Analytics**     | 17    | chart / kpi / funnel | 12 chart types, 5 KPIs, sales funnel                                 |
-| **Setup**         | 2     | —                    | Company creation                                                     |
+| Category          | Tools | Viewer               | Key capabilities                                                       |
+| ----------------- | ----- | -------------------- | ---------------------------------------------------------------------- |
+| **Sales**         | 17    | doclist / invoice    | Customers, Sales Orders, Invoices, Quotations — CRUD + Submit/Cancel   |
+| **Purchasing**    | 11    | doclist / invoice    | Suppliers, Purchase Orders, Invoices, Receipts                         |
+| **Inventory**     | 9     | doclist / stock      | Items, Stock Balance, Warehouses, Stock Entries                        |
+| **Accounting**    | 6     | doclist              | Accounts, Journal Entries, Payment Entries                             |
+| **HR**            | 12    | doclist              | Employees, Attendance, Leave, Salary, Expenses                         |
+| **Project**       | 9     | doclist              | Projects, Tasks, Timesheets                                            |
+| **Delivery**      | 5     | doclist              | Delivery Notes, Shipments                                              |
+| **Manufacturing** | 7     | doclist              | BOMs, Work Orders, Job Cards                                           |
+| **CRM**           | 8     | doclist              | Leads, Opportunities, Contacts, Campaigns                              |
+| **Assets**        | 8     | doclist              | Assets, Movements, Maintenance, Categories                             |
+| **Operations**    | 8     | doclist              | Generic CRUD + native assignment for **any** DocType (`erpnext_doc_*`) |
+| **Kanban**        | 2     | kanban               | Task/Opportunity/Issue boards with drag-and-drop                       |
+| **Analytics**     | 17    | chart / kpi / funnel | 12 chart types, 5 KPIs, sales funnel                                   |
+| **Setup**         | 3     | —                    | Company creation, assignable user listing                              |
 
 > Full tool reference with all parameters: [`docs/tools.md`](docs/tools.md)
 

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -68,17 +68,17 @@
 
 ### Project (9 tools)
 
-| Tool                     | DocType   | Operations                                              | UI Viewer      |
-| ------------------------ | --------- | ------------------------------------------------------- | -------------- |
-| `erpnext_project_list`   | Project   | List + filters (status, company)                        | doclist-viewer |
-| `erpnext_project_get`    | Project   | Get by name                                             | -              |
-| `erpnext_project_create` | Project   | Create (name, status, dates, budget, company)           | -              |
-| `erpnext_task_list`      | Task      | List + filters (project, status, priority)              | doclist-viewer |
-| `erpnext_task_get`       | Task      | Get by name (with dependencies)                         | -              |
-| `erpnext_task_create`    | Task      | Create (project, subject, status, priority, dates)      | -              |
-| `erpnext_task_update`    | Task      | Update (status, priority, progress, dates, description) | -              |
-| `erpnext_timesheet_list` | Timesheet | List + filters (employee, project, status)              | doclist-viewer |
-| `erpnext_timesheet_get`  | Timesheet | Get by name (with time log details)                     | -              |
+| Tool                     | DocType   | Operations                                           | UI Viewer      |
+| ------------------------ | --------- | ---------------------------------------------------- | -------------- |
+| `erpnext_project_list`   | Project   | List + filters (status, company)                     | doclist-viewer |
+| `erpnext_project_get`    | Project   | Get by name                                          | -              |
+| `erpnext_project_create` | Project   | Create (name, status, dates, budget, company)        | -              |
+| `erpnext_task_list`      | Task      | List + filters (project, status, priority)           | doclist-viewer |
+| `erpnext_task_get`       | Task      | Get by name (with dependencies)                      | -              |
+| `erpnext_task_create`    | Task      | Create + native assignment (assignees, ToDo details) | -              |
+| `erpnext_task_update`    | Task      | Update + native assignment (assignees, ToDo details) | -              |
+| `erpnext_timesheet_list` | Timesheet | List + filters (employee, project, status)           | doclist-viewer |
+| `erpnext_timesheet_get`  | Timesheet | Get by name (with time log details)                  | -              |
 
 ### Setup (2 tools)
 

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,6 +1,6 @@
 # ERPNext MCP Library - Coverage
 
-## Covered (120 tools, 14 categories)
+## Covered (122 tools, 14 categories)
 
 ### Sales (17 tools)
 
@@ -80,14 +80,15 @@
 | `erpnext_timesheet_list` | Timesheet | List + filters (employee, project, status)           | doclist-viewer |
 | `erpnext_timesheet_get`  | Timesheet | Get by name (with time log details)                  | -              |
 
-### Setup (2 tools)
+### Setup (3 tools)
 
 | Tool                     | DocType | Operations                                             | UI Viewer      |
 | ------------------------ | ------- | ------------------------------------------------------ | -------------- |
+| `erpnext_user_list`      | User    | List assignable users (enabled System Users, search)   | doclist-viewer |
 | `erpnext_company_list`   | Company | List companies (name, abbr, currency, country)         | doclist-viewer |
 | `erpnext_company_create` | Company | Create company (name, abbr, currency, country, domain) | -              |
 
-### Generic Operations (7 tools)
+### Generic Operations (8 tools)
 
 | Tool                 | DocType | Operations                                       | UI Viewer      |
 | -------------------- | ------- | ------------------------------------------------ | -------------- |
@@ -98,6 +99,7 @@
 | `erpnext_doc_cancel` | Any     | Cancel any submitted document                    | -              |
 | `erpnext_doc_get`    | Any     | Get any document by DocType + name               | -              |
 | `erpnext_doc_list`   | Any     | List any DocType with field/filter/limit control | doclist-viewer |
+| `erpnext_doc_assign` | Any     | Native assignment (ToDo + notification) to users | -              |
 
 ### Kanban (2 tools)
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,12 +1,13 @@
-# Tools Reference (120)
+# Tools Reference (122)
 
 Full reference for all ERPNext MCP tools. See [README](../README.md) for
 overview.
 
-## Setup (2)
+## Setup (3)
 
 | Tool                     | DocType | Operations                                     |
 | ------------------------ | ------- | ---------------------------------------------- |
+| `erpnext_user_list`      | User    | List assignable users (enabled System Users)   |
 | `erpnext_company_list`   | Company | List companies                                 |
 | `erpnext_company_create` | Company | Create (name, abbr, currency, country, domain) |
 
@@ -152,7 +153,7 @@ overview.
 | `erpnext_asset_maintenance_get`  | Asset Maintenance | Get with maintenance tasks                            |
 | `erpnext_asset_category_list`    | Asset Category    | List all categories                                   |
 
-## Generic Operations (7) → doclist-viewer
+## Generic Operations (8) → doclist-viewer
 
 | Tool                 | Operation | Notes                                             |
 | -------------------- | --------- | ------------------------------------------------- |
@@ -163,6 +164,7 @@ overview.
 | `erpnext_doc_delete` | Delete    | Draft documents only                              |
 | `erpnext_doc_submit` | Submit    | Any submittable document                          |
 | `erpnext_doc_cancel` | Cancel    | Any submitted document                            |
+| `erpnext_doc_assign` | Assign    | Native assignment (ToDo + notification) to users  |
 
 ## Kanban (2) → kanban-viewer
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -92,17 +92,17 @@ overview.
 
 ## Project (9) → doclist-viewer
 
-| Tool                     | DocType   | Operations                                         |
-| ------------------------ | --------- | -------------------------------------------------- |
-| `erpnext_project_list`   | Project   | List + filters (status, company)                   |
-| `erpnext_project_get`    | Project   | Get by name                                        |
-| `erpnext_project_create` | Project   | Create (name, status, dates, budget, company)      |
-| `erpnext_task_list`      | Task      | List + filters (project, status, priority)         |
-| `erpnext_task_get`       | Task      | Get with dependencies                              |
-| `erpnext_task_create`    | Task      | Create (project, subject, status, priority, dates) |
-| `erpnext_task_update`    | Task      | Update (status, priority, progress, dates)         |
-| `erpnext_timesheet_list` | Timesheet | List + filters (employee, project, status)         |
-| `erpnext_timesheet_get`  | Timesheet | Get with time log details                          |
+| Tool                     | DocType   | Operations                                           |
+| ------------------------ | --------- | ---------------------------------------------------- |
+| `erpnext_project_list`   | Project   | List + filters (status, company)                     |
+| `erpnext_project_get`    | Project   | Get by name                                          |
+| `erpnext_project_create` | Project   | Create (name, status, dates, budget, company)        |
+| `erpnext_task_list`      | Task      | List + filters (project, status, priority)           |
+| `erpnext_task_get`       | Task      | Get with dependencies                                |
+| `erpnext_task_create`    | Task      | Create + native assignment (assignees, ToDo details) |
+| `erpnext_task_update`    | Task      | Update + native assignment (assignees, ToDo details) |
+| `erpnext_timesheet_list` | Timesheet | List + filters (employee, project, status)           |
+| `erpnext_timesheet_get`  | Timesheet | Get with time log details                            |
 
 ## Delivery (5) → doclist-viewer
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -62,8 +62,12 @@ export interface FrappeErrorResponse {
   message?: string;
 }
 
-/** Frappe list filter: [field, operator, value] */
-export type FrappeFilter = [string, string, string | number | boolean | null];
+/** Frappe list filter: [field, operator, value]. Array values pair with the "in"/"not in" operators. */
+export type FrappeFilter = [
+  string,
+  string,
+  string | number | boolean | null | (string | number)[],
+];
 
 /** Options for Frappe list queries (`GET /api/resource/{doctype}`). */
 export interface FrappeListOptions {

--- a/src/tools/analytics.ts
+++ b/src/tools/analytics.ts
@@ -62,7 +62,7 @@ export const analyticsTools: ErpNextTool[] = [
       }
 
       // Bin has no item_group field — resolve the group to its item codes and
-      // filter in memory (FrappeFilter doesn't support "in" arrays).
+      // filter in memory (the code set can exceed a sane "in" filter size).
       let allowedItems: Set<string> | null = null;
       if (input.item_group) {
         const groupItems = await ctx.client.list("Item", {
@@ -722,7 +722,7 @@ export const analyticsTools: ErpNextTool[] = [
         raw[code] = [totalQty, totalVal, 0, 0];
       }
 
-      // Order data — fetch all, filter in memory (FrappeFilter doesn't support "in" arrays)
+      // Order data — fetch all, filter in memory (the item set can exceed a sane "in" filter size)
       const soItems = await ctx.client.list("Sales Order Item", {
         fields: ["item_code", "qty", "amount"],
         filters: [["docstatus", "!=", 2]],

--- a/src/tools/assignment.ts
+++ b/src/tools/assignment.ts
@@ -1,0 +1,222 @@
+/**
+ * Frappe Native Assignment Helpers
+ *
+ * Shared logic for assigning documents to users through Frappe's native
+ * assignment workflow (`frappe.desk.form.assign_to.add`): one ToDo per
+ * assignee, `_assign` sync, permission sharing, document follow, and native
+ * notifications. Doctype-agnostic — used by the Task tools and the generic
+ * `erpnext_doc_assign` tool.
+ *
+ * @module lib/erpnext/tools/assignment
+ */
+
+import type { ErpNextToolContext, JSONSchema } from "./types.ts";
+
+const ASSIGNMENT_METHOD = "frappe.desk.form.assign_to.add";
+
+// Keeps the validation query well under Frappe's result cap (500) and the
+// native per-assignee ToDo/notification fan-out within a sane request.
+const MAX_ASSIGNEES_PER_CALL = 50;
+
+export type PreparedAssignment = {
+  assignees: string[];
+  args: Record<string, unknown>;
+};
+
+/**
+ * Shared inputSchema properties for tools that accept native assignment.
+ * Frappe v15 always notifies assignees (no per-call suppression), so
+ * `notify_user` only documents that behavior and rejects `false`.
+ */
+export const ASSIGNMENT_INPUT_PROPERTIES: Record<string, JSONSchema> = {
+  assign_to: {
+    type: ["string", "array"],
+    description: "User email or non-empty array of user emails to assign",
+    minLength: 1,
+    minItems: 1,
+    items: { type: "string", minLength: 1 },
+  },
+  notify_user: {
+    type: "boolean",
+    description:
+      "Frappe always sends its native assignment notification (v15 has no " +
+      "per-call suppression), so only true is accepted (default true)",
+    default: true,
+  },
+  assignment_description: {
+    type: "string",
+    description: "Description for the native ToDo assignment",
+  },
+  assignment_priority: {
+    type: "string",
+    description: "Native ToDo priority",
+    enum: ["Low", "Medium", "High"],
+  },
+  assignment_date: {
+    type: "string",
+    description: "Native ToDo date YYYY-MM-DD",
+    pattern: "^\\d{4}-\\d{2}-\\d{2}$",
+  },
+};
+
+/**
+ * Validate and normalize assignment inputs. Returns undefined when the
+ * input carries no `assign_to` (the tool runs its non-assignment path).
+ */
+export function prepareAssignment(
+  input: Record<string, unknown>,
+  toolName: string,
+): PreparedAssignment | undefined {
+  if (input.assign_to === undefined) return undefined;
+
+  if (input.notify_user === false) {
+    throw new Error(
+      `[${toolName}] 'notify_user=false' is not supported for native assignments`,
+    );
+  }
+  if (
+    input.notify_user !== undefined && typeof input.notify_user !== "boolean"
+  ) {
+    throw new Error(`[${toolName}] 'notify_user' must be a boolean`);
+  }
+
+  const rawAssignees = typeof input.assign_to === "string"
+    ? [input.assign_to]
+    : Array.isArray(input.assign_to)
+    ? input.assign_to
+    : undefined;
+  if (!rawAssignees || rawAssignees.length === 0) {
+    throw new Error(
+      `[${toolName}] 'assign_to' must be a non-empty string or array of non-empty strings`,
+    );
+  }
+
+  const assignees = [
+    ...new Set(rawAssignees.map((assignee) => {
+      if (typeof assignee !== "string" || !assignee.trim()) {
+        throw new Error(
+          `[${toolName}] 'assign_to' must be a non-empty string or array of non-empty strings`,
+        );
+      }
+      return assignee.trim();
+    })),
+  ];
+  if (assignees.length > MAX_ASSIGNEES_PER_CALL) {
+    throw new Error(
+      `[${toolName}] 'assign_to' accepts at most ${MAX_ASSIGNEES_PER_CALL} distinct users per call (got ${assignees.length})`,
+    );
+  }
+
+  const args: Record<string, unknown> = { assign_to: assignees };
+  if (input.assignment_description !== undefined) {
+    if (typeof input.assignment_description !== "string") {
+      throw new Error(
+        `[${toolName}] 'assignment_description' must be a string`,
+      );
+    }
+    args.description = input.assignment_description;
+  }
+  if (input.assignment_priority !== undefined) {
+    if (
+      input.assignment_priority !== "Low" &&
+      input.assignment_priority !== "Medium" &&
+      input.assignment_priority !== "High"
+    ) {
+      throw new Error(
+        `[${toolName}] 'assignment_priority' must be one of: Low, Medium, High`,
+      );
+    }
+    args.priority = input.assignment_priority;
+  }
+  if (input.assignment_date !== undefined) {
+    if (
+      typeof input.assignment_date !== "string" ||
+      !/^\d{4}-\d{2}-\d{2}$/.test(input.assignment_date)
+    ) {
+      throw new Error(`[${toolName}] 'assignment_date' must be YYYY-MM-DD`);
+    }
+    args.date = input.assignment_date;
+  }
+
+  return { assignees, args };
+}
+
+/** Reject nonexistent or disabled assignees before any mutation. */
+export async function validateAssignees(
+  assignees: string[],
+  toolName: string,
+  ctx: ErpNextToolContext,
+): Promise<void> {
+  const users = await ctx.client.list("User", {
+    fields: ["name", "enabled"],
+    filters: [["name", "in", assignees]],
+    limit: assignees.length,
+  });
+  const enabledByName = new Map(
+    users.map((user) => [user.name as string, user.enabled]),
+  );
+  for (const assignee of assignees) {
+    if (!enabledByName.has(assignee)) {
+      throw new Error(
+        `[${toolName}] User '${assignee}' does not exist or is not accessible`,
+      );
+    }
+    if (!enabledByName.get(assignee)) {
+      throw new Error(`[${toolName}] User '${assignee}' is disabled`);
+    }
+  }
+}
+
+/**
+ * Run the native assignment. On failure, rethrows with `failureContext`
+ * prepended so callers can state what was already mutated (e.g. "Task X
+ * was created, but assignment failed").
+ */
+export async function applyAssignment(
+  doctype: string,
+  name: string,
+  assignment: PreparedAssignment,
+  ctx: ErpNextToolContext,
+  failureContext: string,
+): Promise<Record<string, unknown>> {
+  let nativeResult: unknown;
+  try {
+    nativeResult = await ctx.client.callMethod(ASSIGNMENT_METHOD, {
+      doctype,
+      name,
+      ...assignment.args,
+    });
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`${failureContext}: ${reason}`, { cause: error });
+  }
+
+  const todos = Array.isArray(nativeResult)
+    ? nativeResult.map((todo) => {
+      const record = todo as Record<string, unknown>;
+      return { owner: record.owner, name: record.name };
+    })
+    : [];
+  return { notify_user: true, assignees: assignment.assignees, todos };
+}
+
+/**
+ * Re-fetch a document after a committed assignment. A failure here must not
+ * read like an assignment failure — the mutation already succeeded.
+ */
+export async function fetchDocAfterAssignment(
+  doctype: string,
+  name: string,
+  ctx: ErpNextToolContext,
+  toolName: string,
+): Promise<Record<string, unknown>> {
+  try {
+    return await ctx.client.get(doctype, name);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `[${toolName}] ${doctype} ${name} assignment succeeded, but re-fetching the document failed: ${reason}`,
+      { cause: error },
+    );
+  }
+}

--- a/src/tools/assignment_test.ts
+++ b/src/tools/assignment_test.ts
@@ -1,0 +1,86 @@
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
+import type { FrappeClient } from "../api/frappe-client.ts";
+import {
+  fetchDocAfterAssignment,
+  prepareAssignment,
+  validateAssignees,
+} from "./assignment.ts";
+import type { ErpNextToolContext } from "./types.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyFn = (...args: any[]) => any;
+
+function makeCtx(overrides: Record<string, AnyFn> = {}): ErpNextToolContext {
+  const client = {
+    list: async () => [],
+    get: async () => ({ name: "TEST-001" }),
+    create: async () => ({ name: "TEST-001" }),
+    update: async () => ({ name: "TEST-001" }),
+    delete: async () => {},
+    callMethod: async () => null,
+    ...overrides,
+  } as unknown as FrappeClient;
+  return { client };
+}
+
+Deno.test("prepareAssignment returns undefined without assign_to", () => {
+  assertEquals(prepareAssignment({}, "tool"), undefined);
+});
+
+Deno.test("prepareAssignment trims and deduplicates assignees", () => {
+  const prepared = prepareAssignment(
+    { assign_to: [" a@example.com ", "a@example.com", "b@example.com"] },
+    "tool",
+  );
+  assertEquals(prepared?.assignees, ["a@example.com", "b@example.com"]);
+});
+
+Deno.test("prepareAssignment caps the number of distinct assignees", () => {
+  const assignees = Array.from(
+    { length: 51 },
+    (_, i) => `user${i}@example.com`,
+  );
+  assertThrows(
+    () => prepareAssignment({ assign_to: assignees }, "tool"),
+    Error,
+    "at most 50 distinct users per call (got 51)",
+  );
+});
+
+Deno.test("prepareAssignment accepts exactly 50 distinct assignees", () => {
+  const assignees = Array.from(
+    { length: 50 },
+    (_, i) => `user${i}@example.com`,
+  );
+  const prepared = prepareAssignment({ assign_to: assignees }, "tool");
+  assertEquals(prepared?.assignees.length, 50);
+});
+
+Deno.test("validateAssignees reports the first missing user", async () => {
+  await assertRejects(
+    () =>
+      validateAssignees(
+        ["a@example.com", "b@example.com"],
+        "tool",
+        makeCtx({ list: async () => [{ name: "b@example.com", enabled: 1 }] }),
+      ),
+    Error,
+    "User 'a@example.com' does not exist",
+  );
+});
+
+Deno.test("fetchDocAfterAssignment marks re-fetch failures as post-assignment", async () => {
+  const original = new Error("HTTP 502 Bad Gateway");
+  const ctx = makeCtx({
+    get: async () => {
+      throw original;
+    },
+  });
+  const rejection = await assertRejects(
+    () =>
+      fetchDocAfterAssignment("Task", "TASK-001", ctx, "erpnext_task_update"),
+    Error,
+    "Task TASK-001 assignment succeeded, but re-fetching the document failed: HTTP 502 Bad Gateway",
+  );
+  assertEquals((rejection as Error).cause, original);
+});

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -11,6 +11,13 @@
 import type { FrappeFilter } from "../api/types.ts";
 import type { ErpNextTool } from "./types.ts";
 import { DOCLIST_META } from "./viewer-meta.ts";
+import {
+  applyAssignment,
+  ASSIGNMENT_INPUT_PROPERTIES,
+  fetchDocAfterAssignment,
+  prepareAssignment,
+  validateAssignees,
+} from "./assignment.ts";
 
 export const operationsTools: ErpNextTool[] = [
   // ── Generic Create ──────────────────────────────────────────────────────────
@@ -360,6 +367,73 @@ export const operationsTools: ErpNextTool[] = [
         count: docs.length,
         data: docs,
         _meta: DOCLIST_META,
+      };
+    },
+  },
+
+  // ── Generic Assign ────────────────────────────────────────────────────────
+
+  {
+    name: "erpnext_doc_assign",
+    description:
+      "Assign any ERPNext document to one or more users through Frappe's native " +
+      "assignment workflow (per-assignee ToDo, _assign sync, permission sharing, " +
+      "native notifications). Works on any DocType (e.g. 'Task', 'Issue', 'Opportunity'). " +
+      "Idempotent: re-assigning an already-assigned user returns the existing ToDo without re-notifying.",
+    category: "operations",
+    inputSchema: {
+      type: "object",
+      properties: {
+        doctype: {
+          type: "string",
+          description:
+            "ERPNext DocType name (e.g. 'Task', 'Issue', 'Opportunity')",
+        },
+        name: {
+          type: "string",
+          description: "Document name/ID (e.g. 'TASK-2026-00001')",
+        },
+        ...ASSIGNMENT_INPUT_PROPERTIES,
+      },
+      required: ["doctype", "name", "assign_to"],
+    },
+    handler: async (input, ctx) => {
+      if (!input.doctype) {
+        throw new Error("[erpnext_doc_assign] 'doctype' is required");
+      }
+      if (!input.name) {
+        throw new Error("[erpnext_doc_assign] 'name' is required");
+      }
+      const assignment = prepareAssignment(input, "erpnext_doc_assign");
+      if (!assignment) {
+        throw new Error("[erpnext_doc_assign] 'assign_to' is required");
+      }
+
+      const doctype = input.doctype as string;
+      const name = input.name as string;
+      // Fast-fail on a missing document before touching users or ToDos.
+      await ctx.client.get(doctype, name);
+      await validateAssignees(assignment.assignees, "erpnext_doc_assign", ctx);
+
+      const assignmentInfo = await applyAssignment(
+        doctype,
+        name,
+        assignment,
+        ctx,
+        `[erpnext_doc_assign] ${doctype} ${name} assignment failed`,
+      );
+      const doc = await fetchDocAfterAssignment(
+        doctype,
+        name,
+        ctx,
+        "erpnext_doc_assign",
+      );
+      return {
+        data: doc,
+        message: `${doctype} ${name} is now assigned to ${
+          assignment.assignees.join(", ")
+        }`,
+        assignment: assignmentInfo,
       };
     },
   },

--- a/src/tools/operations_test.ts
+++ b/src/tools/operations_test.ts
@@ -173,3 +173,106 @@ Deno.test("erpnext_doc_delete - calls client.delete", async () => {
   assertEquals(deletedName, "CUST-001");
   assertEquals(result.deleted, true);
 });
+
+// ── erpnext_doc_assign ──────────────────────────────────────────────────────
+
+Deno.test("erpnext_doc_assign - assigns through the native API and returns the fresh doc", async () => {
+  let assignmentArgs: Record<string, unknown> = {};
+  const result = await getTool("erpnext_doc_assign").handler(
+    {
+      doctype: "Issue",
+      name: "ISS-001",
+      assign_to: "user@example.com",
+      assignment_priority: "High",
+    },
+    makeCtx(makeMockClient({
+      list: async () => [{ name: "user@example.com", enabled: 1 }],
+      get: async (_doctype: string, name: string) => ({
+        name,
+        status: "Open",
+      }),
+      callMethod: async (method: string, args: Record<string, unknown>) => {
+        assertEquals(method, "frappe.desk.form.assign_to.add");
+        assignmentArgs = args;
+        return [{ owner: "user@example.com", name: "TODO-001" }];
+      },
+    })),
+  ) as Record<string, unknown>;
+
+  assertEquals(assignmentArgs, {
+    doctype: "Issue",
+    name: "ISS-001",
+    assign_to: ["user@example.com"],
+    priority: "High",
+  });
+  assertEquals(result.data, { name: "ISS-001", status: "Open" });
+  assertEquals(
+    result.message,
+    "Issue ISS-001 is now assigned to user@example.com",
+  );
+  assertEquals(result.assignment, {
+    notify_user: true,
+    assignees: ["user@example.com"],
+    todos: [{ owner: "user@example.com", name: "TODO-001" }],
+  });
+});
+
+Deno.test("erpnext_doc_assign - fails fast on a missing document before validating users", async () => {
+  let listCalls = 0;
+  let callMethodCalls = 0;
+  await assertRejects(
+    () =>
+      getTool("erpnext_doc_assign").handler(
+        { doctype: "Issue", name: "MISSING", assign_to: "user@example.com" },
+        makeCtx(makeMockClient({
+          get: async () => {
+            throw new Error("Issue MISSING not found");
+          },
+          list: async () => {
+            listCalls++;
+            return [{ name: "user@example.com", enabled: 1 }];
+          },
+          callMethod: async () => {
+            callMethodCalls++;
+            return [];
+          },
+        })),
+      ),
+    Error,
+    "not found",
+  );
+  assertEquals(listCalls, 0);
+  assertEquals(callMethodCalls, 0);
+});
+
+Deno.test("erpnext_doc_assign - rejects unknown assignees before mutation", async () => {
+  let callMethodCalls = 0;
+  await assertRejects(
+    () =>
+      getTool("erpnext_doc_assign").handler(
+        { doctype: "Task", name: "TASK-001", assign_to: "ghost@example.com" },
+        makeCtx(makeMockClient({
+          list: async () => [],
+          callMethod: async () => {
+            callMethodCalls++;
+            return [];
+          },
+        })),
+      ),
+    Error,
+    "does not exist",
+  );
+  assertEquals(callMethodCalls, 0);
+});
+
+Deno.test("erpnext_doc_assign - requires assign_to", async () => {
+  await assertRejects(
+    () =>
+      getTool("erpnext_doc_assign").handler(
+        { doctype: "Task", name: "TASK-001" },
+        makeCtx(makeMockClient()),
+      ),
+    Error,
+    "'assign_to' is required",
+  );
+});

--- a/src/tools/project.ts
+++ b/src/tools/project.ts
@@ -9,121 +9,13 @@
 import type { FrappeFilter } from "../api/types.ts";
 import type { ErpNextTool } from "./types.ts";
 import { DOCLIST_META } from "./viewer-meta.ts";
-
-const ASSIGNMENT_METHOD = "frappe.desk.form.assign_to.add";
-
-type TaskAssignment = {
-  assignees: string[];
-  args: Record<string, unknown>;
-};
-
-function prepareTaskAssignment(
-  input: Record<string, unknown>,
-  toolName: string,
-): TaskAssignment | undefined {
-  if (input.assign_to === undefined) return undefined;
-
-  if (input.notify_user === false) {
-    throw new Error(
-      `[${toolName}] 'notify_user=false' is not supported for native Task assignments`,
-    );
-  }
-  if (
-    input.notify_user !== undefined && typeof input.notify_user !== "boolean"
-  ) {
-    throw new Error(`[${toolName}] 'notify_user' must be a boolean`);
-  }
-
-  const rawAssignees = typeof input.assign_to === "string"
-    ? [input.assign_to]
-    : Array.isArray(input.assign_to)
-    ? input.assign_to
-    : undefined;
-  if (!rawAssignees || rawAssignees.length === 0) {
-    throw new Error(
-      `[${toolName}] 'assign_to' must be a non-empty string or array of non-empty strings`,
-    );
-  }
-
-  const assignees = [
-    ...new Set(rawAssignees.map((assignee) => {
-      if (typeof assignee !== "string" || !assignee.trim()) {
-        throw new Error(
-          `[${toolName}] 'assign_to' must be a non-empty string or array of non-empty strings`,
-        );
-      }
-      return assignee.trim();
-    })),
-  ];
-
-  const args: Record<string, unknown> = { assign_to: assignees };
-  if (input.assignment_description !== undefined) {
-    if (typeof input.assignment_description !== "string") {
-      throw new Error(
-        `[${toolName}] 'assignment_description' must be a string`,
-      );
-    }
-    args.description = input.assignment_description;
-  }
-  if (input.assignment_priority !== undefined) {
-    if (
-      input.assignment_priority !== "Low" &&
-      input.assignment_priority !== "Medium" &&
-      input.assignment_priority !== "High"
-    ) {
-      throw new Error(
-        `[${toolName}] 'assignment_priority' must be ToDo Low, Medium, or High`,
-      );
-    }
-    args.priority = input.assignment_priority;
-  }
-  if (input.assignment_date !== undefined) {
-    if (
-      typeof input.assignment_date !== "string" ||
-      !/^\d{4}-\d{2}-\d{2}$/.test(input.assignment_date)
-    ) {
-      throw new Error(`[${toolName}] 'assignment_date' must be YYYY-MM-DD`);
-    }
-    args.date = input.assignment_date;
-  }
-
-  return { assignees, args };
-}
-
-async function validateTaskAssignees(
-  assignees: string[],
-  toolName: string,
-  ctx: Parameters<ErpNextTool["handler"]>[1],
-): Promise<void> {
-  for (const assignee of assignees) {
-    const users = await ctx.client.list("User", {
-      fields: ["name", "enabled"],
-      filters: [["name", "=", assignee]],
-      limit: 1,
-    });
-    if (users.length === 0) {
-      throw new Error(
-        `[${toolName}] User '${assignee}' does not exist or is not accessible`,
-      );
-    }
-    if (!users[0].enabled) {
-      throw new Error(`[${toolName}] User '${assignee}' is disabled`);
-    }
-  }
-}
-
-function assignmentResult(
-  assignees: string[],
-  nativeResult: unknown,
-): Record<string, unknown> {
-  const todos = Array.isArray(nativeResult)
-    ? nativeResult.map((todo) => {
-      const record = todo as Record<string, unknown>;
-      return { owner: record.owner, name: record.name };
-    })
-    : [];
-  return { notify_user: true, assignees, todos };
-}
+import {
+  applyAssignment,
+  ASSIGNMENT_INPUT_PROPERTIES,
+  fetchDocAfterAssignment,
+  prepareAssignment,
+  validateAssignees,
+} from "./assignment.ts";
 
 export const projectTools: ErpNextTool[] = [
   // ── Projects ──────────────────────────────────────────────────────────────
@@ -304,32 +196,7 @@ export const projectTools: ErpNextTool[] = [
           type: "string",
           description: "Expected end date YYYY-MM-DD",
         },
-        assign_to: {
-          type: ["string", "array"],
-          description: "User email or non-empty array of user emails to assign",
-          minLength: 1,
-          minItems: 1,
-          items: { type: "string", minLength: 1 },
-        },
-        notify_user: {
-          type: "boolean",
-          description: "Notify assigned users (must be true; default true)",
-          default: true,
-        },
-        assignment_description: {
-          type: "string",
-          description: "Description for the native ToDo assignment",
-        },
-        assignment_priority: {
-          type: "string",
-          description: "Native ToDo priority",
-          enum: ["Low", "Medium", "High"],
-        },
-        assignment_date: {
-          type: "string",
-          description: "Native ToDo date YYYY-MM-DD",
-          pattern: "^\\d{4}-\\d{2}-\\d{2}$",
-        },
+        ...ASSIGNMENT_INPUT_PROPERTIES,
       },
       required: ["project", "subject"],
     },
@@ -341,9 +208,9 @@ export const projectTools: ErpNextTool[] = [
         throw new Error("[erpnext_task_create] 'subject' is required");
       }
 
-      const assignment = prepareTaskAssignment(input, "erpnext_task_create");
+      const assignment = prepareAssignment(input, "erpnext_task_create");
       if (assignment) {
-        await validateTaskAssignees(
+        await validateAssignees(
           assignment.assignees,
           "erpnext_task_create",
           ctx,
@@ -369,16 +236,23 @@ export const projectTools: ErpNextTool[] = [
         };
       }
 
-      const nativeResult = await ctx.client.callMethod(ASSIGNMENT_METHOD, {
-        doctype: "Task",
-        name: doc.name,
-        ...assignment.args,
-      });
-      const freshDoc = await ctx.client.get("Task", doc.name);
+      const assignmentInfo = await applyAssignment(
+        "Task",
+        doc.name as string,
+        assignment,
+        ctx,
+        `[erpnext_task_create] Task ${doc.name} was created, but assignment failed`,
+      );
+      const freshDoc = await fetchDocAfterAssignment(
+        "Task",
+        doc.name as string,
+        ctx,
+        "erpnext_task_create",
+      );
       return {
         data: freshDoc,
         message: `Task ${doc.name} created successfully`,
-        assignment: assignmentResult(assignment.assignees, nativeResult),
+        assignment: assignmentInfo,
       };
     },
   },
@@ -441,32 +315,7 @@ export const projectTools: ErpNextTool[] = [
           description: "New expected end date YYYY-MM-DD",
         },
         description: { type: "string", description: "New task description" },
-        assign_to: {
-          type: ["string", "array"],
-          description: "User email or non-empty array of user emails to assign",
-          minLength: 1,
-          minItems: 1,
-          items: { type: "string", minLength: 1 },
-        },
-        notify_user: {
-          type: "boolean",
-          description: "Notify assigned users (must be true; default true)",
-          default: true,
-        },
-        assignment_description: {
-          type: "string",
-          description: "Description for the native ToDo assignment",
-        },
-        assignment_priority: {
-          type: "string",
-          description: "Native ToDo priority",
-          enum: ["Low", "Medium", "High"],
-        },
-        assignment_date: {
-          type: "string",
-          description: "Native ToDo date YYYY-MM-DD",
-          pattern: "^\\d{4}-\\d{2}-\\d{2}$",
-        },
+        ...ASSIGNMENT_INPUT_PROPERTIES,
       },
       required: ["name"],
     },
@@ -475,9 +324,9 @@ export const projectTools: ErpNextTool[] = [
         throw new Error("[erpnext_task_update] 'name' is required");
       }
 
-      const assignment = prepareTaskAssignment(input, "erpnext_task_update");
+      const assignment = prepareAssignment(input, "erpnext_task_update");
       if (assignment) {
-        await validateTaskAssignees(
+        await validateAssignees(
           assignment.assignees,
           "erpnext_task_update",
           ctx,
@@ -512,19 +361,30 @@ export const projectTools: ErpNextTool[] = [
         };
       }
 
-      if (Object.keys(data).length > 0) {
+      const fieldsUpdated = Object.keys(data).length > 0;
+      if (fieldsUpdated) {
         await ctx.client.update("Task", name, data);
       }
-      const nativeResult = await ctx.client.callMethod(ASSIGNMENT_METHOD, {
-        doctype: "Task",
+      const failureContext = fieldsUpdated
+        ? `[erpnext_task_update] Task ${name} was updated, but assignment failed`
+        : `[erpnext_task_update] Task ${name} assignment failed`;
+      const assignmentInfo = await applyAssignment(
+        "Task",
         name,
-        ...assignment.args,
-      });
-      const freshDoc = await ctx.client.get("Task", name);
+        assignment,
+        ctx,
+        failureContext,
+      );
+      const freshDoc = await fetchDocAfterAssignment(
+        "Task",
+        name,
+        ctx,
+        "erpnext_task_update",
+      );
       return {
         data: freshDoc,
         message: `Task ${name} updated successfully`,
-        assignment: assignmentResult(assignment.assignees, nativeResult),
+        assignment: assignmentInfo,
       };
     },
   },

--- a/src/tools/project.ts
+++ b/src/tools/project.ts
@@ -10,6 +10,121 @@ import type { FrappeFilter } from "../api/types.ts";
 import type { ErpNextTool } from "./types.ts";
 import { DOCLIST_META } from "./viewer-meta.ts";
 
+const ASSIGNMENT_METHOD = "frappe.desk.form.assign_to.add";
+
+type TaskAssignment = {
+  assignees: string[];
+  args: Record<string, unknown>;
+};
+
+function prepareTaskAssignment(
+  input: Record<string, unknown>,
+  toolName: string,
+): TaskAssignment | undefined {
+  if (input.assign_to === undefined) return undefined;
+
+  if (input.notify_user === false) {
+    throw new Error(
+      `[${toolName}] 'notify_user=false' is not supported for native Task assignments`,
+    );
+  }
+  if (
+    input.notify_user !== undefined && typeof input.notify_user !== "boolean"
+  ) {
+    throw new Error(`[${toolName}] 'notify_user' must be a boolean`);
+  }
+
+  const rawAssignees = typeof input.assign_to === "string"
+    ? [input.assign_to]
+    : Array.isArray(input.assign_to)
+    ? input.assign_to
+    : undefined;
+  if (!rawAssignees || rawAssignees.length === 0) {
+    throw new Error(
+      `[${toolName}] 'assign_to' must be a non-empty string or array of non-empty strings`,
+    );
+  }
+
+  const assignees = [
+    ...new Set(rawAssignees.map((assignee) => {
+      if (typeof assignee !== "string" || !assignee.trim()) {
+        throw new Error(
+          `[${toolName}] 'assign_to' must be a non-empty string or array of non-empty strings`,
+        );
+      }
+      return assignee.trim();
+    })),
+  ];
+
+  const args: Record<string, unknown> = { assign_to: assignees };
+  if (input.assignment_description !== undefined) {
+    if (typeof input.assignment_description !== "string") {
+      throw new Error(
+        `[${toolName}] 'assignment_description' must be a string`,
+      );
+    }
+    args.description = input.assignment_description;
+  }
+  if (input.assignment_priority !== undefined) {
+    if (
+      input.assignment_priority !== "Low" &&
+      input.assignment_priority !== "Medium" &&
+      input.assignment_priority !== "High"
+    ) {
+      throw new Error(
+        `[${toolName}] 'assignment_priority' must be ToDo Low, Medium, or High`,
+      );
+    }
+    args.priority = input.assignment_priority;
+  }
+  if (input.assignment_date !== undefined) {
+    if (
+      typeof input.assignment_date !== "string" ||
+      !/^\d{4}-\d{2}-\d{2}$/.test(input.assignment_date)
+    ) {
+      throw new Error(`[${toolName}] 'assignment_date' must be YYYY-MM-DD`);
+    }
+    args.date = input.assignment_date;
+  }
+
+  return { assignees, args };
+}
+
+async function validateTaskAssignees(
+  assignees: string[],
+  toolName: string,
+  ctx: Parameters<ErpNextTool["handler"]>[1],
+): Promise<void> {
+  for (const assignee of assignees) {
+    const users = await ctx.client.list("User", {
+      fields: ["name", "enabled"],
+      filters: [["name", "=", assignee]],
+      limit: 1,
+    });
+    if (users.length === 0) {
+      throw new Error(
+        `[${toolName}] User '${assignee}' does not exist or is not accessible`,
+      );
+    }
+    if (!users[0].enabled) {
+      throw new Error(`[${toolName}] User '${assignee}' is disabled`);
+    }
+  }
+}
+
+function assignmentResult(
+  assignees: string[],
+  nativeResult: unknown,
+): Record<string, unknown> {
+  const todos = Array.isArray(nativeResult)
+    ? nativeResult.map((todo) => {
+      const record = todo as Record<string, unknown>;
+      return { owner: record.owner, name: record.name };
+    })
+    : [];
+  return { notify_user: true, assignees, todos };
+}
+
 export const projectTools: ErpNextTool[] = [
   // ── Projects ──────────────────────────────────────────────────────────────
 
@@ -157,7 +272,7 @@ export const projectTools: ErpNextTool[] = [
     name: "erpnext_task_create",
     description:
       "Create a new Task in a project. Requires project and subject. " +
-      "Dates in YYYY-MM-DD format.",
+      "Dates in YYYY-MM-DD format. Use assign_to for Frappe's native assignment workflow; native notifications are sent to assigned users.",
     category: "project",
     inputSchema: {
       type: "object",
@@ -189,6 +304,32 @@ export const projectTools: ErpNextTool[] = [
           type: "string",
           description: "Expected end date YYYY-MM-DD",
         },
+        assign_to: {
+          type: ["string", "array"],
+          description: "User email or non-empty array of user emails to assign",
+          minLength: 1,
+          minItems: 1,
+          items: { type: "string", minLength: 1 },
+        },
+        notify_user: {
+          type: "boolean",
+          description: "Notify assigned users (must be true; default true)",
+          default: true,
+        },
+        assignment_description: {
+          type: "string",
+          description: "Description for the native ToDo assignment",
+        },
+        assignment_priority: {
+          type: "string",
+          description: "Native ToDo priority",
+          enum: ["Low", "Medium", "High"],
+        },
+        assignment_date: {
+          type: "string",
+          description: "Native ToDo date YYYY-MM-DD",
+          pattern: "^\\d{4}-\\d{2}-\\d{2}$",
+        },
       },
       required: ["project", "subject"],
     },
@@ -198,6 +339,15 @@ export const projectTools: ErpNextTool[] = [
       }
       if (!input.subject) {
         throw new Error("[erpnext_task_create] 'subject' is required");
+      }
+
+      const assignment = prepareTaskAssignment(input, "erpnext_task_create");
+      if (assignment) {
+        await validateTaskAssignees(
+          assignment.assignees,
+          "erpnext_task_create",
+          ctx,
+        );
       }
 
       const data: Record<string, unknown> = {
@@ -212,9 +362,23 @@ export const projectTools: ErpNextTool[] = [
       if (input.exp_end_date) data.exp_end_date = input.exp_end_date as string;
 
       const doc = await ctx.client.create("Task", data);
+      if (!assignment) {
+        return {
+          data: doc,
+          message: `Task ${doc.name} created successfully`,
+        };
+      }
+
+      const nativeResult = await ctx.client.callMethod(ASSIGNMENT_METHOD, {
+        doctype: "Task",
+        name: doc.name,
+        ...assignment.args,
+      });
+      const freshDoc = await ctx.client.get("Task", doc.name);
       return {
-        data: doc,
+        data: freshDoc,
         message: `Task ${doc.name} created successfully`,
+        assignment: assignmentResult(assignment.assignees, nativeResult),
       };
     },
   },
@@ -245,7 +409,7 @@ export const projectTools: ErpNextTool[] = [
     name: "erpnext_task_update",
     description:
       "Update an existing Task. Pass only the fields you want to change. " +
-      "Commonly used to change status, progress, or dates.",
+      "Commonly used to change status, progress, or dates. Use assign_to for Frappe's native assignment workflow; native notifications are sent to assigned users.",
     category: "project",
     inputSchema: {
       type: "object",
@@ -277,6 +441,32 @@ export const projectTools: ErpNextTool[] = [
           description: "New expected end date YYYY-MM-DD",
         },
         description: { type: "string", description: "New task description" },
+        assign_to: {
+          type: ["string", "array"],
+          description: "User email or non-empty array of user emails to assign",
+          minLength: 1,
+          minItems: 1,
+          items: { type: "string", minLength: 1 },
+        },
+        notify_user: {
+          type: "boolean",
+          description: "Notify assigned users (must be true; default true)",
+          default: true,
+        },
+        assignment_description: {
+          type: "string",
+          description: "Description for the native ToDo assignment",
+        },
+        assignment_priority: {
+          type: "string",
+          description: "Native ToDo priority",
+          enum: ["Low", "Medium", "High"],
+        },
+        assignment_date: {
+          type: "string",
+          description: "Native ToDo date YYYY-MM-DD",
+          pattern: "^\\d{4}-\\d{2}-\\d{2}$",
+        },
       },
       required: ["name"],
     },
@@ -285,22 +475,56 @@ export const projectTools: ErpNextTool[] = [
         throw new Error("[erpnext_task_update] 'name' is required");
       }
 
-      const { name, ...rest } = input;
-      const data: Record<string, unknown> = {};
-      for (const [k, v] of Object.entries(rest)) {
-        if (v !== undefined) data[k] = v;
+      const assignment = prepareTaskAssignment(input, "erpnext_task_update");
+      if (assignment) {
+        await validateTaskAssignees(
+          assignment.assignees,
+          "erpnext_task_update",
+          ctx,
+        );
       }
 
-      if (Object.keys(data).length === 0) {
+      const data: Record<string, unknown> = {};
+      for (
+        const key of [
+          "status",
+          "priority",
+          "progress",
+          "exp_end_date",
+          "description",
+        ]
+      ) {
+        if (input[key] !== undefined) data[key] = input[key];
+      }
+
+      if (Object.keys(data).length === 0 && !assignment) {
         throw new Error(
           "[erpnext_task_update] At least one field to update is required",
         );
       }
 
-      const doc = await ctx.client.update("Task", name as string, data);
+      const name = input.name as string;
+      if (!assignment) {
+        const doc = await ctx.client.update("Task", name, data);
+        return {
+          data: doc,
+          message: `Task ${name} updated successfully`,
+        };
+      }
+
+      if (Object.keys(data).length > 0) {
+        await ctx.client.update("Task", name, data);
+      }
+      const nativeResult = await ctx.client.callMethod(ASSIGNMENT_METHOD, {
+        doctype: "Task",
+        name,
+        ...assignment.args,
+      });
+      const freshDoc = await ctx.client.get("Task", name);
       return {
-        data: doc,
+        data: freshDoc,
         message: `Task ${name} updated successfully`,
+        assignment: assignmentResult(assignment.assignees, nativeResult),
       };
     },
   },

--- a/src/tools/project_test.ts
+++ b/src/tools/project_test.ts
@@ -138,10 +138,11 @@ Deno.test("erpnext_task_update deduplicates assignees and returns an existing na
       assign_to: ["a@example.com", " a@example.com "],
     },
     makeCtx(makeMockClient({
-      list: async (_doctype: string, options: { filters?: unknown[][] }) => [{
-        name: options.filters?.[0][2],
-        enabled: 1,
-      }],
+      list: async (_doctype: string, options: { filters?: unknown[][] }) =>
+        (options.filters?.[0][2] as string[]).map((name) => ({
+          name,
+          enabled: 1,
+        })),
       update: async () => {
         updateCalls++;
         return { name: "TASK-001" };
@@ -280,6 +281,77 @@ Deno.test("erpnext_task_update accepts assignment-only input and refreshes the T
 
   assertEquals(updateCalls, 0);
   assertEquals(result.data, { name: "TASK-001", subject: "Fresh task" });
+});
+
+Deno.test("erpnext_task_create reports the created Task when assignment fails", async () => {
+  await assertRejects(
+    () =>
+      getTool("erpnext_task_create").handler(
+        {
+          project: "PROJ-001",
+          subject: "Plan release",
+          assign_to: "user@example.com",
+        },
+        makeCtx(makeMockClient({
+          callMethod: async () => {
+            throw new Error("Assignment permission denied");
+          },
+        })),
+      ),
+    Error,
+    "Task TASK-001 was created, but assignment failed: Assignment permission denied",
+  );
+});
+
+Deno.test("erpnext_task_update reports updated fields when assignment fails", async () => {
+  let updateCalls = 0;
+  await assertRejects(
+    () =>
+      getTool("erpnext_task_update").handler(
+        {
+          name: "TASK-001",
+          status: "Working",
+          assign_to: "user@example.com",
+        },
+        makeCtx(makeMockClient({
+          update: async () => {
+            updateCalls++;
+            return { name: "TASK-001" };
+          },
+          callMethod: async () => {
+            throw new Error("Assignment permission denied");
+          },
+        })),
+      ),
+    Error,
+    "Task TASK-001 was updated, but assignment failed: Assignment permission denied",
+  );
+  assertEquals(updateCalls, 1);
+});
+
+Deno.test("assignee validation issues a single User query with an 'in' filter", async () => {
+  const listCalls: { doctype: string; filters?: unknown[][] }[] = [];
+  await getTool("erpnext_task_update").handler(
+    { name: "TASK-001", assign_to: ["a@example.com", "b@example.com"] },
+    makeCtx(makeMockClient({
+      list: async (doctype: string, options: { filters?: unknown[][] }) => {
+        listCalls.push({ doctype, filters: options.filters });
+        return [
+          { name: "a@example.com", enabled: 1 },
+          { name: "b@example.com", enabled: 1 },
+        ];
+      },
+      callMethod: async () => [],
+      get: async () => ({ name: "TASK-001" }),
+    })),
+  );
+
+  assertEquals(listCalls.length, 1);
+  assertEquals(listCalls[0].doctype, "User");
+  assertEquals(listCalls[0].filters, [["name", "in", [
+    "a@example.com",
+    "b@example.com",
+  ]]]);
 });
 
 Deno.test("erpnext_task_update propagates native assignment errors", async () => {

--- a/src/tools/project_test.ts
+++ b/src/tools/project_test.ts
@@ -1,0 +1,300 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import type { FrappeClient } from "../api/frappe-client.ts";
+import { projectTools } from "./project.ts";
+import type { ErpNextToolContext } from "./types.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyFn = (...args: any[]) => any;
+
+function makeMockClient(overrides: Record<string, AnyFn> = {}): FrappeClient {
+  return {
+    list: async () => [{ name: "user@example.com", enabled: 1 }],
+    get: async (_doctype: string, name: string) => ({ name }),
+    create: async (_doctype: string, data: Record<string, unknown>) => ({
+      name: "TASK-001",
+      ...data,
+    }),
+    update: async (
+      _doctype: string,
+      name: string,
+      data: Record<string, unknown>,
+    ) => ({
+      name,
+      ...data,
+    }),
+    delete: async () => {},
+    callMethod: async () => [],
+    ...overrides,
+  } as unknown as FrappeClient;
+}
+
+function getTool(name: string) {
+  const tool = projectTools.find((candidate) => candidate.name === name);
+  if (!tool) throw new Error(`Tool not found: ${name}`);
+  return tool;
+}
+
+function makeCtx(client: FrappeClient): ErpNextToolContext {
+  return { client };
+}
+
+Deno.test("erpnext_task_create preserves the existing response without assignees", async () => {
+  let createCalls = 0;
+  const result = await getTool("erpnext_task_create").handler(
+    { project: "PROJ-001", subject: "Plan release", priority: "High" },
+    makeCtx(makeMockClient({
+      create: async (doctype: string, data: Record<string, unknown>) => {
+        createCalls++;
+        assertEquals(doctype, "Task");
+        assertEquals(data, {
+          project: "PROJ-001",
+          subject: "Plan release",
+          priority: "High",
+        });
+        return { name: "TASK-001", ...data };
+      },
+    })),
+  ) as Record<string, unknown>;
+
+  assertEquals(createCalls, 1);
+  assertEquals(result, {
+    data: {
+      name: "TASK-001",
+      project: "PROJ-001",
+      subject: "Plan release",
+      priority: "High",
+    },
+    message: "Task TASK-001 created successfully",
+  });
+});
+
+Deno.test("erpnext_task_update preserves the existing response without assignees", async () => {
+  const result = await getTool("erpnext_task_update").handler(
+    { name: "TASK-001", status: "Working" },
+    makeCtx(makeMockClient({
+      update: async (
+        doctype: string,
+        name: string,
+        data: Record<string, unknown>,
+      ) => {
+        assertEquals([doctype, name, data], ["Task", "TASK-001", {
+          status: "Working",
+        }]);
+        return { name, ...data };
+      },
+    })),
+  ) as Record<string, unknown>;
+
+  assertEquals(result, {
+    data: { name: "TASK-001", status: "Working" },
+    message: "Task TASK-001 updated successfully",
+  });
+});
+
+Deno.test("erpnext_task_create assigns a trimmed string through the native API", async () => {
+  let assignmentArgs: Record<string, unknown> = {};
+  const result = await getTool("erpnext_task_create").handler(
+    {
+      project: "PROJ-001",
+      subject: "Plan release",
+      assign_to: " user@example.com ",
+      assignment_description: "Review scope",
+      assignment_priority: "High",
+      assignment_date: "2026-07-13",
+    },
+    makeCtx(makeMockClient({
+      callMethod: async (method: string, args: Record<string, unknown>) => {
+        assertEquals(method, "frappe.desk.form.assign_to.add");
+        assignmentArgs = args;
+        return [{ owner: "user@example.com", name: "TODO-001" }];
+      },
+      get: async () => ({ name: "TASK-001", status: "Open" }),
+    })),
+  ) as Record<string, unknown>;
+
+  assertEquals(assignmentArgs, {
+    doctype: "Task",
+    name: "TASK-001",
+    assign_to: ["user@example.com"],
+    description: "Review scope",
+    priority: "High",
+    date: "2026-07-13",
+  });
+  assertEquals(result.data, { name: "TASK-001", status: "Open" });
+  assertEquals(result.assignment, {
+    notify_user: true,
+    assignees: ["user@example.com"],
+    todos: [{ owner: "user@example.com", name: "TODO-001" }],
+  });
+});
+
+Deno.test("erpnext_task_update deduplicates assignees and returns an existing native ToDo", async () => {
+  let updateCalls = 0;
+  let assignmentArgs: Record<string, unknown> = {};
+  const result = await getTool("erpnext_task_update").handler(
+    {
+      name: "TASK-001",
+      status: "Working",
+      assign_to: ["a@example.com", " a@example.com "],
+    },
+    makeCtx(makeMockClient({
+      list: async (_doctype: string, options: { filters?: unknown[][] }) => [{
+        name: options.filters?.[0][2],
+        enabled: 1,
+      }],
+      update: async () => {
+        updateCalls++;
+        return { name: "TASK-001" };
+      },
+      callMethod: async (_method: string, args: Record<string, unknown>) => {
+        assignmentArgs = args;
+        return [{ owner: "a@example.com", name: "TODO-001" }];
+      },
+      get: async () => ({ name: "TASK-001", status: "Working" }),
+    })),
+  ) as Record<string, unknown>;
+
+  assertEquals(updateCalls, 1);
+  assertEquals(assignmentArgs, {
+    doctype: "Task",
+    name: "TASK-001",
+    assign_to: ["a@example.com"],
+  });
+  assertEquals(result.assignment, {
+    notify_user: true,
+    assignees: ["a@example.com"],
+    todos: [{ owner: "a@example.com", name: "TODO-001" }],
+  });
+});
+
+Deno.test("erpnext_task_create rejects nonexistent and disabled assignees before mutation", async () => {
+  const tool = getTool("erpnext_task_create");
+  let createCalls = 0;
+  const nonexistent = makeMockClient({
+    list: async () => [],
+    create: async () => {
+      createCalls++;
+      return { name: "TASK-001" };
+    },
+  });
+  await assertRejects(
+    () =>
+      tool.handler({
+        project: "PROJ-001",
+        subject: "Test",
+        assign_to: "missing@example.com",
+      }, makeCtx(nonexistent)),
+    Error,
+    "does not exist",
+  );
+
+  const disabled = makeMockClient({
+    list: async () => [{ name: "disabled@example.com", enabled: 0 }],
+    create: async () => {
+      createCalls++;
+      return { name: "TASK-001" };
+    },
+  });
+  await assertRejects(
+    () =>
+      tool.handler({
+        project: "PROJ-001",
+        subject: "Test",
+        assign_to: "disabled@example.com",
+      }, makeCtx(disabled)),
+    Error,
+    "disabled",
+  );
+  assertEquals(createCalls, 0);
+});
+
+Deno.test("erpnext_task_update assignment controls without assignees do not update Task", async () => {
+  let updateCalls = 0;
+  await assertRejects(
+    () =>
+      getTool("erpnext_task_update").handler(
+        {
+          name: "TASK-001",
+          notify_user: true,
+          assignment_description: "Review scope",
+          assignment_priority: "High",
+          assignment_date: "2026-07-13",
+        },
+        makeCtx(makeMockClient({
+          update: async () => {
+            updateCalls++;
+            return { name: "TASK-001" };
+          },
+        })),
+      ),
+    Error,
+    "At least one field to update is required",
+  );
+  assertEquals(updateCalls, 0);
+});
+
+Deno.test("erpnext_task_update assign_to schema accepts strings and arrays", () => {
+  const schema = getTool("erpnext_task_update").inputSchema.properties
+    ?.assign_to;
+  assertEquals(schema?.type, ["string", "array"]);
+});
+
+Deno.test("erpnext_task_update rejects notify_user=false before mutation", async () => {
+  let updateCalls = 0;
+  const client = makeMockClient({
+    update: async () => {
+      updateCalls++;
+      return { name: "TASK-001" };
+    },
+  });
+  await assertRejects(
+    () =>
+      getTool("erpnext_task_update").handler(
+        {
+          name: "TASK-001",
+          status: "Working",
+          assign_to: "user@example.com",
+          notify_user: false,
+        },
+        makeCtx(client),
+      ),
+    Error,
+    "notify_user=false",
+  );
+  assertEquals(updateCalls, 0);
+});
+
+Deno.test("erpnext_task_update accepts assignment-only input and refreshes the Task", async () => {
+  let updateCalls = 0;
+  const result = await getTool("erpnext_task_update").handler(
+    { name: "TASK-001", assign_to: "user@example.com" },
+    makeCtx(makeMockClient({
+      update: async () => {
+        updateCalls++;
+        return { name: "TASK-001" };
+      },
+      callMethod: async () => [{ owner: "user@example.com", name: "TODO-001" }],
+      get: async () => ({ name: "TASK-001", subject: "Fresh task" }),
+    })),
+  ) as Record<string, unknown>;
+
+  assertEquals(updateCalls, 0);
+  assertEquals(result.data, { name: "TASK-001", subject: "Fresh task" });
+});
+
+Deno.test("erpnext_task_update propagates native assignment errors", async () => {
+  const nativeError = new Error("Assignment permission denied");
+  await assertRejects(
+    () =>
+      getTool("erpnext_task_update").handler(
+        { name: "TASK-001", assign_to: "user@example.com" },
+        makeCtx(makeMockClient({
+          callMethod: async () => {
+            throw nativeError;
+          },
+        })),
+      ),
+    Error,
+    "Assignment permission denied",
+  );
+});

--- a/src/tools/setup.ts
+++ b/src/tools/setup.ts
@@ -7,10 +7,71 @@
  * @module lib/erpnext/tools/setup
  */
 
+import type { FrappeFilter } from "../api/types.ts";
 import type { ErpNextTool } from "./types.ts";
 import { DOCLIST_META } from "./viewer-meta.ts";
 
 export const setupTools: ErpNextTool[] = [
+  // ── Users ──────────────────────────────────────────────────────────────────
+
+  {
+    name: "erpnext_user_list",
+    annotations: { readOnlyHint: true },
+    _meta: DOCLIST_META,
+    description:
+      "List assignable ERPNext users. Defaults to enabled System Users, " +
+      "excluding Administrator and Guest — the population valid for document " +
+      "assignment (erpnext_doc_assign, task assign_to). " +
+      "Fields: name (email), full_name, enabled.",
+    category: "setup",
+    inputSchema: {
+      type: "object",
+      properties: {
+        search: {
+          type: "string",
+          description: "Substring match on full name",
+        },
+        include_disabled: {
+          type: "boolean",
+          description: "Include disabled users (default false)",
+        },
+        limit: { type: "number", description: "Max results (default 50)" },
+      },
+    },
+    handler: async (input, ctx) => {
+      const limit = (input.limit as number) ?? 50;
+      const filters: FrappeFilter[] = [
+        ["user_type", "=", "System User"],
+        ["name", "not in", ["Administrator", "Guest"]],
+      ];
+      if (!input.include_disabled) {
+        filters.push(["enabled", "=", 1]);
+      }
+      if (input.search) {
+        // Escape LIKE wildcards so search is a literal substring match.
+        const literal = (input.search as string).replace(
+          /[\\%_]/g,
+          (match) => `\\${match}`,
+        );
+        filters.push(["full_name", "like", `%${literal}%`]);
+      }
+
+      const docs = await ctx.client.list("User", {
+        fields: ["name", "full_name", "enabled"],
+        filters,
+        limit,
+        order_by: "full_name asc",
+      });
+
+      return {
+        doctype: "User",
+        count: docs.length,
+        data: docs,
+        _meta: DOCLIST_META,
+      };
+    },
+  },
+
   // ── Companies ──────────────────────────────────────────────────────────────
 
   {

--- a/src/tools/setup_test.ts
+++ b/src/tools/setup_test.ts
@@ -1,7 +1,8 @@
 /**
  * Setup Tools Tests
  *
- * Tests for erpnext_company_list and erpnext_company_create.
+ * Tests for erpnext_user_list, erpnext_company_list, and
+ * erpnext_company_create.
  *
  * @module lib/erpnext/tests/tools/setup_test
  */
@@ -203,4 +204,75 @@ Deno.test("erpnext_company_create - domain is optional", async () => {
   );
 
   assertEquals(capturedData.domain, undefined);
+});
+
+// ── erpnext_user_list ───────────────────────────────────────────────────────
+
+Deno.test("erpnext_user_list - defaults to enabled System Users without system accounts", async () => {
+  let capturedFilters: unknown[][] = [];
+  let capturedLimit = 0;
+  const result = await getTool("erpnext_user_list").handler(
+    {},
+    makeCtx(makeMockClient({
+      list: async (
+        doctype: string,
+        options: { filters?: unknown[][]; limit?: number },
+      ) => {
+        assertEquals(doctype, "User");
+        capturedFilters = options.filters ?? [];
+        capturedLimit = options.limit ?? 0;
+        return [{
+          name: "user@example.com",
+          full_name: "User One",
+          enabled: 1,
+        }];
+      },
+    })),
+  ) as Record<string, unknown>;
+
+  assertEquals(capturedFilters, [
+    ["user_type", "=", "System User"],
+    ["name", "not in", ["Administrator", "Guest"]],
+    ["enabled", "=", 1],
+  ]);
+  assertEquals(capturedLimit, 50);
+  assertEquals(result.doctype, "User");
+  assertEquals(result.count, 1);
+});
+
+Deno.test("erpnext_user_list - supports search and include_disabled", async () => {
+  let capturedFilters: unknown[][] = [];
+  await getTool("erpnext_user_list").handler(
+    { search: "Marie", include_disabled: true, limit: 10 },
+    makeCtx(makeMockClient({
+      list: async (_doctype: string, options: { filters?: unknown[][] }) => {
+        capturedFilters = options.filters ?? [];
+        return [];
+      },
+    })),
+  );
+
+  assertEquals(capturedFilters, [
+    ["user_type", "=", "System User"],
+    ["name", "not in", ["Administrator", "Guest"]],
+    ["full_name", "like", "%Marie%"],
+  ]);
+});
+
+Deno.test("erpnext_user_list - escapes LIKE wildcards in search", async () => {
+  let capturedFilters: unknown[][] = [];
+  await getTool("erpnext_user_list").handler(
+    { search: "100%_done\\x" },
+    makeCtx(makeMockClient({
+      list: async (_doctype: string, options: { filters?: unknown[][] }) => {
+        capturedFilters = options.filters ?? [];
+        return [];
+      },
+    })),
+  );
+
+  assertEquals(
+    capturedFilters.find((filter) => filter[0] === "full_name"),
+    ["full_name", "like", "%100\\%\\_done\\\\x%"],
+  );
 });

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -31,7 +31,7 @@ export type ErpNextToolCategory =
 
 /** JSON Schema for tool inputs (MCP wire format) */
 export type JSONSchema = {
-  type: string;
+  type: string | string[];
   properties?: Record<string, JSONSchema>;
   required?: string[];
   description?: string;

--- a/src/ui/global.css
+++ b/src/ui/global.css
@@ -90,7 +90,8 @@ html {
   overflow: hidden;
 }
 
-html, body {
+html,
+body {
   background: var(--bg-root);
   color: var(--text-primary);
   font-family: var(--font-sans);
@@ -124,7 +125,8 @@ body {
 
 /* Animations */
 @keyframes pulse {
-  0%, 100% {
+  0%,
+  100% {
     opacity: 0.4;
   }
   50% {

--- a/src/ui/kanban-viewer/src/DetailModal.tsx
+++ b/src/ui/kanban-viewer/src/DetailModal.tsx
@@ -720,6 +720,183 @@ function DetailMetadataGrid({
 }
 
 // ---------------------------------------------------------------------------
+// Assignees section
+// ---------------------------------------------------------------------------
+
+export type AssignableUser = { name: string; full_name?: string };
+
+/** Parse Frappe's `_assign` meta field (JSON-encoded array of user emails). */
+function parseAssignees(value: unknown): string[] {
+  if (typeof value !== "string" || !value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? parsed.filter((entry): entry is string => typeof entry === "string")
+      : [];
+  } catch (error) {
+    // Malformed _assign must not break the modal — treat as unassigned.
+    console.warn("[parseAssignees] Could not parse _assign:", error, value);
+    return [];
+  }
+}
+
+function AssigneesSection({
+  assignees,
+  onAssign,
+  onLoadUsers,
+}: {
+  assignees: string[];
+  onAssign: (assignTo: string) => Promise<void>;
+  onLoadUsers: () => Promise<AssignableUser[]>;
+}) {
+  const [users, setUsers] = useState<AssignableUser[] | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [selected, setSelected] = useState("");
+  const [assigning, setAssigning] = useState(false);
+  const [assignError, setAssignError] = useState<string | null>(null);
+
+  // Mount-only: the assignable-user list is card-independent, and onLoadUsers
+  // gets a fresh identity on every parent render (board auto-refresh).
+  useEffect(() => {
+    let cancelled = false;
+    onLoadUsers()
+      .then((loaded) => {
+        if (!cancelled) setUsers(loaded);
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setLoadError(
+            error instanceof Error ? error.message : "Failed to load users",
+          );
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const options = (users ?? []).filter(
+    (user) => !assignees.includes(user.name),
+  );
+
+  async function handleAssign() {
+    if (!selected || assigning) return;
+    setAssigning(true);
+    setAssignError(null);
+    try {
+      await onAssign(selected);
+      setSelected("");
+    } catch (error) {
+      setAssignError(
+        error instanceof Error ? error.message : "Assignment failed",
+      );
+    } finally {
+      setAssigning(false);
+    }
+  }
+
+  return (
+    <div
+      style={{
+        padding: "8px 16px 10px",
+        borderBottom: `1px solid ${colors.borderSubtle}`,
+        display: "flex",
+        flexDirection: "column",
+        gap: 6,
+      }}
+    >
+      <div
+        style={{
+          fontSize: 9,
+          fontWeight: 700,
+          color: colors.text.faint,
+          textTransform: "uppercase" as const,
+          letterSpacing: "0.08em",
+        }}
+      >
+        Assigned to
+      </div>
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: 6,
+          alignItems: "center",
+        }}
+      >
+        {assignees.length === 0 && (
+          <span style={{ fontSize: 11, color: colors.text.faint }}>
+            Unassigned
+          </span>
+        )}
+        {assignees.map((email) => (
+          <span
+            key={email}
+            style={{
+              ...styles.badge(colors.accent, colors.accentDim),
+              fontSize: 10,
+            }}
+          >
+            {email}
+          </span>
+        ))}
+        <select
+          aria-label="Assign to user"
+          value={selected}
+          onChange={(e) => setSelected(e.target.value)}
+          disabled={assigning || (users === null && !loadError)}
+          style={{
+            ...styles.input,
+            padding: "3px 8px",
+            fontSize: 11,
+            width: "auto",
+            maxWidth: 220,
+            cursor: "pointer",
+          }}
+        >
+          <option value="">
+            {users === null
+              ? (loadError ? "Users unavailable" : "Loading users…")
+              : "Assign to…"}
+          </option>
+          {options.map((user) => (
+            <option key={user.name} value={user.name}>
+              {user.full_name ? `${user.full_name} (${user.name})` : user.name}
+            </option>
+          ))}
+        </select>
+        {selected && (
+          <button
+            type="button"
+            onClick={handleAssign}
+            disabled={assigning}
+            style={{
+              ...styles.button,
+              padding: "3px 12px",
+              fontSize: 11,
+              fontWeight: 600,
+              background: colors.accent,
+              color: "#fff",
+              borderColor: colors.accent,
+              opacity: assigning ? 0.6 : 1,
+              borderRadius: 5,
+            }}
+          >
+            {assigning ? "Assigning…" : "Assign"}
+          </button>
+        )}
+      </div>
+      {(assignError ?? loadError) && (
+        <div style={{ fontSize: 10, color: colors.error }}>
+          {assignError ?? loadError}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Main modal component
 // ---------------------------------------------------------------------------
 
@@ -729,6 +906,8 @@ export function CardDetailModal({
   onClose,
   onMove,
   onSave,
+  onAssign,
+  onLoadUsers,
   onNavigate,
 }: {
   detail: CardDetailState;
@@ -740,6 +919,12 @@ export function CardDetailModal({
     name: string,
     data: Record<string, string>,
   ) => void;
+  onAssign?: (
+    doctype: string,
+    name: string,
+    assignTo: string,
+  ) => Promise<void>;
+  onLoadUsers?: () => Promise<AssignableUser[]>;
   onNavigate?: (message: string) => void;
 }) {
   const [editedFields, setEditedFields] = useState<Record<string, string>>({});
@@ -766,6 +951,7 @@ export function CardDetailModal({
 
   if (!detail.selectedCardId) return null;
 
+  const selectedCardId = detail.selectedCardId;
   const card = board.cards.find((c) => c.id === detail.selectedCardId);
   const cardTitle = card?.title ?? detail.selectedCardId;
   const availableTargets = card
@@ -1056,6 +1242,16 @@ export function CardDetailModal({
             >
               {detail.detailError}
             </div>
+          )}
+
+          {!detail.detailLoading && detail.cardDetail && onAssign &&
+            onLoadUsers && (
+            <AssigneesSection
+              assignees={parseAssignees(detail.cardDetail._assign)}
+              onAssign={(assignTo) =>
+                onAssign(board.doctype, selectedCardId, assignTo)}
+              onLoadUsers={onLoadUsers}
+            />
           )}
 
           {classified?.descriptionField && (

--- a/src/ui/kanban-viewer/src/KanbanViewer.tsx
+++ b/src/ui/kanban-viewer/src/KanbanViewer.tsx
@@ -1503,6 +1503,63 @@ export function KanbanViewer() {
     void requestBoardRefresh({ ignoreInterval: true });
   }
 
+  async function handleLoadAssignableUsers(): Promise<
+    Array<{ name: string; full_name?: string }>
+  > {
+    if (!app.getHostCapabilities()?.serverTools) {
+      throw new Error("Host does not support proxied server tool calls");
+    }
+    const result = await app.callServerTool({
+      name: "erpnext_user_list",
+      arguments: { limit: 100 },
+    }, { timeout: TOOL_CALL_TIMEOUT_MS });
+    if (result.isError) {
+      throw new Error(extractToolError(result));
+    }
+    const text = extractTextContent(result);
+    if (!text) return [];
+    let payload: { data?: Array<{ name: string; full_name?: string }> };
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      throw new Error("Could not read the user list returned by the server");
+    }
+    return payload.data ?? [];
+  }
+
+  async function handleAssignDetail(
+    doctype: string,
+    name: string,
+    assignTo: string,
+  ) {
+    if (!app.getHostCapabilities()?.serverTools) {
+      throw new Error("Host does not support proxied server tool calls");
+    }
+    const result = await app.callServerTool({
+      name: "erpnext_doc_assign",
+      arguments: { doctype, name, assign_to: assignTo },
+    }, { timeout: TOOL_CALL_TIMEOUT_MS });
+    if (result.isError) {
+      throw new Error(extractToolError(result));
+    }
+
+    // erpnext_doc_assign returns the fresh doc — no extra fetch needed.
+    // The assignment is committed at this point: a hydration hiccup must not
+    // block the board refresh or read as an assignment failure.
+    const text = extractTextContent(result);
+    if (text) {
+      try {
+        hydrateDetail(unwrapDoc(JSON.parse(text) as Record<string, unknown>));
+      } catch (error) {
+        console.warn(
+          "[handleAssignDetail] Could not hydrate the assigned doc:",
+          error,
+        );
+      }
+    }
+    void requestBoardRefresh({ ignoreInterval: true });
+  }
+
   if (state.loading) {
     return (
       <div style={{ minHeight: 600, background: colors.bg.root }}>
@@ -1555,6 +1612,8 @@ export function KanbanViewer() {
           onClose={closeDetail}
           onMove={requestMove}
           onSave={handleSaveDetail}
+          onAssign={handleAssignDetail}
+          onLoadUsers={handleLoadAssignableUsers}
           onNavigate={handleNavigate}
         />
       )}


### PR DESCRIPTION
## Summary

Builds on @mateotiedra's native Task assignment work (#3) — his commits are
included as-is — and generalizes it into a full assignment feature across the
server and the kanban MCP App:

- **Shared assignment module** (`src/tools/assignment.ts`): the Task
  assignment logic from #3, extracted doctype-agnostic and reusable
  (validation, native `frappe.desk.form.assign_to.add` delegation, result
  shaping)
- **`erpnext_doc_assign`** (operations): assign any DocType (Task, Issue,
  Opportunity, …) to one or more users through Frappe's native workflow
- **`erpnext_user_list`** (setup, read-only): list assignable users (enabled
  System Users, excluding Administrator/Guest) — built for assignment pickers
- **Kanban viewer**: the card detail modal now shows current assignees
  (parsed from `_assign`) with a user dropdown fed by `erpnext_user_list` and
  one-click assignment via `erpnext_doc_assign`, with board refresh on success
- **`FrappeFilter`** now accepts array values, enabling `in` / `not in`
  operators

### Review fixes applied on top of #3

- Assignment failures after a successful create/update now say so explicitly
  ("Task X was created, but assignment failed: …") instead of propagating a
  bare error — with regression tests for both paths
- Assignee validation is a single `User` query with an `in` filter instead of
  one query per assignee
- Fixed the `assignment_priority` error message wording
- Clarified the `notify_user` description (Frappe v15 always notifies; `false`
  is rejected)

## Type of change

- [x] feat
- [ ] fix
- [x] docs
- [x] refactor
- [ ] chore
- [x] test

## Related issues

Supersedes and includes #3 — thanks @mateotiedra for the excellent
groundwork: upfront validation, fast-fail semantics, native-workflow
delegation, and the staged ERPNext validation.

## Compatibility

- `erpnext_task_create` / `erpnext_task_update` keep the exact request/response
  behavior introduced in #3; calls without `assign_to` keep the pre-#3
  behavior.
- New tools only add capabilities; nothing is renamed or removed.
- Tool count: 120 → 122 (docs updated).

## How tested

- `deno fmt --check`, `deno lint`, `deno task check`
- Full suite: 199 passed, 0 failed, 4 environment-dependent ignored
- New tests: assignment failure contexts (create + update), single-query
  assignee validation, assignee cap, LIKE-wildcard escaping,
  `erpnext_doc_assign` (happy path, missing doc fast-fail, unknown assignee,
  missing assign_to), `erpnext_user_list` (default filters, search +
  include_disabled), pure `assignment.ts` unit tests
- All 7 UI viewers built successfully
- Three-axis pre-merge review (conventions, silent failures, tool-contract
  correctness); all confirmed findings applied, including: board refresh
  guaranteed after a committed assignment even if detail hydration fails,
  post-assignment re-fetch failures labeled as post-mutation, explicit
  assignee cap, idempotent-safe result message

## Before merge

- [ ] `deno task release:check` (npm bundle gate) — deferred locally because
  a concurrent runtime-selector branch is reworking `scripts/build-node.sh`
- [ ] Staged ERPNext validation of `erpnext_doc_assign`, `erpnext_user_list`
  and the kanban assign flow, mirroring the excellent staging protocol from
  #3 (the unit/build gates are green; the new tools have not yet been
  exercised against a live Frappe 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkWmhS3tj3TfJ7bEnDDDrN
