### PR TITLE
fix(http): default HTTP bind to loopback (127.0.0.1)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -72,7 +72,11 @@ async function main() {
     ? parseInt(portArg.split("=")[1], 10)
     : DEFAULT_HTTP_PORT;
   const hostnameArg = args.find((arg) => arg.startsWith("--hostname="));
-  const hostname = hostnameArg ? hostnameArg.split("=")[1] : "0.0.0.0";
+  // Safe default: bind to loopback only. Exposing HTTP mode to the network must
+  // be an explicit choice (`--hostname=0.0.0.0`), since every tool acts with the
+  // server's ERPNext API key. NOTE: in Docker the published port needs
+  // `--hostname=0.0.0.0` for the container to be reachable.
+  const hostname = hostnameArg ? hostnameArg.split("=")[1] : "127.0.0.1";
 
   // Initialize tools client
   const toolsClient = new ErpNextToolsClient(
@@ -144,6 +148,16 @@ async function main() {
 
   // Start server
   if (httpFlag) {
+    const isLoopback = hostname === "127.0.0.1" || hostname === "::1" ||
+      hostname === "localhost";
+    if (!isLoopback) {
+      console.error(
+        `[mcp-erpnext] WARNING: binding to ${hostname} exposes the HTTP server ` +
+          `to the network. Every tool acts with the server's ERPNext API key, ` +
+          `so restrict access (firewall, private network, or an authenticating ` +
+          `reverse proxy).`,
+      );
+    }
     await server.startHttp({
       port: httpPort,
       hostname,


### PR DESCRIPTION
## Summary

HTTP mode (`--http`) bound to **`0.0.0.0` by default**, so the server — and every tool, which acts with the server's ERPNext API key — was reachable from the whole network with no gate in front. Reaching the port meant driving the ERP to the extent of that key's rights, without presenting any credential.

This changes the default bind to **`127.0.0.1`** (loopback), making network exposure an explicit choice, and warns on startup when binding to a non-loopback interface. This matches documented MCP security guidance (binding MCP servers to `0.0.0.0` is a known exposure / DNS-rebinding vector).

- `server.ts`: default `hostname` → `127.0.0.1`; startup warning when the bind address is non-loopback.
- **Docker note:** containers must pass `--hostname=0.0.0.0` in the `CMD` — the published port is unreachable otherwise, since loopback lives inside the container's network namespace. Folded into the Docker work tracked in #8.

This is the immediate, auth-independent mitigation split out of the discussion on #8. The broader HTTP-auth story (static token / OAuth) stays in #8, to be wired through `@casys/mcp-server`'s native auth.

Credit to @notnotkeshav for surfacing the exposure gap in #8. 🙏

## Test plan

- [x] `deno fmt server.ts` / `deno lint server.ts`
- [x] `deno check server.ts`
- [ ] Manual: `--http` (no flag) binds loopback only; `--http --hostname=0.0.0.0` binds all interfaces + prints the exposure warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)