### PR TITLE
feat: add date_from/date_to filters to list tools missing them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,10 @@ body — no silent fallbacks.
 **Submit handlers must GET the doc first** to pass `modified` for Frappe's
 optimistic locking (see `docs/known-issues.md`). Cancel does not need this.
 
+### Date-range filters
+
+List tools whose DocType has a natural date field accept `date_from`/`date_to` (`"Start date filter YYYY-MM-DD"` / `"End date filter YYYY-MM-DD"`), filtering `[field, ">=", date_from]` / `[field, "<=", date_to]`. Doctypes with distinct start/end fields (Timesheet, Project, Task, Leave Application, Campaign) filter the start field with `date_from` and the end field with `date_to` — not both bounds on one column. Master-data lists (Customer, Item, Warehouse, etc.) intentionally have no date filter.
+
 ### Kanban system
 
 The kanban viewer is the canonical read-write MCP App. Architecture:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,13 @@ optimistic locking (see `docs/known-issues.md`). Cancel does not need this.
 
 ### Date-range filters
 
-List tools whose DocType has a natural date field accept `date_from`/`date_to` (`"Start date filter YYYY-MM-DD"` / `"End date filter YYYY-MM-DD"`), filtering `[field, ">=", date_from]` / `[field, "<=", date_to]`. Doctypes with distinct start/end fields (Timesheet, Project, Task, Leave Application, Campaign) filter the start field with `date_from` and the end field with `date_to` — not both bounds on one column. Master-data lists (Customer, Item, Warehouse, etc.) intentionally have no date filter.
+List tools whose DocType has a natural date field accept `date_from`/`date_to`
+(`"Start date filter YYYY-MM-DD"` / `"End date filter YYYY-MM-DD"`), filtering
+`[field, ">=", date_from]` / `[field, "<=", date_to]`. Doctypes with distinct
+start/end fields (Timesheet, Project, Task, Leave Application, Campaign) filter
+the start field with `date_from` and the end field with `date_to` — not both
+bounds on one column. Master-data lists (Customer, Item, Warehouse, etc.)
+intentionally have no date filter.
 
 ### Kanban system
 

--- a/src/tools/assets.ts
+++ b/src/tools/assets.ts
@@ -41,6 +41,14 @@ export const assetsTools: ErpNextTool[] = [
           type: "string",
           description: "Filter by custodian (employee)",
         },
