### PR TITLE
release: v2.4.2 — HTTP bind loopback default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to `@casys/mcp-erpnext` will be documented in this file.
 
+## [2.4.2](https://github.com/Casys-AI/mcp-erpnext/compare/v2.4.1...v2.4.2) (2026-07-21)
+
+### Bug Fixes
+
+- **http:** HTTP mode (`--http`) now binds to `127.0.0.1` by default instead of
+  `0.0.0.0`. The server — and every tool, which acts with the server's ERPNext
+  API key — is no longer reachable from the whole network unless exposure is
+  explicitly opted into via `--hostname=0.0.0.0`, matching MCP security best
+  practice. A startup warning is printed when binding to a non-loopback
+  interface. Docker deployments must pass `--hostname=0.0.0.0` in the container
+  command. Thanks @notnotkeshav for surfacing the exposure gap (#8, #10).
+
 ## [2.4.1](https://github.com/Casys-AI/mcp-erpnext/compare/v2.4.0...v2.4.1) (2026-07-16)
 
 ### Features

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@casys/mcp-erpnext",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "nodeModulesDir": "auto",
   "tasks": {
     "serve": "deno run --allow-all server.ts --http --port=3012",

--- a/server.ts
+++ b/server.ts
@@ -86,7 +86,7 @@ async function main() {
   // Build MCP server
   const server = new McpApp({
     name: "mcp-erpnext",
-    version: "2.4.1",
+    version: "2.4.2",
     maxConcurrent: 10,
     backpressureStrategy: "queue",
     validateSchema: true,


### PR DESCRIPTION
Bumps to **2.4.2** and ships the security-hardening fix from #10 (HTTP mode binds to `127.0.0.1` by default; exposure is opt-in via `--hostname=0.0.0.0`, required in Docker's CMD).

- `deno.json` + `server.ts`: 2.4.1 → 2.4.2
- `CHANGELOG.md`: 2.4.2 entry

After merge, publish via the **Publish** workflow (`workflow_dispatch`) — JSR + npm use the repo's OIDC / `NPM_TOKEN` secret; no manual token needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)