### PR TITLE
feat: add pluggable cache layer for FrappeClient

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,10 +131,10 @@ status and parsed body — no silent fallbacks.
 
 **Submit handlers must GET the doc first** to pass `modified` for Frappe's
 optimistic locking (see `docs/known-issues.md`), and must pass
-`{ skipCache: true }` so that read isn't served from a stale cache entry.
-Cancel does not need the pre-fetch, but both submit and cancel must call
-`ctx.client.invalidate(doctype, name)` after the mutating `callMethod`
-succeeds — see `src/tools/operations.ts`.
+`{ skipCache: true }` so that read isn't served from a stale cache entry. Cancel
+does not need the pre-fetch, but both submit and cancel must call
+`ctx.client.invalidate(doctype, name)` after the mutating `callMethod` succeeds
+— see `src/tools/operations.ts`.
 
 ### Caching
 
@@ -144,28 +144,27 @@ in-process implementation — a hand-rolled TTL `Map`, zero dependencies;
 `NoopCache` (`src/cache/noop.ts`) disables caching without branching inside
 `FrappeClient`. A future backend (e.g. Redis) just implements `Cache`.
 
-- **Per-instance vs. shared**: `FrappeClient` defaults to a *fresh, unshared*
-  `MemoryCache` per instance unless a `cache` is passed in
-  `FrappeClientConfig`. `getFrappeClient()` (the app-wide singleton in the
-  same file) explicitly wires in the shared `getCache()` singleton
-  (`src/cache/cache.ts`) so all tool calls in the process share one cache.
-  Tests that construct their own `FrappeClient` (e.g. `frappe-client_test.ts`)
-  get isolated per-test caches for free — don't change this default.
+- **Per-instance vs. shared**: `FrappeClient` defaults to a _fresh, unshared_
+  `MemoryCache` per instance unless a `cache` is passed in `FrappeClientConfig`.
+  `getFrappeClient()` (the app-wide singleton in the same file) explicitly wires
+  in the shared `getCache()` singleton (`src/cache/cache.ts`) so all tool calls
+  in the process share one cache. Tests that construct their own `FrappeClient`
+  (e.g. `frappe-client_test.ts`) get isolated per-test caches for free — don't
+  change this default.
 - **Invalidation**: `create()`, `update()`, `delete()` call
-  `this.invalidate(doctype, name)` automatically. Any handler that mutates
-  via `callMethod` (submit, cancel, or a custom business method) must call
+  `this.invalidate(doctype, name)` automatically. Any handler that mutates via
+  `callMethod` (submit, cancel, or a custom business method) must call
   `ctx.client.invalidate(doctype, name)` itself afterward.
-- **Config**: `MCP_CACHE_ENABLED` (`"false"` disables caching entirely,
-  default enabled) and `MCP_CACHE_TTL_MS` (default `15000`).
-- **Warming**: `src/cache/warm.ts`'s `warmCache()` optionally pre-populates
-  the cache on startup by calling a configured set of read-only `_list` tool
-  handlers with no filters — matching the exact cache key a real unfiltered
-  call would use (fields/limit/order_by come from the tool itself, not a
-  hand-rolled `client.list()` guess). Configured via `MCP_CACHE_WARM_TOOLS`
-  (comma-separated tool names; unset/empty = disabled). Refuses to call
-  unknown or non-read-only tools, and never lets one tool's failure abort the
-  rest or the server — see the fire-and-forget call in `server.ts` right
-  after tool registration.
+- **Config**: `MCP_CACHE_ENABLED` (`"false"` disables caching entirely, default
+  enabled) and `MCP_CACHE_TTL_MS` (default `15000`).
+- **Warming**: `src/cache/warm.ts`'s `warmCache()` optionally pre-populates the
+  cache on startup by calling a configured set of read-only `_list` tool
+  handlers with no filters — matching the exact cache key a real unfiltered call
+  would use (fields/limit/order_by come from the tool itself, not a hand-rolled
+  `client.list()` guess). Configured via `MCP_CACHE_WARM_TOOLS` (comma-separated
+  tool names; unset/empty = disabled). Refuses to call unknown or non-read-only
+  tools, and never lets one tool's failure abort the rest or the server — see
+  the fire-and-forget call in `server.ts` right after tool registration.
 
 ### Kanban system
 
@@ -353,8 +352,8 @@ Rules:
 - Environment variables: `ERPNEXT_URL`, `ERPNEXT_API_KEY`, `ERPNEXT_API_SECRET`
   (all required at runtime).
 - Caching (optional): `MCP_CACHE_ENABLED` (default enabled), `MCP_CACHE_TTL_MS`