+        date_from: {
+          type: "string",
+          description: "Purchase date start filter YYYY-MM-DD",
+        },
+        date_to: {
+          type: "string",
+          description: "Purchase date end filter YYYY-MM-DD",
+        },
       },
     },
     handler: async (input, ctx) => {
@@ -57,6 +65,12 @@ export const assetsTools: ErpNextTool[] = [
       }
       if (input.custodian) {
         filters.push(["custodian", "=", input.custodian as string]);
+      }
+      if (input.date_from) {
+        filters.push(["purchase_date", ">=", input.date_from as string]);
+      }
+      if (input.date_to) {
+        filters.push(["purchase_date", "<=", input.date_to as string]);
       }
 
       const docs = await ctx.client.list("Asset", {

--- a/src/tools/crm.ts
+++ b/src/tools/crm.ts
@@ -325,6 +325,11 @@ export const crmTools: ErpNextTool[] = [
           type: "string",
           description: "Filter by campaign type",
         },
+        date_from: {
+          type: "string",
+          description: "Start date filter YYYY-MM-DD",
+        },
+        date_to: { type: "string", description: "End date filter YYYY-MM-DD" },
       },
     },
     handler: async (input, ctx) => {
@@ -332,6 +337,12 @@ export const crmTools: ErpNextTool[] = [
       const filters: FrappeFilter[] = [];
       if (input.campaign_type) {
         filters.push(["campaign_type", "=", input.campaign_type as string]);
+      }
+      if (input.date_from) {
+        filters.push(["start_date", ">=", input.date_from as string]);
+      }
+      if (input.date_to) {
+        filters.push(["end_date", "<=", input.date_to as string]);
       }
 
       const docs = await ctx.client.list("Campaign", {

--- a/src/tools/crm_test.ts
+++ b/src/tools/crm_test.ts
@@ -1,0 +1,62 @@
+/**
+ * CRM Tools Tests
+ *
+ * @module lib/erpnext/tests/tools/crm_test
+ */
+
+import { assertEquals } from "@std/assert";
+import { crmTools } from "./crm.ts";
+import type { FrappeClient } from "../api/frappe-client.ts";
+import type { ErpNextToolContext } from "./types.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyFn = (...args: any[]) => any;
+
+function makeMockClient(overrides: Record<string, AnyFn> = {}): FrappeClient {
+  const mock: Record<string, AnyFn> = {
+    list: async () => [],
+    get: async () => ({ name: "TEST-001" }),
+    create: async () => ({ name: "NEW-001" }),
+    update: async () => ({ name: "TEST-001" }),
+    delete: async () => {},
+    callMethod: async () => null,
+    invalidate: () => {},
+    ...overrides,
+  };
+  return mock as unknown as FrappeClient;
+}
+
+function makeCtx(client: FrappeClient): ErpNextToolContext {
+  return { client };
+}
+
+function getTool(name: string) {
+  const tool = crmTools.find((t) => t.name === name);
+  if (!tool) throw new Error(`Tool not found: ${name}`);
+  return tool;
+}
+
+Deno.test("erpnext_campaign_list - filters by date range", async () => {
+  let capturedFilters: unknown[][] = [];
+  const client = makeMockClient({
+    list: async (_doctype: string, opts: { filters?: unknown[][] }) => {
+      capturedFilters = opts?.filters ?? [];
+      return [];
+    },
+  });
+
+  const tool = getTool("erpnext_campaign_list");
+  await tool.handler(
+    { date_from: "2026-01-01", date_to: "2026-01-31" },
+    makeCtx(client),
+  );
+
+  const hasStart = capturedFilters.some((f) =>
+    f[0] === "start_date" && f[1] === ">=" && f[2] === "2026-01-01"
+  );
+  const hasEnd = capturedFilters.some((f) =>
+    f[0] === "end_date" && f[1] === "<=" && f[2] === "2026-01-31"
+  );
+  assertEquals(hasStart, true);
+  assertEquals(hasEnd, true);
+});

--- a/src/tools/hr.ts
+++ b/src/tools/hr.ts
@@ -184,6 +184,11 @@ export const hrTools: ErpNextTool[] = [
           type: "string",
           description: "Filter by leave type (e.g. Sick Leave)",
         },
+        date_from: {
+          type: "string",
+          description: "Start date filter YYYY-MM-DD",
+        },
+        date_to: { type: "string", description: "End date filter YYYY-MM-DD" },
       },
     },
     handler: async (input, ctx) => {
@@ -197,6 +202,12 @@ export const hrTools: ErpNextTool[] = [
       }
       if (input.leave_type) {
         filters.push(["leave_type", "=", input.leave_type as string]);
+      }
+      if (input.date_from) {
+        filters.push(["from_date", ">=", input.date_from as string]);
+      }
+      if (input.date_to) {
+        filters.push(["to_date", "<=", input.date_to as string]);
       }
 
       const docs = await ctx.client.list("Leave Application", {
@@ -427,6 +438,11 @@ export const hrTools: ErpNextTool[] = [
           description: "Filter by status (Draft, Submitted, Cancelled)",
           enum: ["Draft", "Submitted", "Cancelled"],
         },
+        date_from: {
+          type: "string",
+          description: "Start date filter YYYY-MM-DD",
+        },
+        date_to: { type: "string", description: "End date filter YYYY-MM-DD" },
       },
     },
     handler: async (input, ctx) => {
@@ -437,6 +453,12 @@ export const hrTools: ErpNextTool[] = [
       }
       if (input.status) {
         filters.push(["status", "=", input.status as string]);
+      }
+      if (input.date_from) {
+        filters.push(["posting_date", ">=", input.date_from as string]);
+      }
+      if (input.date_to) {
+        filters.push(["posting_date", "<=", input.date_to as string]);
       }
 
       const docs = await ctx.client.list("Payroll Entry", {
@@ -487,6 +509,11 @@ export const hrTools: ErpNextTool[] = [
             "Filter by approval status (Pending, Approved, Rejected)",
           enum: ["Pending", "Approved", "Rejected"],
         },
+        date_from: {
+          type: "string",
+          description: "Start date filter YYYY-MM-DD",
+        },
+        date_to: { type: "string", description: "End date filter YYYY-MM-DD" },
       },
     },
     handler: async (input, ctx) => {
@@ -500,6 +527,12 @@ export const hrTools: ErpNextTool[] = [
       }
       if (input.approval_status) {
         filters.push(["approval_status", "=", input.approval_status as string]);
+      }
+      if (input.date_from) {
+        filters.push(["posting_date", ">=", input.date_from as string]);
+      }
+      if (input.date_to) {
+        filters.push(["posting_date", "<=", input.date_to as string]);
       }
 
       const docs = await ctx.client.list("Expense Claim", {

--- a/src/tools/project.ts
+++ b/src/tools/project.ts
@@ -38,6 +38,11 @@ export const projectTools: ErpNextTool[] = [
           enum: ["Open", "Completed", "Cancelled"],
         },
         company: { type: "string", description: "Filter by company" },
+        date_from: {
+          type: "string",
+          description: "Start date filter YYYY-MM-DD",
+        },
+        date_to: { type: "string", description: "End date filter YYYY-MM-DD" },
       },
     },
     handler: async (input, ctx) => {
@@ -48,6 +53,12 @@ export const projectTools: ErpNextTool[] = [
       }
       if (input.company) {
         filters.push(["company", "=", input.company as string]);
+      }
+      if (input.date_from) {
+        filters.push(["expected_start_date", ">=", input.date_from as string]);
+      }
+      if (input.date_to) {
+        filters.push(["expected_end_date", "<=", input.date_to as string]);
       }
 
       const docs = await ctx.client.list("Project", {
@@ -120,6 +131,11 @@ export const projectTools: ErpNextTool[] = [
           description: "Filter by priority (Low, Medium, High, Urgent)",
           enum: ["Low", "Medium", "High", "Urgent"],
         },
+        date_from: {
+          type: "string",
+          description: "Start date filter YYYY-MM-DD",
+        },
+        date_to: { type: "string", description: "End date filter YYYY-MM-DD" },
       },
     },
     handler: async (input, ctx) => {
@@ -133,6 +149,12 @@ export const projectTools: ErpNextTool[] = [
       }
       if (input.priority) {
         filters.push(["priority", "=", input.priority as string]);
+      }
+      if (input.date_from) {
+        filters.push(["exp_start_date", ">=", input.date_from as string]);
+      }
+      if (input.date_to) {
+        filters.push(["exp_end_date", "<=", input.date_to as string]);
       }
 
       const docs = await ctx.client.list("Task", {
@@ -408,6 +430,11 @@ export const projectTools: ErpNextTool[] = [
           type: "string",
           description: "Filter by status (Draft, Submitted, Cancelled)",
         },
+        date_from: {
+          type: "string",
+          description: "Start date filter YYYY-MM-DD",
+        },
+        date_to: { type: "string", description: "End date filter YYYY-MM-DD" },
       },
     },
     handler: async (input, ctx) => {
@@ -421,6 +448,12 @@ export const projectTools: ErpNextTool[] = [
       }
       if (input.status) {
         filters.push(["status", "=", input.status as string]);
+      }
+      if (input.date_from) {
+        filters.push(["start_date", ">=", input.date_from as string]);
+      }
+      if (input.date_to) {
+        filters.push(["end_date", "<=", input.date_to as string]);
       }
 
       const docs = await ctx.client.list("Timesheet", {

--- a/src/tools/purchasing.ts
+++ b/src/tools/purchasing.ts
@@ -534,6 +534,11 @@ export const purchasingTools: ErpNextTool[] = [
           description:
             "Filter by status (Draft, Submitted, Ordered, Lost, Cancelled)",
         },
+        date_from: {
+          type: "string",
+          description: "Start date filter YYYY-MM-DD",
+        },
+        date_to: { type: "string", description: "End date filter YYYY-MM-DD" },
       },
     },
     handler: async (input, ctx) => {
@@ -544,6 +549,12 @@ export const purchasingTools: ErpNextTool[] = [
       }
       if (input.status) {
         filters.push(["status", "=", input.status as string]);
+      }
+      if (input.date_from) {
+        filters.push(["transaction_date", ">=", input.date_from as string]);
+      }
+      if (input.date_to) {
+        filters.push(["transaction_date", "<=", input.date_to as string]);
       }
 
       const docs = await ctx.client.list("Supplier Quotation", {

--- a/src/tools/purchasing_test.ts
+++ b/src/tools/purchasing_test.ts
@@ -142,3 +142,32 @@ Deno.test("erpnext_purchase_order_create - throws if supplier missing", async ()
     "supplier",
   );
 });
+
+// ── erpnext_supplier_quotation_list ─────────────────────────────────────────
+
+Deno.test("erpnext_supplier_quotation_list - filters by date range", async () => {
+  let capturedFilters: unknown[][] = [];
+  const client = makeMockClient({
+    list: async (_doctype: string, opts: { filters?: unknown[][] }) => {
+      capturedFilters = opts?.filters ?? [];
+      return [];
+    },
+  });
+
+  const tool = getTool("erpnext_supplier_quotation_list");
+  await tool.handler(
+    { date_from: "2026-01-01", date_to: "2026-01-31" },
+    makeCtx(client),
+  );
+
+  const hasStart = capturedFilters.some(
+    (f) =>
+      f[0] === "transaction_date" && f[1] === ">=" && f[2] === "2026-01-01",
+  );
+  const hasEnd = capturedFilters.some(
+    (f) =>
+      f[0] === "transaction_date" && f[1] === "<=" && f[2] === "2026-01-31",
+  );
+  assertEquals(hasStart, true);
+  assertEquals(hasEnd, true);
+});

--- a/src/tools/sales.ts
+++ b/src/tools/sales.ts
@@ -806,6 +806,11 @@ export const salesTools: ErpNextTool[] = [
           description:
             "Filter by status (Draft, Open, Replied, Ordered, Lost, Cancelled)",
         },
+        date_from: {
+          type: "string",
+          description: "Start date filter YYYY-MM-DD",
+        },
+        date_to: { type: "string", description: "End date filter YYYY-MM-DD" },
       },
     },
     handler: async (input, ctx) => {
@@ -816,6 +821,12 @@ export const salesTools: ErpNextTool[] = [
       }
       if (input.status) {
         filters.push(["status", "=", input.status as string]);
+      }
+      if (input.date_from) {
+        filters.push(["transaction_date", ">=", input.date_from as string]);
+      }
+      if (input.date_to) {
+        filters.push(["transaction_date", "<=", input.date_to as string]);
       }
 
       const docs = await ctx.client.list("Quotation", {


### PR DESCRIPTION
## Summary

10 `_list` tools have a natural date field on their DocType but no way to filter by it — e.g. `erpnext_timesheet_list` has no date filter at all, so "today's timesheet" required fetching everything and filtering client-side.

Applied the same `date_from`/`date_to` convention already used elsewhere in the codebase (`"Start date filter YYYY-MM-DD"` / `"End date filter YYYY-MM-DD"`, `[field, ">=", date_from]` / `[field, "<=", date_to]`) to:

- `erpnext_timesheet_list`, `erpnext_project_list`, `erpnext_task_list`
- `erpnext_leave_application_list`, `erpnext_payroll_entry_list`, `erpnext_expense_claim_list`
- `erpnext_asset_list`
- `erpnext_campaign_list`
- `erpnext_quotation_list`, `erpnext_supplier_quotation_list`

Doctypes with distinct start/end fields (Timesheet, Project, Task, Leave Application, Campaign) filter the start field with `date_from` and the end field with `date_to`, matching the house convention already used by `salary_slip_list`/`work_order_list`, rather than bounding a single column.

## Test plan

- [x] `deno test --allow-all src/` — full suite passes (204 passed, 0 failed)
- [x] `deno check mod.ts server.ts`
- [x] `deno lint` / `deno fmt --check`
- [x] New tests: `erpnext_campaign_list` and `erpnext_supplier_quotation_list` date-range filter assertions