-  (default `15000`), `MCP_CACHE_WARM_TOOLS` (comma-separated tool names to
-  warm on startup, default disabled). See [Caching](#caching).
+  (default `15000`), `MCP_CACHE_WARM_TOOLS` (comma-separated tool names to warm
+  on startup, default disabled). See [Caching](#caching).
 - Never commit `.env` files, API keys, or credentials. The `.gitignore` already
   covers `.env*`.
 - `FrappeClient` authenticates via API key/secret headers. No OAuth or
@@ -379,13 +378,13 @@ Rules:
 ## Known Issues & Frappe Gotchas
 
 - **Optimistic locking on submit**: Frappe requires the `modified` timestamp.
-  Submit handlers must `GET` the doc first with `{ skipCache: true }`, then
-  pass the full doc to `frappe.client.submit`, then call
-  `ctx.client.invalidate(doctype, name)`. Cancel doesn't need the pre-fetch
-  but must still invalidate. See `docs/known-issues.md`.
-- **`_server_messages`**: Frappe error responses have 2 levels — `exc_type`
-  and `_server_messages`. The client now parses both and includes
-  `_server_messages` in the error message (see `src/api/frappe-client.ts`).
+  Submit handlers must `GET` the doc first with `{ skipCache: true }`, then pass
+  the full doc to `frappe.client.submit`, then call
+  `ctx.client.invalidate(doctype, name)`. Cancel doesn't need the pre-fetch but
+  must still invalidate. See `docs/known-issues.md`.
+- **`_server_messages`**: Frappe error responses have 2 levels — `exc_type` and
+  `_server_messages`. The client now parses both and includes `_server_messages`
+  in the error message (see `src/api/frappe-client.ts`).
 - **Fresh ERPNext instances**: may fail on submit with
   `base_rounded_total = None` until the setup wizard is completed.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,15 @@ in-process implementation — a hand-rolled TTL `Map`, zero dependencies;
   `ctx.client.invalidate(doctype, name)` itself afterward.
 - **Config**: `MCP_CACHE_ENABLED` (`"false"` disables caching entirely,
   default enabled) and `MCP_CACHE_TTL_MS` (default `15000`).
+- **Warming**: `src/cache/warm.ts`'s `warmCache()` optionally pre-populates
+  the cache on startup by calling a configured set of read-only `_list` tool
+  handlers with no filters — matching the exact cache key a real unfiltered
+  call would use (fields/limit/order_by come from the tool itself, not a
+  hand-rolled `client.list()` guess). Configured via `MCP_CACHE_WARM_TOOLS`
+  (comma-separated tool names; unset/empty = disabled). Refuses to call
+  unknown or non-read-only tools, and never lets one tool's failure abort the
+  rest or the server — see the fire-and-forget call in `server.ts` right
+  after tool registration.
 
 ### Kanban system
 
@@ -344,7 +353,8 @@ Rules:
 - Environment variables: `ERPNEXT_URL`, `ERPNEXT_API_KEY`, `ERPNEXT_API_SECRET`
   (all required at runtime).
 - Caching (optional): `MCP_CACHE_ENABLED` (default enabled), `MCP_CACHE_TTL_MS`
-  (default `15000`). See [Caching](#caching).
+  (default `15000`), `MCP_CACHE_WARM_TOOLS` (comma-separated tool names to
+  warm on startup, default disabled). See [Caching](#caching).
 - Never commit `.env` files, API keys, or credentials. The `.gitignore` already
   covers `.env*`.
 - `FrappeClient` authenticates via API key/secret headers. No OAuth or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,8 @@ and JSR (Deno).
   publish config).
 - **Kanban**: `src/kanban/` contains types, definitions, field-utils, and
   per-DocType adapters in `adapters/`.
+- **Cache**: `src/cache/` — pluggable `Cache` interface, `MemoryCache`/
+  `NoopCache` implementations, app-wide singleton.
 - **Runtime adapters**: `src/runtime.ts` (Deno) and `src/runtime.node.ts`
   (Node.js) — the build script swaps them.
 - **Scripts**: `scripts/build-node.sh` produces the npm bundle.
@@ -124,11 +126,37 @@ singleton. The client is lazily initialized from env vars on first use.
 
 `src/api/frappe-client.ts` is a zero-dependency HTTP client wrapping the Frappe
 REST API. Key methods: `list()`, `get()`, `create()`, `update()`, `delete()`,
-`callMethod()`. All errors throw `FrappeAPIError` with HTTP status and parsed
-body — no silent fallbacks.
+`callMethod()`, `invalidate()`. All errors throw `FrappeAPIError` with HTTP
+status and parsed body — no silent fallbacks.
 
 **Submit handlers must GET the doc first** to pass `modified` for Frappe's
-optimistic locking (see `docs/known-issues.md`). Cancel does not need this.
+optimistic locking (see `docs/known-issues.md`), and must pass
+`{ skipCache: true }` so that read isn't served from a stale cache entry.
+Cancel does not need the pre-fetch, but both submit and cancel must call
+`ctx.client.invalidate(doctype, name)` after the mutating `callMethod`
+succeeds — see `src/tools/operations.ts`.
+
+### Caching
+
+`FrappeClient.list()` and `.get()` are cached through a pluggable `Cache`
+(`src/cache/types.ts`). `MemoryCache` (`src/cache/memory.ts`) is the default
+in-process implementation — a hand-rolled TTL `Map`, zero dependencies;
+`NoopCache` (`src/cache/noop.ts`) disables caching without branching inside
+`FrappeClient`. A future backend (e.g. Redis) just implements `Cache`.
+
+- **Per-instance vs. shared**: `FrappeClient` defaults to a *fresh, unshared*
+  `MemoryCache` per instance unless a `cache` is passed in
+  `FrappeClientConfig`. `getFrappeClient()` (the app-wide singleton in the
+  same file) explicitly wires in the shared `getCache()` singleton
+  (`src/cache/cache.ts`) so all tool calls in the process share one cache.
+  Tests that construct their own `FrappeClient` (e.g. `frappe-client_test.ts`)
+  get isolated per-test caches for free — don't change this default.
+- **Invalidation**: `create()`, `update()`, `delete()` call
+  `this.invalidate(doctype, name)` automatically. Any handler that mutates
+  via `callMethod` (submit, cancel, or a custom business method) must call
+  `ctx.client.invalidate(doctype, name)` itself afterward.
+- **Config**: `MCP_CACHE_ENABLED` (`"false"` disables caching entirely,
+  default enabled) and `MCP_CACHE_TTL_MS` (default `15000`).
 
 ### Kanban system
 
@@ -239,6 +267,7 @@ function makeMockClient(overrides: Record<string, unknown> = {}): FrappeClient {
     update: async () => ({ name: "TEST-001" }),
     delete: async () => {},
     callMethod: async () => null,
+    invalidate: () => {},
     ...overrides,
   } as unknown as FrappeClient;
 }
@@ -314,6 +343,8 @@ Rules:
 
 - Environment variables: `ERPNEXT_URL`, `ERPNEXT_API_KEY`, `ERPNEXT_API_SECRET`
   (all required at runtime).
+- Caching (optional): `MCP_CACHE_ENABLED` (default enabled), `MCP_CACHE_TTL_MS`
+  (default `15000`). See [Caching](#caching).
 - Never commit `.env` files, API keys, or credentials. The `.gitignore` already
   covers `.env*`.
 - `FrappeClient` authenticates via API key/secret headers. No OAuth or
@@ -338,11 +369,13 @@ Rules:
 ## Known Issues & Frappe Gotchas
 
 - **Optimistic locking on submit**: Frappe requires the `modified` timestamp.
-  Submit handlers must `GET` the doc first, then pass the full doc to
-  `frappe.client.submit`. Cancel does not need this. See `docs/known-issues.md`.
-- **`_server_messages`**: Frappe error responses have 2 levels — `exc_type` and
-  `_server_messages`. The client now parses both and includes `_server_messages`
-  in the error message (see `src/api/frappe-client.ts`).
+  Submit handlers must `GET` the doc first with `{ skipCache: true }`, then
+  pass the full doc to `frappe.client.submit`, then call
+  `ctx.client.invalidate(doctype, name)`. Cancel doesn't need the pre-fetch
+  but must still invalidate. See `docs/known-issues.md`.
+- **`_server_messages`**: Frappe error responses have 2 levels — `exc_type`
+  and `_server_messages`. The client now parses both and includes
+  `_server_messages` in the error message (see `src/api/frappe-client.ts`).
 - **Fresh ERPNext instances**: may fail on submit with
   `base_rounded_total = None` until the setup wizard is completed.
 

--- a/mod.ts
+++ b/mod.ts
@@ -55,6 +55,7 @@ export { getCache, setCache } from "./src/cache/cache.ts";
 export { MemoryCache } from "./src/cache/memory.ts";
 export { NoopCache } from "./src/cache/noop.ts";
 export type { Cache } from "./src/cache/types.ts";
+export { warmCache } from "./src/cache/warm.ts";
 
 // Re-export API types
 export type {

--- a/mod.ts
+++ b/mod.ts
@@ -50,6 +50,12 @@ export {
 
 export type { FrappeClientConfig } from "./src/api/frappe-client.ts";
 
+// Re-export cache (for direct use or DI in tests)
+export { getCache, setCache } from "./src/cache/cache.ts";
+export { MemoryCache } from "./src/cache/memory.ts";
+export { NoopCache } from "./src/cache/noop.ts";
+export type { Cache } from "./src/cache/types.ts";
+
 // Re-export API types
 export type {
   ErpBin,

--- a/server.ts
+++ b/server.ts
@@ -43,6 +43,7 @@ import {
   readTextFile,
   statSync,
 } from "./src/runtime.ts";
+import { warmCache } from "./src/cache/warm.ts";
 
 const DEFAULT_HTTP_PORT = 3012;
 
@@ -141,6 +142,11 @@ async function main() {
       categories ? ` (categories: ${categories.join(", ")})` : ""
     }`,
   );
+
+  // Fire-and-forget — must never block or fail startup (see warmCache() docs).
+  warmCache().catch((err) => {
+    console.error("[mcp-erpnext] Cache warm failed (non-fatal):", err);
+  });
 
   // Start server
   if (httpFlag) {

--- a/src/api/frappe-client.ts
+++ b/src/api/frappe-client.ts
@@ -27,6 +27,29 @@ import type {
   FrappeMethodResponse,
 } from "./types.ts";
 import { env } from "../runtime.ts";
+import type { Cache } from "../cache/types.ts";
+import { MemoryCache } from "../cache/memory.ts";
+import { getCache, getCacheTtlMs } from "../cache/cache.ts";
+
+/** Deterministic JSON.stringify — sorts object keys so equivalent options produce the same cache key. */
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  if (value !== null && typeof value === "object") {
+    const keys = Object.keys(value as Record<string, unknown>).sort();
+    return `{${
+      keys
+        .map((k) =>
+          `${JSON.stringify(k)}:${
+            stableStringify((value as Record<string, unknown>)[k])
+          }`
+        )
+        .join(",")
+    }}`;
+  }
+  return JSON.stringify(value);
+}
 
 export interface FrappeClientConfig {
   /** ERPNext base URL, e.g. http://localhost:8000 */
@@ -60,6 +83,14 @@ export interface FrappeClientConfig {
    * applied the change.
    */
   retryMethods?: string[];
+  /**
+   * Cache used for list()/get() reads. Defaults to a fresh, unshared
+   * MemoryCache per client instance — NOT the app-wide singleton — so
+   * multiple FrappeClient instances (e.g. one per test) never leak cached
+   * data into each other. Pass `getCache()` explicitly to share the
+   * app-wide cache (see getFrappeClient()).
+   */
+  cache?: Cache;
 }
 
 const DEFAULT_RETRY_STATUSES = [408, 429, 502, 503, 504];
@@ -162,6 +193,7 @@ export class FrappeClient {
   private retryStatuses: number[];
   private retryBackoffMs: number;
   private retryMethods: string[];
+  private cache: Cache;
 
   constructor(config: FrappeClientConfig) {
     this.baseUrl = config.baseUrl.replace(/\/$/, "");
@@ -171,6 +203,7 @@ export class FrappeClient {
     this.retryStatuses = config.retryStatuses ?? DEFAULT_RETRY_STATUSES;
     this.retryBackoffMs = config.retryBackoffMs ?? 200;
     this.retryMethods = config.retryMethods ?? DEFAULT_RETRY_METHODS;
+    this.cache = config.cache ?? new MemoryCache();
   }
 
   // ── Private HTTP helpers ────────────────────────────────────────────────────
@@ -322,6 +355,10 @@ export class FrappeClient {
     doctype: string,
     options: FrappeListOptions = {},
   ): Promise<T[]> {
+    const cacheKey = `list:${doctype}:${stableStringify(options)}`;
+    const cached = this.cache.get<T[]>(cacheKey);
+    if (cached !== undefined) return cached;
+
     const params = new URLSearchParams();
 
     if (options.fields && options.fields.length > 0) {
@@ -346,24 +383,50 @@ export class FrappeClient {
       "GET",
       `/api/resource/${encodeURIComponent(doctype)}${query}`,
     );
-    return res.data ?? [];
+    const docs = res.data ?? [];
+    this.cache.set(cacheKey, docs, getCacheTtlMs());
+    return docs;
   }
 
   /**
    * Get a single document by name.
    * GET /api/resource/{doctype}/{name}
+   *
+   * Pass `{ skipCache: true }` to force a fresh read — required before any
+   * operation relying on the doc's `modified` timestamp for optimistic
+   * locking (see erpnext_doc_submit/erpnext_doc_cancel in operations.ts).
+   * The fresh result still refreshes the cache for subsequent normal reads.
    */
   async get<T extends FrappeDoc = FrappeDoc>(
     doctype: string,
     name: string,
+    opts: { skipCache?: boolean } = {},
   ): Promise<T> {
+    const cacheKey = `get:${doctype}:${name}`;
+    if (!opts.skipCache) {
+      const cached = this.cache.get<T>(cacheKey);
+      if (cached !== undefined) return cached;
+    }
+
     const res = await this.request<FrappeDocResponse<T>>(
       "GET",
       `/api/resource/${encodeURIComponent(doctype)}/${
         encodeURIComponent(name)
       }`,
     );
+    this.cache.set(cacheKey, res.data, getCacheTtlMs());
     return res.data;
+  }
+
+  /**
+   * Clear cached entries for a doctype (list results) and, if `name` is
+   * given, the cached single-document read too. Called automatically after
+   * create/update/delete; call explicitly after any mutation that bypasses
+   * those methods (e.g. frappe.client.submit/cancel via callMethod).
+   */
+  invalidate(doctype: string, name?: string): void {
+    this.cache.deleteByPrefix(`list:${doctype}:`);
+    if (name) this.cache.delete(`get:${doctype}:${name}`);
   }
 
   /**
@@ -379,6 +442,7 @@ export class FrappeClient {
       `/api/resource/${encodeURIComponent(doctype)}`,
       { data: { ...data, doctype } },
     );
+    this.invalidate(doctype, res.data.name as string | undefined);
     return res.data;
   }
 
@@ -398,6 +462,7 @@ export class FrappeClient {
       }`,
       { data },
     );
+    this.invalidate(doctype, name);
     return res.data;
   }
 
@@ -412,6 +477,7 @@ export class FrappeClient {
         encodeURIComponent(name)
       }`,
     );
+    this.invalidate(doctype, name);
   }
 
   /**
@@ -462,7 +528,12 @@ export function getFrappeClient(): FrappeClient {
     );
   }
 
-  _client = new FrappeClient({ baseUrl: url, apiKey, apiSecret });
+  _client = new FrappeClient({
+    baseUrl: url,
+    apiKey,
+    apiSecret,
+    cache: getCache(),
+  });
   return _client;
 }
 

--- a/src/api/frappe-client.ts
+++ b/src/api/frappe-client.ts
@@ -350,14 +350,22 @@ export class FrappeClient {
   /**
    * List documents of a DocType.
    * Frappe list API: GET /api/resource/{doctype}?fields=...&filters=...
+   *
+   * Pass `{ skipCache: true }` to force a fresh read — e.g. for aggregate/KPI
+   * tools that read across doctypes other than the one a preceding mutation
+   * invalidated (see `invalidate()` below for why that gap exists). The fresh
+   * result still refreshes the cache for subsequent normal reads.
    */
   async list<T extends FrappeDoc = FrappeDoc>(
     doctype: string,
     options: FrappeListOptions = {},
+    opts: { skipCache?: boolean } = {},
   ): Promise<T[]> {
     const cacheKey = `list:${doctype}:${stableStringify(options)}`;
-    const cached = this.cache.get<T[]>(cacheKey);
-    if (cached !== undefined) return cached;
+    if (!opts.skipCache) {
+      const cached = this.cache.get<T[]>(cacheKey);
+      if (cached !== undefined) return cached;
+    }
 
     const params = new URLSearchParams();
 
@@ -423,6 +431,14 @@ export class FrappeClient {
    * given, the cached single-document read too. Called automatically after
    * create/update/delete; call explicitly after any mutation that bypasses
    * those methods (e.g. frappe.client.submit/cancel via callMethod).
+   *
+   * Known limitation: this only clears the mutated doctype. Frappe mutations
+   * commonly cascade — submitting a Sales Order also writes Bin/GL
+   * Entry/Sales Invoice rows — and those doctypes' cached `list()` results
+   * aren't invalidated here. Aggregate/KPI tools that read across doctypes
+   * can therefore serve up-to-TTL-stale numbers right after a mutation; pass
+   * `{ skipCache: true }` to `list()` in those tools if that staleness isn't
+   * acceptable for a given call site.
    */
   invalidate(doctype: string, name?: string): void {
     this.cache.deleteByPrefix(`list:${doctype}:`);

--- a/src/api/frappe-client_test.ts
+++ b/src/api/frappe-client_test.ts
@@ -462,6 +462,103 @@ Deno.test("FrappeClient.list() - caches result for identical options", async () 
   }
 });
 
+Deno.test("FrappeClient.list() - skipCache bypasses the cached read", async () => {
+  let fetchCount = 0;
+  const original = globalThis.fetch;
+  globalThis.fetch = async () => {
+    fetchCount++;
+    return new Response(
+      JSON.stringify({ data: [{ name: "CUST-001" }] }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+
+  try {
+    const client = makeClient();
+    await client.list("Customer", { limit: 10 });
+    await client.list("Customer", { limit: 10 }, { skipCache: true });
+    assertEquals(fetchCount, 2);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("FrappeClient.create() - invalidates the list cache for that doctype", async () => {
+  let fetchCount = 0;
+  let created = false;
+  const original = globalThis.fetch;
+  globalThis.fetch = async (_url, init?: RequestInit) => {
+    fetchCount++;
+    if (init?.method === "POST") {
+      created = true;
+      return new Response(
+        JSON.stringify({ data: { name: "CUST-002" } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    return new Response(
+      JSON.stringify({
+        data: created ? [{ name: "CUST-001" }, { name: "CUST-002" }] : [{
+          name: "CUST-001",
+        }],
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+
+  try {
+    const client = makeClient();
+    const before = await client.list("Customer", { limit: 10 });
+    assertEquals(before.length, 1);
+
+    await client.create("Customer", { customer_name: "New Corp" });
+
+    const after = await client.list("Customer", { limit: 10 });
+    assertEquals(after.length, 2);
+    assertEquals(fetchCount, 3); // initial list, create, refreshed list
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("FrappeClient.delete() - invalidates both the list cache and the cached get() for that name", async () => {
+  let fetchCount = 0;
+  let deleted = false;
+  const original = globalThis.fetch;
+  globalThis.fetch = async (_url, init?: RequestInit) => {
+    fetchCount++;
+    if (init?.method === "DELETE") {
+      deleted = true;
+      return new Response("", { status: 202 });
+    }
+    if (deleted) {
+      return new Response(
+        JSON.stringify({ message: "Document not found" }),
+        { status: 404, headers: { "content-type": "application/json" } },
+      );
+    }
+    return new Response(
+      JSON.stringify({ data: { name: "CUST-001" } }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+
+  try {
+    const client = makeClient();
+    await client.get("Customer", "CUST-001");
+    await client.delete("Customer", "CUST-001");
+
+    await assertRejects(
+      () => client.get("Customer", "CUST-001"),
+      FrappeAPIError,
+      "HTTP 404",
+    );
+    assertEquals(fetchCount, 3); // initial get, delete, refreshed (now-404) get
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
 Deno.test("FrappeClient.update() - invalidates the cached get() for that name", async () => {
   let fetchCount = 0;
   let updated = false;

--- a/src/api/frappe-client_test.ts
+++ b/src/api/frappe-client_test.ts
@@ -396,3 +396,131 @@ Deno.test("FrappeClient parsing - malformed JSON in error body falls back to tex
     restore();
   }
 });
+
+// ── Caching ──────────────────────────────────────────────────────────────────
+
+Deno.test("FrappeClient.get() - caches result, second call skips fetch", async () => {
+  let fetchCount = 0;
+  const original = globalThis.fetch;
+  globalThis.fetch = async () => {
+    fetchCount++;
+    return new Response(
+      JSON.stringify({ data: { name: "CUST-001" } }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+
+  try {
+    const client = makeClient();
+    await client.get("Customer", "CUST-001");
+    await client.get("Customer", "CUST-001");
+    assertEquals(fetchCount, 1);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("FrappeClient.get() - skipCache bypasses the cached read", async () => {
+  let fetchCount = 0;
+  const original = globalThis.fetch;
+  globalThis.fetch = async () => {
+    fetchCount++;
+    return new Response(
+      JSON.stringify({ data: { name: "CUST-001" } }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+
+  try {
+    const client = makeClient();
+    await client.get("Customer", "CUST-001");
+    await client.get("Customer", "CUST-001", { skipCache: true });
+    assertEquals(fetchCount, 2);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("FrappeClient.list() - caches result for identical options", async () => {
+  let fetchCount = 0;
+  const original = globalThis.fetch;
+  globalThis.fetch = async () => {
+    fetchCount++;
+    return new Response(
+      JSON.stringify({ data: [{ name: "CUST-001" }] }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+
+  try {
+    const client = makeClient();
+    await client.list("Customer", { limit: 10 });
+    await client.list("Customer", { limit: 10 });
+    assertEquals(fetchCount, 1);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("FrappeClient.update() - invalidates the cached get() for that name", async () => {
+  let fetchCount = 0;
+  let updated = false;
+  const original = globalThis.fetch;
+  globalThis.fetch = async (_url, init?: RequestInit) => {
+    fetchCount++;
+    if (init?.method === "PUT") {
+      updated = true;
+      return new Response(
+        JSON.stringify({
+          data: { name: "CUST-001", customer_name: "Updated" },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    return new Response(
+      JSON.stringify({
+        data: {
+          name: "CUST-001",
+          customer_name: updated ? "Updated" : "Original",
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+
+  try {
+    const client = makeClient();
+    const before = await client.get("Customer", "CUST-001");
+    assertEquals(before.customer_name, "Original");
+
+    await client.update("Customer", "CUST-001", { customer_name: "Updated" });
+
+    const after = await client.get("Customer", "CUST-001");
+    assertEquals(after.customer_name, "Updated");
+    assertEquals(fetchCount, 3); // initial get, update, refreshed get
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("FrappeClient.invalidate() - clears list cache for a doctype", async () => {
+  let fetchCount = 0;
+  const original = globalThis.fetch;
+  globalThis.fetch = async () => {
+    fetchCount++;
+    return new Response(
+      JSON.stringify({ data: [{ name: "CUST-001" }] }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+
+  try {
+    const client = makeClient();
+    await client.list("Customer", { limit: 10 });
+    client.invalidate("Customer");
+    await client.list("Customer", { limit: 10 });
+    assertEquals(fetchCount, 2);
+  } finally {
+    globalThis.fetch = original;
+  }
+});

--- a/src/cache/cache.ts
+++ b/src/cache/cache.ts
@@ -1,0 +1,38 @@
+/**
+ * App-wide cache singleton.
+ *
+ * Mirrors the getFrappeClient()/setFrappeClient() pattern in
+ * src/api/frappe-client.ts. Backend and TTL are configured via env vars:
+ *   MCP_CACHE_ENABLED — "false" disables caching (NoopCache). Default: enabled.
+ *   MCP_CACHE_TTL_MS   — default TTL for cached entries. Default: 15000.
+ *
+ * @module lib/erpnext/cache/cache
+ */
+
+import type { Cache } from "./types.ts";
+import { MemoryCache } from "./memory.ts";
+import { NoopCache } from "./noop.ts";
+import { env } from "../runtime.ts";
+
+export const DEFAULT_CACHE_TTL_MS = 15_000;
+
+let _cache: Cache | null = null;
+
+export function getCacheTtlMs(): number {
+  const raw = env("MCP_CACHE_TTL_MS");
+  const parsed = raw ? Number(raw) : NaN;
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_CACHE_TTL_MS;
+}
+
+/** Get (or lazily create) the singleton app-wide Cache. */
+export function getCache(): Cache {
+  if (_cache) return _cache;
+  const enabled = env("MCP_CACHE_ENABLED") !== "false";
+  _cache = enabled ? new MemoryCache() : new NoopCache();
+  return _cache;
+}
+
+/** Override the singleton (useful for tests or dependency injection). */
+export function setCache(cache: Cache): void {
+  _cache = cache;
+}

--- a/src/cache/cache.ts
+++ b/src/cache/cache.ts
@@ -4,7 +4,12 @@
  * Mirrors the getFrappeClient()/setFrappeClient() pattern in
  * src/api/frappe-client.ts. Backend and TTL are configured via env vars:
  *   MCP_CACHE_ENABLED — "false" disables caching (NoopCache). Default: enabled.
- *   MCP_CACHE_TTL_MS   — default TTL for cached entries. Default: 15000.
+ *   MCP_CACHE_TTL_MS   — default TTL in ms for cached entries. Default: 15000.
+ *     0 is a valid, explicit value: entries expire immediately (cache
+ *     read/write overhead still applies but nothing is ever served stale) —
+ *     prefer MCP_CACHE_ENABLED=false to skip that overhead entirely. Any
+ *     other invalid value (non-numeric or negative) is logged and falls back
+ *     to the default rather than failing silently.
  *
  * @module lib/erpnext/cache/cache
  */
@@ -20,8 +25,18 @@ let _cache: Cache | null = null;
 
 export function getCacheTtlMs(): number {
   const raw = env("MCP_CACHE_TTL_MS");
-  const parsed = raw ? Number(raw) : NaN;
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_CACHE_TTL_MS;
+  if (raw === undefined) return DEFAULT_CACHE_TTL_MS;
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    console.error(
+      `[mcp-erpnext] Invalid MCP_CACHE_TTL_MS=${
+        JSON.stringify(raw)
+      } — must be a non-negative number. Falling back to default (${DEFAULT_CACHE_TTL_MS}ms).`,
+    );
+    return DEFAULT_CACHE_TTL_MS;
+  }
+  return parsed;
 }
 
 /** Get (or lazily create) the singleton app-wide Cache. */

--- a/src/cache/cache_test.ts
+++ b/src/cache/cache_test.ts
@@ -5,8 +5,29 @@
  */
 
 import { assertEquals, assertStrictEquals } from "@std/assert";
-import { getCache, setCache } from "./cache.ts";
+import {
+  DEFAULT_CACHE_TTL_MS,
+  getCache,
+  getCacheTtlMs,
+  setCache,
+} from "./cache.ts";
 import { MemoryCache } from "./memory.ts";
+
+function withEnv(
+  key: string,
+  value: string | undefined,
+  fn: () => void,
+) {
+  const original = Deno.env.get(key);
+  if (value === undefined) Deno.env.delete(key);
+  else Deno.env.set(key, value);
+  try {
+    fn();
+  } finally {
+    if (original === undefined) Deno.env.delete(key);
+    else Deno.env.set(key, original);
+  }
+}
 
 Deno.test("getCache() - returns the same instance across calls", () => {
   setCache(new MemoryCache());
@@ -25,4 +46,54 @@ Deno.test("setCache() - overrides the singleton", () => {
   setCache(other);
   assertStrictEquals(getCache(), other);
   assertEquals(getCache().get("marker"), undefined);
+});
+
+Deno.test("getCacheTtlMs() - returns the default when MCP_CACHE_TTL_MS is unset", () => {
+  withEnv("MCP_CACHE_TTL_MS", undefined, () => {
+    assertEquals(getCacheTtlMs(), DEFAULT_CACHE_TTL_MS);
+  });
+});
+
+Deno.test("getCacheTtlMs() - returns a valid explicit value", () => {
+  withEnv("MCP_CACHE_TTL_MS", "5000", () => {
+    assertEquals(getCacheTtlMs(), 5000);
+  });
+});
+
+Deno.test("getCacheTtlMs() - 0 is a valid explicit value (immediate expiry)", () => {
+  withEnv("MCP_CACHE_TTL_MS", "0", () => {
+    assertEquals(getCacheTtlMs(), 0);
+  });
+});
+
+Deno.test("getCacheTtlMs() - logs and falls back to the default on a non-numeric value", () => {
+  const originalError = console.error;
+  let loggedMessage = "";
+  console.error = (msg: string) => {
+    loggedMessage = msg;
+  };
+  try {
+    withEnv("MCP_CACHE_TTL_MS", "abc", () => {
+      assertEquals(getCacheTtlMs(), DEFAULT_CACHE_TTL_MS);
+    });
+  } finally {
+    console.error = originalError;
+  }
+  assertEquals(loggedMessage.includes("Invalid MCP_CACHE_TTL_MS"), true);
+});
+
+Deno.test("getCacheTtlMs() - logs and falls back to the default on a negative value", () => {
+  const originalError = console.error;
+  let loggedMessage = "";
+  console.error = (msg: string) => {
+    loggedMessage = msg;
+  };
+  try {
+    withEnv("MCP_CACHE_TTL_MS", "-5", () => {
+      assertEquals(getCacheTtlMs(), DEFAULT_CACHE_TTL_MS);
+    });
+  } finally {
+    console.error = originalError;
+  }
+  assertEquals(loggedMessage.includes("Invalid MCP_CACHE_TTL_MS"), true);
 });

--- a/src/cache/cache_test.ts
+++ b/src/cache/cache_test.ts
@@ -1,0 +1,28 @@
+/**
+ * Cache Singleton Tests
+ *
+ * @module lib/erpnext/tests/cache/cache_test
+ */
+
+import { assertEquals, assertStrictEquals } from "@std/assert";
+import { getCache, setCache } from "./cache.ts";
+import { MemoryCache } from "./memory.ts";
+
+Deno.test("getCache() - returns the same instance across calls", () => {
+  setCache(new MemoryCache());
+  const a = getCache();
+  const b = getCache();
+  assertStrictEquals(a, b);
+});
+
+Deno.test("setCache() - overrides the singleton", () => {
+  const custom = new MemoryCache();
+  custom.set("marker", "custom", 1000);
+  setCache(custom);
+  assertStrictEquals(getCache(), custom);
+
+  const other = new MemoryCache();
+  setCache(other);
+  assertStrictEquals(getCache(), other);
+  assertEquals(getCache().get("marker"), undefined);
+});

--- a/src/cache/memory.ts
+++ b/src/cache/memory.ts
@@ -1,0 +1,47 @@
+/**
+ * In-memory TTL cache.
+ *
+ * Zero-dependency, hand-rolled Map with lazy expiry (checked on read/write,
+ * no background timers) so behavior is identical on Deno and Node.
+ *
+ * @module lib/erpnext/cache/memory
+ */
+
+import type { Cache } from "./types.ts";
+
+interface Entry {
+  value: unknown;
+  expiresAt: number;
+}
+
+export class MemoryCache implements Cache {
+  private store = new Map<string, Entry>();
+
+  get<T>(key: string): T | undefined {
+    const entry = this.store.get(key);
+    if (!entry) return undefined;
+    if (Date.now() >= entry.expiresAt) {
+      this.store.delete(key);
+      return undefined;
+    }
+    return entry.value as T;
+  }
+
+  set<T>(key: string, value: T, ttlMs: number): void {
+    this.store.set(key, { value, expiresAt: Date.now() + ttlMs });
+  }
+
+  delete(key: string): void {
+    this.store.delete(key);
+  }
+
+  deleteByPrefix(prefix: string): void {
+    for (const key of this.store.keys()) {
+      if (key.startsWith(prefix)) this.store.delete(key);
+    }
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}

--- a/src/cache/memory.ts
+++ b/src/cache/memory.ts
@@ -24,7 +24,10 @@ export class MemoryCache implements Cache {
       this.store.delete(key);
       return undefined;
     }
-    return entry.value as T;
+    // Clone on every read: callers get an independent copy, so mutating a
+    // returned doc/array (e.g. a future `docs.sort()` or `doc.x = ...`)
+    // can't corrupt what later callers read back within the TTL.
+    return structuredClone(entry.value) as T;
   }
 
   set<T>(key: string, value: T, ttlMs: number): void {

--- a/src/cache/memory_test.ts
+++ b/src/cache/memory_test.ts
@@ -46,6 +46,19 @@ Deno.test("MemoryCache - deleteByPrefix clears only matching keys", () => {
   assertEquals(cache.get("get:Customer:CUST-001"), { name: "CUST-001" });
 });
 
+Deno.test("MemoryCache - get() returns an independent copy, so mutating it doesn't corrupt later reads", () => {
+  const cache = new MemoryCache();
+  const original = [{ name: "A" }, { name: "B" }];
+  cache.set("docs", original, 1000);
+
+  const firstRead = cache.get<{ name: string }[]>("docs")!;
+  firstRead.sort((a, b) => b.name.localeCompare(a.name));
+  firstRead[0].name = "mutated";
+
+  const secondRead = cache.get<{ name: string }[]>("docs")!;
+  assertEquals(secondRead, [{ name: "A" }, { name: "B" }]);
+});
+
 Deno.test("MemoryCache - clear removes everything", () => {
   const cache = new MemoryCache();
   cache.set("a", 1, 1000);

--- a/src/cache/memory_test.ts
+++ b/src/cache/memory_test.ts
@@ -1,0 +1,56 @@
+/**
+ * MemoryCache Tests
+ *
+ * @module lib/erpnext/tests/cache/memory_test
+ */
+
+import { assertEquals } from "@std/assert";
+import { MemoryCache } from "./memory.ts";
+
+Deno.test("MemoryCache - set/get round trip", () => {
+  const cache = new MemoryCache();
+  cache.set("a", { foo: "bar" }, 1000);
+  assertEquals(cache.get<{ foo: string }>("a"), { foo: "bar" });
+});
+
+Deno.test("MemoryCache - get returns undefined for missing key", () => {
+  const cache = new MemoryCache();
+  assertEquals(cache.get("missing"), undefined);
+});
+
+Deno.test("MemoryCache - entry expires after ttlMs", async () => {
+  const cache = new MemoryCache();
+  cache.set("a", "value", 10);
+  assertEquals(cache.get("a"), "value");
+  await new Promise((r) => setTimeout(r, 20));
+  assertEquals(cache.get("a"), undefined);
+});
+
+Deno.test("MemoryCache - delete removes a single key", () => {
+  const cache = new MemoryCache();
+  cache.set("a", 1, 1000);
+  cache.set("b", 2, 1000);
+  cache.delete("a");
+  assertEquals(cache.get("a"), undefined);
+  assertEquals(cache.get("b"), 2);
+});
+
+Deno.test("MemoryCache - deleteByPrefix clears only matching keys", () => {
+  const cache = new MemoryCache();
+  cache.set("list:Customer:x", [1], 1000);
+  cache.set("list:Customer:y", [2], 1000);
+  cache.set("get:Customer:CUST-001", { name: "CUST-001" }, 1000);
+  cache.deleteByPrefix("list:Customer:");
+  assertEquals(cache.get("list:Customer:x"), undefined);
+  assertEquals(cache.get("list:Customer:y"), undefined);
+  assertEquals(cache.get("get:Customer:CUST-001"), { name: "CUST-001" });
+});
+
+Deno.test("MemoryCache - clear removes everything", () => {
+  const cache = new MemoryCache();
+  cache.set("a", 1, 1000);
+  cache.set("b", 2, 1000);
+  cache.clear();
+  assertEquals(cache.get("a"), undefined);
+  assertEquals(cache.get("b"), undefined);
+});

--- a/src/cache/noop.ts
+++ b/src/cache/noop.ts
@@ -1,0 +1,20 @@
+/**
+ * No-op cache — every read misses, every write is discarded.
+ *
+ * Lets caching be fully disabled via config (MCP_CACHE_ENABLED=false)
+ * without branching inside FrappeClient.
+ *
+ * @module lib/erpnext/cache/noop
+ */
+
+import type { Cache } from "./types.ts";
+
+export class NoopCache implements Cache {
+  get<T>(_key: string): T | undefined {
+    return undefined;
+  }
+  set<T>(_key: string, _value: T, _ttlMs: number): void {}
+  delete(_key: string): void {}
+  deleteByPrefix(_prefix: string): void {}
+  clear(): void {}
+}

--- a/src/cache/noop_test.ts
+++ b/src/cache/noop_test.ts
@@ -1,0 +1,35 @@
+/**
+ * NoopCache Tests
+ *
+ * @module lib/erpnext/tests/cache/noop_test
+ */
+
+import { assertEquals } from "@std/assert";
+import { NoopCache } from "./noop.ts";
+
+Deno.test("NoopCache - get always returns undefined, even right after set", () => {
+  const cache = new NoopCache();
+  cache.set("a", "value", 1000);
+  assertEquals(cache.get("a"), undefined);
+});
+
+Deno.test("NoopCache - delete is a no-op that doesn't throw", () => {
+  const cache = new NoopCache();
+  cache.set("a", "value", 1000);
+  cache.delete("a");
+  assertEquals(cache.get("a"), undefined);
+});
+
+Deno.test("NoopCache - deleteByPrefix is a no-op that doesn't throw", () => {
+  const cache = new NoopCache();
+  cache.set("list:Customer:x", [1], 1000);
+  cache.deleteByPrefix("list:Customer:");
+  assertEquals(cache.get("list:Customer:x"), undefined);
+});
+
+Deno.test("NoopCache - clear is a no-op that doesn't throw", () => {
+  const cache = new NoopCache();
+  cache.set("a", "value", 1000);
+  cache.clear();
+  assertEquals(cache.get("a"), undefined);
+});

--- a/src/cache/types.ts
+++ b/src/cache/types.ts
@@ -1,0 +1,16 @@
+/**
+ * Cache abstraction.
+ *
+ * Pluggable seam: MemoryCache is the default in-process implementation;
+ * a future backend (e.g. Redis) implements the same interface.
+ *
+ * @module lib/erpnext/cache/types
+ */
+
+export interface Cache {
+  get<T>(key: string): T | undefined;
+  set<T>(key: string, value: T, ttlMs: number): void;
+  delete(key: string): void;
+  deleteByPrefix(prefix: string): void;
+  clear(): void;
+}

--- a/src/cache/warm.ts
+++ b/src/cache/warm.ts
@@ -1,0 +1,56 @@
+/**
+ * Cache warming.
+ *
+ * Optionally pre-populates the cache on server startup so the first real
+ * tool call in a session isn't a cold miss.
+ *
+ * @module lib/erpnext/cache/warm
+ */
+
+import { getToolByName } from "../client.ts";
+import { getFrappeClient } from "../api/frappe-client.ts";
+import { env } from "../runtime.ts";
+
+/**
+ * Warm the cache by calling a configured set of read-only `_list` tools with
+ * no filters. Calling the real tool handler — rather than client.list()
+ * directly — guarantees the cache key matches exactly what a real unfiltered
+ * "list X" call will use (same fields/limit/order_by), so the warmed entry
+ * is actually a hit later.
+ *
+ * Configured via MCP_CACHE_WARM_TOOLS (comma-separated tool names). Unset or
+ * empty disables warming entirely — no behavior change by default. Never
+ * throws: every failure (unknown tool, non-read-only tool, network error) is
+ * logged and skipped so one bad entry can't abort the rest or the server.
+ */
+export async function warmCache(): Promise<void> {
+  const configured = env("MCP_CACHE_WARM_TOOLS");
+  if (!configured?.trim()) return;
+
+  const client = getFrappeClient();
+  const names = configured.split(",").map((s) => s.trim()).filter(Boolean);
+
+  for (const name of names) {
+    const tool = getToolByName(name);
+    if (!tool) {
+      console.error(
+        `[mcp-erpnext] Cache warm: unknown tool "${name}", skipping`,
+      );
+      continue;
+    }
+    if (!tool.annotations?.readOnlyHint) {
+      console.error(
+        `[mcp-erpnext] Cache warm: "${name}" is not read-only, refusing to call it, skipping`,
+      );
+      continue;
+    }
+    try {
+      await tool.handler({}, { client });
+    } catch (err) {
+      console.error(
+        `[mcp-erpnext] Cache warm: "${name}" failed (non-fatal):`,
+        err,
+      );
+    }
+  }
+}

--- a/src/cache/warm_test.ts
+++ b/src/cache/warm_test.ts
@@ -1,0 +1,106 @@
+/**
+ * Cache Warming Tests
+ *
+ * @module lib/erpnext/tests/cache/warm_test
+ */
+
+import { assertEquals } from "@std/assert";
+import { warmCache } from "./warm.ts";
+import { setFrappeClient } from "../api/frappe-client.ts";
+import type { FrappeClient } from "../api/frappe-client.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyFn = (...args: any[]) => any;
+
+function makeMockClient(overrides: Record<string, AnyFn> = {}): FrappeClient {
+  const mock: Record<string, AnyFn> = {
+    list: async () => [],
+    get: async () => ({ name: "TEST-001" }),
+    create: async () => ({ name: "NEW-001" }),
+    update: async () => ({ name: "TEST-001" }),
+    delete: async () => {},
+    callMethod: async () => null,
+    invalidate: () => {},
+    ...overrides,
+  };
+  return mock as unknown as FrappeClient;
+}
+
+function withEnv(
+  key: string,
+  value: string | undefined,
+  fn: () => Promise<void>,
+) {
+  const original = Deno.env.get(key);
+  if (value === undefined) Deno.env.delete(key);
+  else Deno.env.set(key, value);
+  return fn().finally(() => {
+    if (original === undefined) Deno.env.delete(key);
+    else Deno.env.set(key, original);
+  });
+}
+
+Deno.test("warmCache - no-op when MCP_CACHE_WARM_TOOLS is unset", async () => {
+  await withEnv("MCP_CACHE_WARM_TOOLS", undefined, async () => {
+    let listCalled = false;
+    setFrappeClient(
+      makeMockClient({ list: async () => (listCalled = true, []) }),
+    );
+    await warmCache();
+    assertEquals(listCalled, false);
+  });
+});
+
+Deno.test("warmCache - calls handler for a configured read-only list tool", async () => {
+  await withEnv("MCP_CACHE_WARM_TOOLS", "erpnext_employee_list", async () => {
+    let listCalled = false;
+    setFrappeClient(
+      makeMockClient({ list: async () => (listCalled = true, []) }),
+    );
+    await warmCache();
+    assertEquals(listCalled, true);
+  });
+});
+
+Deno.test("warmCache - skips an unknown tool name without throwing", async () => {
+  await withEnv(
+    "MCP_CACHE_WARM_TOOLS",
+    "erpnext_totally_fake_tool_xyz",
+    async () => {
+      setFrappeClient(makeMockClient());
+      await warmCache(); // should not throw
+    },
+  );
+});
+
+Deno.test("warmCache - refuses to call a non-read-only tool", async () => {
+  await withEnv("MCP_CACHE_WARM_TOOLS", "erpnext_doc_create", async () => {
+    let createCalled = false;
+    setFrappeClient(
+      makeMockClient({ create: async () => (createCalled = true, {}) }),
+    );
+    await warmCache();
+    assertEquals(createCalled, false);
+  });
+});
+
+Deno.test("warmCache - one tool failing doesn't stop the rest", async () => {
+  await withEnv(
+    "MCP_CACHE_WARM_TOOLS",
+    "erpnext_customer_list,erpnext_employee_list",
+    async () => {
+      let employeeListCalled = false;
+      setFrappeClient(makeMockClient({
+        list: async (doctype: string) => {
+          if (doctype === "Customer") {
+            throw new Error("simulated network failure");
+          }
+          if (doctype === "Employee") employeeListCalled = true;
+          return [];
+        },
+      }));
+      await warmCache(); // should not throw despite Customer list failing
+      assertEquals(employeeListCalled, true);
+    },
+  );
+});

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -200,14 +200,17 @@ export const operationsTools: ErpNextTool[] = [
         throw new Error("[erpnext_doc_submit] 'name' is required");
       }
 
-      // Fetch fresh doc first — frappe.client.submit requires `modified` for optimistic locking
+      // Fetch fresh doc first — frappe.client.submit requires `modified` for optimistic
+      // locking, so this read must bypass the cache even if a recent copy is cached.
       const doc = await ctx.client.get(
         input.doctype as string,
         input.name as string,
+        { skipCache: true },
       );
       const result = await ctx.client.callMethod("frappe.client.submit", {
         doc: { ...doc, doctype: input.doctype as string },
       });
+      ctx.client.invalidate(input.doctype as string, input.name as string);
 
       return {
         data: result,
@@ -255,6 +258,7 @@ export const operationsTools: ErpNextTool[] = [
         doctype: input.doctype as string,
         name: input.name as string,
       });
+      ctx.client.invalidate(input.doctype as string, input.name as string);
 
       return {
         data: result,

--- a/src/tools/operations_test.ts
+++ b/src/tools/operations_test.ts
@@ -25,6 +25,7 @@ function makeMockClient(overrides: Record<string, AnyFn> = {}): FrappeClient {
     update: async () => ({ name: "TEST-001" }),
     delete: async () => {},
     callMethod: async () => null,
+    invalidate: () => {},
     ...overrides,
   };
   return mock as unknown as FrappeClient;
@@ -130,6 +131,64 @@ Deno.test("erpnext_doc_create - works with Item Group (tree doctype)", async () 
   const doc = result.data as Record<string, unknown>;
   assertEquals(doc.name, "Products");
   assertEquals(doc.parent_item_group, "All Item Groups");
+});
+
+// ── erpnext_doc_submit ───────────────────────────────────────────────────────
+
+Deno.test("erpnext_doc_submit - skips cache on the pre-submit get and invalidates after", async () => {
+  let getSkipCache: boolean | undefined;
+  let invalidatedDoctype = "";
+  let invalidatedName = "";
+
+  const mockClient = makeMockClient({
+    get: async (
+      _doctype: string,
+      _name: string,
+      opts?: { skipCache?: boolean },
+    ) => {
+      getSkipCache = opts?.skipCache;
+      return { name: "SO-001", modified: "2026-01-01 00:00:00" };
+    },
+    callMethod: async () => ({ name: "SO-001", docstatus: 1 }),
+    invalidate: (doctype: string, name?: string) => {
+      invalidatedDoctype = doctype;
+      invalidatedName = name ?? "";
+    },
+  });
+
+  const tool = getTool("erpnext_doc_submit");
+  await tool.handler(
+    { doctype: "Sales Order", name: "SO-001" },
+    makeCtx(mockClient),
+  );
+
+  assertEquals(getSkipCache, true);
+  assertEquals(invalidatedDoctype, "Sales Order");
+  assertEquals(invalidatedName, "SO-001");
+});
+
+// ── erpnext_doc_cancel ───────────────────────────────────────────────────────
+
+Deno.test("erpnext_doc_cancel - invalidates cache after cancel", async () => {
+  let invalidatedDoctype = "";
+  let invalidatedName = "";
+
+  const mockClient = makeMockClient({
+    callMethod: async () => ({ name: "SO-001", docstatus: 2 }),
+    invalidate: (doctype: string, name?: string) => {
+      invalidatedDoctype = doctype;
+      invalidatedName = name ?? "";
+    },
+  });
+
+  const tool = getTool("erpnext_doc_cancel");
+  await tool.handler(
+    { doctype: "Sales Order", name: "SO-001" },
+    makeCtx(mockClient),
+  );
+
+  assertEquals(invalidatedDoctype, "Sales Order");
+  assertEquals(invalidatedName, "SO-001");
 });
 
 // ── erpnext_doc_list ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds a small pluggable `Cache` interface (`src/cache/types.ts`) with a zero-dependency `MemoryCache` implementation (hand-rolled TTL map) and a `NoopCache` to fully disable caching without branching inside `FrappeClient`.
- Wires caching into `FrappeClient.list()`/`.get()`, keyed by doctype + options/name. `create()`/`update()`/`delete()` invalidate automatically; anything mutating via `callMethod` (e.g. `frappe.client.submit`/`cancel`) must invalidate explicitly, since `FrappeClient` can't infer intent from an arbitrary method call — the two existing submit/cancel handlers in `operations.ts` were updated accordingly.
- Adds cache warming on startup (`src/cache/warm.ts`): optionally calls a configured set of read-only `_list` tool handlers with no filters, so the cache key matches exactly what a real first "list X" call will use. Configured via `MCP_CACHE_WARM_TOOLS` (comma-separated tool names, unset/empty = disabled by default). Refuses unknown/non-read-only tools and never lets one tool's failure abort the rest or the server.
- Fixes a correctness risk along the way: submit's pre-fetch `GET` (needed for Frappe's optimistic-lock `modified` timestamp) now passes `{ skipCache: true }` so it can't serve a stale timestamp from cache.

Config: `MCP_CACHE_ENABLED`, `MCP_CACHE_TTL_MS` (default 15s), `MCP_CACHE_WARM_TOOLS`.

## Test plan

- [x] `deno test --allow-all src/` — full suite passes (222 passed, 0 failed)
- [x] `deno check mod.ts server.ts`
- [x] `deno lint` / `deno fmt --check`
- [x] Manually verified against a real ERPNext instance: cold vs. warm `erpnext_employee_list` call timing (159ms → 0.1ms), `warmCache()` skipping unknown/non-read-only tools without throwing