### PR TITLE
fix(submit): auto-disable rounded total when null on fresh instances

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -84,9 +84,9 @@ submitting a Sales Order/Invoice failed with `TypeError: abs(None)` in
 `validate_grand_total()`, because `base_rounded_total`/`rounded_total` stay
 `None` when the rounding configuration is not initialized.
 
-**Applied fix**: `withRoundedTotalFallback()` sets `disable_rounded_total: 1`
-on the pre-submit doc whenever `base_rounded_total` or `rounded_total` is
-`null` and it isn't already set:
+**Applied fix**: `withRoundedTotalFallback()` sets `disable_rounded_total: 1` on
+the pre-submit doc whenever `base_rounded_total` or `rounded_total` is `null`
+and it isn't already set:
 
 - `src/tools/submit-helpers.ts` — `withRoundedTotalFallback()`
 - `src/tools/operations.ts` — `erpnext_doc_submit`

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -77,26 +77,25 @@ called `app.callServerTool` without checking
 **Applied fix**: `handleSaveDetail` now fails explicitly with the same guard as
 card moves when the host does not support proxied server calls.
 
+### Fresh instance: `base_rounded_total = None` → TypeError
+
+**Historical symptom**: On a fresh ERPNext instance (without setup wizard),
+submitting a Sales Order/Invoice failed with `TypeError: abs(None)` in
+`validate_grand_total()`, because `base_rounded_total`/`rounded_total` stay
+`None` when the rounding configuration is not initialized.
+
+**Applied fix**: `withRoundedTotalFallback()` sets `disable_rounded_total: 1`
+on the pre-submit doc whenever `base_rounded_total` or `rounded_total` is
+`null` and it isn't already set:
+
+- `src/tools/submit-helpers.ts` — `withRoundedTotalFallback()`
+- `src/tools/operations.ts` — `erpnext_doc_submit`
+- `src/tools/sales.ts` — `erpnext_sales_order_submit`,
+  `erpnext_sales_invoice_submit`
+
 ---
 
 ## Open bugs
-
-### P0 — Fresh instance: `base_rounded_total = None` → TypeError
-
-**Symptom**: On a fresh ERPNext instance (without setup wizard), submitting a
-Sales Order/Invoice fails with `TypeError: abs(None)` in
-`validate_grand_total()`.
-
-**Cause**: ERPNext calculates `base_rounded_total` automatically but the field
-remains `None` if the rounding configuration is not initialized.
-
-**Current workaround**: Pass `disable_rounded_total: 1` in the document before
-submit.
-
-**Desired fix**: Either do it automatically in the submit handlers when the
-field is `None`, or document that the ERPNext setup wizard is required.
-
----
 
 ### ~~RuntimeError: `Deno is not defined` on Node.js~~ — fixed in 2.4.0
 

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -11,7 +11,10 @@
 import type { FrappeFilter } from "../api/types.ts";
 import type { ErpNextTool } from "./types.ts";
 import { DOCLIST_META } from "./viewer-meta.ts";
-import { withRoundedTotalFallback } from "./submit-helpers.ts";
+import {
+  roundedTotalFallbackWarning,
+  withRoundedTotalFallback,
+} from "./submit-helpers.ts";
 import {
   applyAssignment,
   ASSIGNMENT_INPUT_PROPERTIES,
@@ -208,19 +211,21 @@ export const operationsTools: ErpNextTool[] = [
         input.name as string,
         { skipCache: true },
       );
+      const docWithDoctype = { ...doc, doctype: input.doctype as string };
+      const patchedDoc = withRoundedTotalFallback(docWithDoctype);
       const result = await ctx.client.callMethod("frappe.client.submit", {
-        doc: withRoundedTotalFallback({
-          ...doc,
-          doctype: input.doctype as string,
-        }),
+        doc: patchedDoc,
       });
       ctx.client.invalidate(input.doctype as string, input.name as string);
+
+      const warnings = roundedTotalFallbackWarning(docWithDoctype, patchedDoc);
 
       return {
         data: result,
         message: `${input.doctype} ${input.name} submitted successfully`,
         doctype: input.doctype,
         name: input.name,
+        ...(warnings.length > 0 ? { warnings } : {}),
       };
     },
   },

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -11,6 +11,7 @@
 import type { FrappeFilter } from "../api/types.ts";
 import type { ErpNextTool } from "./types.ts";
 import { DOCLIST_META } from "./viewer-meta.ts";
+import { withRoundedTotalFallback } from "./submit-helpers.ts";
 import {
   applyAssignment,
   ASSIGNMENT_INPUT_PROPERTIES,
@@ -208,7 +209,10 @@ export const operationsTools: ErpNextTool[] = [
         { skipCache: true },
       );
       const result = await ctx.client.callMethod("frappe.client.submit", {
-        doc: { ...doc, doctype: input.doctype as string },
+        doc: withRoundedTotalFallback({
+          ...doc,
+          doctype: input.doctype as string,
+        }),
       });
       ctx.client.invalidate(input.doctype as string, input.name as string);
 

--- a/src/tools/operations_test.ts
+++ b/src/tools/operations_test.ts
@@ -167,6 +167,33 @@ Deno.test("erpnext_doc_submit - skips cache on the pre-submit get and invalidate
   assertEquals(invalidatedName, "SO-001");
 });
 
+Deno.test("erpnext_doc_submit - disables rounded total when base_rounded_total is null (fresh instance)", async () => {
+  let submittedDoc: Record<string, unknown> = {};
+
+  const mockClient = makeMockClient({
+    get: async () => ({
+      name: "SO-001",
+      base_rounded_total: null,
+      modified: "2026-01-01 00:00:00",
+    }),
+    callMethod: async (
+      _method: string,
+      args: { doc: Record<string, unknown> },
+    ) => {
+      submittedDoc = args.doc;
+      return { name: "SO-001", docstatus: 1 };
+    },
+  });
+
+  const tool = getTool("erpnext_doc_submit");
+  await tool.handler(
+    { doctype: "Sales Order", name: "SO-001" },
+    makeCtx(mockClient),
+  );
+
+  assertEquals(submittedDoc.disable_rounded_total, 1);
+});
+
 // ── erpnext_doc_cancel ───────────────────────────────────────────────────────
 
 Deno.test("erpnext_doc_cancel - invalidates cache after cancel", async () => {

--- a/src/tools/operations_test.ts
+++ b/src/tools/operations_test.ts
@@ -186,12 +186,13 @@ Deno.test("erpnext_doc_submit - disables rounded total when base_rounded_total i
   });
 
   const tool = getTool("erpnext_doc_submit");
-  await tool.handler(
+  const result = await tool.handler(
     { doctype: "Sales Order", name: "SO-001" },
     makeCtx(mockClient),
-  );
+  ) as Record<string, unknown>;
 
   assertEquals(submittedDoc.disable_rounded_total, 1);
+  assertEquals((result.warnings as string[]).length, 1);
 });
 
 // ── erpnext_doc_cancel ───────────────────────────────────────────────────────

--- a/src/tools/sales.ts
+++ b/src/tools/sales.ts
@@ -10,6 +10,7 @@ import type { FrappeFilter } from "../api/types.ts";
 import type { ErpNextTool } from "./types.ts";
 import { DOCLIST_META, INVOICE_META } from "./viewer-meta.ts";
 import { resolveCustomer, resolveDynamicLink } from "../api/resolve.ts";
+import { withRoundedTotalFallback } from "./submit-helpers.ts";
 
 interface LineItemInput {
   item_code: string;
@@ -524,7 +525,7 @@ export const salesTools: ErpNextTool[] = [
       // Fetch fresh doc — frappe.client.submit requires `modified` for optimistic locking
       const doc = await ctx.client.get("Sales Order", input.name as string);
       const result = await ctx.client.callMethod("frappe.client.submit", {
-        doc: { ...doc, doctype: "Sales Order" },
+        doc: withRoundedTotalFallback({ ...doc, doctype: "Sales Order" }),
       });
 
       return {
@@ -793,7 +794,7 @@ export const salesTools: ErpNextTool[] = [
       // Fetch fresh doc — frappe.client.submit requires `modified` for optimistic locking
       const doc = await ctx.client.get("Sales Invoice", input.name as string);
       const result = await ctx.client.callMethod("frappe.client.submit", {
-        doc: { ...doc, doctype: "Sales Invoice" },
+        doc: withRoundedTotalFallback({ ...doc, doctype: "Sales Invoice" }),
       });
 
       return {

--- a/src/tools/sales.ts
+++ b/src/tools/sales.ts
@@ -526,12 +526,15 @@ export const salesTools: ErpNextTool[] = [
       }
 
       // Fetch fresh doc — frappe.client.submit requires `modified` for optimistic locking
-      const doc = await ctx.client.get("Sales Order", input.name as string);
+      const doc = await ctx.client.get("Sales Order", input.name as string, {
+        skipCache: true,
+      });
       const docWithDoctype = { ...doc, doctype: "Sales Order" };
       const patchedDoc = withRoundedTotalFallback(docWithDoctype);
       const result = await ctx.client.callMethod("frappe.client.submit", {
         doc: patchedDoc,
       });
+      ctx.client.invalidate("Sales Order", input.name as string);
 
       const warnings = roundedTotalFallbackWarning(docWithDoctype, patchedDoc);
 
@@ -569,6 +572,7 @@ export const salesTools: ErpNextTool[] = [
         doctype: "Sales Order",
         name: input.name as string,
       });
+      ctx.client.invalidate("Sales Order", input.name as string);
 
       return {
         data: result,
@@ -800,12 +804,15 @@ export const salesTools: ErpNextTool[] = [
       }
 
       // Fetch fresh doc — frappe.client.submit requires `modified` for optimistic locking
-      const doc = await ctx.client.get("Sales Invoice", input.name as string);
+      const doc = await ctx.client.get("Sales Invoice", input.name as string, {
+        skipCache: true,
+      });
       const docWithDoctype = { ...doc, doctype: "Sales Invoice" };
       const patchedDoc = withRoundedTotalFallback(docWithDoctype);
       const result = await ctx.client.callMethod("frappe.client.submit", {
         doc: patchedDoc,
       });
+      ctx.client.invalidate("Sales Invoice", input.name as string);
 
       const warnings = roundedTotalFallbackWarning(docWithDoctype, patchedDoc);
 

--- a/src/tools/sales.ts
+++ b/src/tools/sales.ts
@@ -10,7 +10,10 @@ import type { FrappeFilter } from "../api/types.ts";
 import type { ErpNextTool } from "./types.ts";
 import { DOCLIST_META, INVOICE_META } from "./viewer-meta.ts";
 import { resolveCustomer, resolveDynamicLink } from "../api/resolve.ts";
-import { withRoundedTotalFallback } from "./submit-helpers.ts";
+import {
+  roundedTotalFallbackWarning,
+  withRoundedTotalFallback,
+} from "./submit-helpers.ts";
 
 interface LineItemInput {
   item_code: string;
@@ -524,13 +527,18 @@ export const salesTools: ErpNextTool[] = [
 
       // Fetch fresh doc — frappe.client.submit requires `modified` for optimistic locking
       const doc = await ctx.client.get("Sales Order", input.name as string);
+      const docWithDoctype = { ...doc, doctype: "Sales Order" };
+      const patchedDoc = withRoundedTotalFallback(docWithDoctype);
       const result = await ctx.client.callMethod("frappe.client.submit", {
-        doc: withRoundedTotalFallback({ ...doc, doctype: "Sales Order" }),
+        doc: patchedDoc,
       });
+
+      const warnings = roundedTotalFallbackWarning(docWithDoctype, patchedDoc);
 
       return {
         data: result,
         message: `Sales Order ${input.name} submitted successfully`,
+        ...(warnings.length > 0 ? { warnings } : {}),
       };
     },
   },
@@ -793,14 +801,19 @@ export const salesTools: ErpNextTool[] = [
 
       // Fetch fresh doc — frappe.client.submit requires `modified` for optimistic locking
       const doc = await ctx.client.get("Sales Invoice", input.name as string);
+      const docWithDoctype = { ...doc, doctype: "Sales Invoice" };
+      const patchedDoc = withRoundedTotalFallback(docWithDoctype);
       const result = await ctx.client.callMethod("frappe.client.submit", {
-        doc: withRoundedTotalFallback({ ...doc, doctype: "Sales Invoice" }),
+        doc: patchedDoc,
       });
+
+      const warnings = roundedTotalFallbackWarning(docWithDoctype, patchedDoc);
 
       return {
         data: result,
         message: `Sales Invoice ${input.name} submitted successfully`,
         _meta: INVOICE_META,
+        ...(warnings.length > 0 ? { warnings } : {}),
       };
     },
   },

--- a/src/tools/sales_test.ts
+++ b/src/tools/sales_test.ts
@@ -28,6 +28,7 @@ function makeMockClient(overrides: Record<string, AnyFn> = {}): FrappeClient {
     update: async () => ({ name: "TEST-001" }),
     delete: async () => {},
     callMethod: async () => null,
+    invalidate: () => {},
     ...overrides,
   };
   return mock as unknown as FrappeClient;
@@ -284,18 +285,30 @@ Deno.test("erpnext_quotation_create - resolves party_name before building the cr
 
 Deno.test("erpnext_sales_order_submit - disables rounded total when base_rounded_total is null (fresh instance)", async () => {
   let submittedDoc: Record<string, unknown> = {};
+  let skipCache: boolean | undefined;
+  let invalidated: [string, string | undefined] | undefined;
   const mockClient = makeMockClient({
-    get: async () => ({
-      name: "SO-001",
-      base_rounded_total: null,
-      modified: "2026-01-01 00:00:00",
-    }),
+    get: async (
+      _doctype: string,
+      _name: string,
+      opts?: { skipCache?: boolean },
+    ) => {
+      skipCache = opts?.skipCache;
+      return {
+        name: "SO-001",
+        base_rounded_total: null,
+        modified: "2026-01-01 00:00:00",
+      };
+    },
     callMethod: async (
       _method: string,
       args: { doc: Record<string, unknown> },
     ) => {
       submittedDoc = args.doc;
       return { name: "SO-001", docstatus: 1 };
+    },
+    invalidate: (doctype: string, name?: string) => {
+      invalidated = [doctype, name];
     },
   });
 
@@ -307,22 +320,36 @@ Deno.test("erpnext_sales_order_submit - disables rounded total when base_rounded
 
   assertEquals(submittedDoc.disable_rounded_total, 1);
   assertEquals((result.warnings as string[]).length, 1);
+  assertEquals(skipCache, true);
+  assertEquals(invalidated, ["Sales Order", "SO-001"]);
 });
 
 Deno.test("erpnext_sales_invoice_submit - disables rounded total when base_rounded_total is null (fresh instance)", async () => {
   let submittedDoc: Record<string, unknown> = {};
+  let skipCache: boolean | undefined;
+  let invalidated: [string, string | undefined] | undefined;
   const mockClient = makeMockClient({
-    get: async () => ({
-      name: "SINV-001",
-      base_rounded_total: null,
-      modified: "2026-01-01 00:00:00",
-    }),
+    get: async (
+      _doctype: string,
+      _name: string,
+      opts?: { skipCache?: boolean },
+    ) => {
+      skipCache = opts?.skipCache;
+      return {
+        name: "SINV-001",
+        base_rounded_total: null,
+        modified: "2026-01-01 00:00:00",
+      };
+    },
     callMethod: async (
       _method: string,
       args: { doc: Record<string, unknown> },
     ) => {
       submittedDoc = args.doc;
       return { name: "SINV-001", docstatus: 1 };
+    },
+    invalidate: (doctype: string, name?: string) => {
+      invalidated = [doctype, name];
     },
   });
 
@@ -334,4 +361,23 @@ Deno.test("erpnext_sales_invoice_submit - disables rounded total when base_round
 
   assertEquals(submittedDoc.disable_rounded_total, 1);
   assertEquals((result.warnings as string[]).length, 1);
+  assertEquals(skipCache, true);
+  assertEquals(invalidated, ["Sales Invoice", "SINV-001"]);
+});
+
+Deno.test("erpnext_sales_order_cancel - invalidates the cancelled document", async () => {
+  let invalidated: [string, string | undefined] | undefined;
+  const tool = getTool("erpnext_sales_order_cancel");
+
+  await tool.handler(
+    { name: "SO-001" },
+    makeCtx(makeMockClient({
+      callMethod: async () => ({ name: "SO-001", docstatus: 2 }),
+      invalidate: (doctype: string, name?: string) => {
+        invalidated = [doctype, name];
+      },
+    })),
+  );
+
+  assertEquals(invalidated, ["Sales Order", "SO-001"]);
 });

--- a/src/tools/sales_test.ts
+++ b/src/tools/sales_test.ts
@@ -279,3 +279,51 @@ Deno.test("erpnext_quotation_create - resolves party_name before building the cr
 
   assertEquals(createdData.party_name, "CUST-042");
 });
+
+// ── erpnext_sales_order_submit / erpnext_sales_invoice_submit ────────────────
+
+Deno.test("erpnext_sales_order_submit - disables rounded total when base_rounded_total is null (fresh instance)", async () => {
+  let submittedDoc: Record<string, unknown> = {};
+  const mockClient = makeMockClient({
+    get: async () => ({
+      name: "SO-001",
+      base_rounded_total: null,
+      modified: "2026-01-01 00:00:00",
+    }),
+    callMethod: async (
+      _method: string,
+      args: { doc: Record<string, unknown> },
+    ) => {
+      submittedDoc = args.doc;
+      return { name: "SO-001", docstatus: 1 };
+    },
+  });
+
+  const tool = getTool("erpnext_sales_order_submit");
+  await tool.handler({ name: "SO-001" }, makeCtx(mockClient));
+
+  assertEquals(submittedDoc.disable_rounded_total, 1);
+});
+
+Deno.test("erpnext_sales_invoice_submit - disables rounded total when base_rounded_total is null (fresh instance)", async () => {
+  let submittedDoc: Record<string, unknown> = {};
+  const mockClient = makeMockClient({
+    get: async () => ({
+      name: "SINV-001",
+      base_rounded_total: null,
+      modified: "2026-01-01 00:00:00",
+    }),
+    callMethod: async (
+      _method: string,
+      args: { doc: Record<string, unknown> },
+    ) => {
+      submittedDoc = args.doc;
+      return { name: "SINV-001", docstatus: 1 };
+    },
+  });
+
+  const tool = getTool("erpnext_sales_invoice_submit");
+  await tool.handler({ name: "SINV-001" }, makeCtx(mockClient));
+
+  assertEquals(submittedDoc.disable_rounded_total, 1);
+});

--- a/src/tools/sales_test.ts
+++ b/src/tools/sales_test.ts
@@ -300,9 +300,13 @@ Deno.test("erpnext_sales_order_submit - disables rounded total when base_rounded
   });
 
   const tool = getTool("erpnext_sales_order_submit");
-  await tool.handler({ name: "SO-001" }, makeCtx(mockClient));
+  const result = await tool.handler(
+    { name: "SO-001" },
+    makeCtx(mockClient),
+  ) as Record<string, unknown>;
 
   assertEquals(submittedDoc.disable_rounded_total, 1);
+  assertEquals((result.warnings as string[]).length, 1);
 });
 
 Deno.test("erpnext_sales_invoice_submit - disables rounded total when base_rounded_total is null (fresh instance)", async () => {
@@ -323,7 +327,11 @@ Deno.test("erpnext_sales_invoice_submit - disables rounded total when base_round
   });
 
   const tool = getTool("erpnext_sales_invoice_submit");
-  await tool.handler({ name: "SINV-001" }, makeCtx(mockClient));
+  const result = await tool.handler(
+    { name: "SINV-001" },
+    makeCtx(mockClient),
+  ) as Record<string, unknown>;
 
   assertEquals(submittedDoc.disable_rounded_total, 1);
+  assertEquals((result.warnings as string[]).length, 1);
 });

--- a/src/tools/submit-helpers.ts
+++ b/src/tools/submit-helpers.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared helpers for submit-handler tools (erpnext_doc_submit,
+ * erpnext_sales_order_submit, erpnext_sales_invoice_submit).
+ *
+ * @module lib/erpnext/tools/submit-helpers
+ */
+
+/**
+ * On a fresh ERPNext instance (rounding configuration not initialized),
+ * `base_rounded_total`/`rounded_total` stay `None` and `validate_grand_total()`
+ * crashes with `TypeError: abs(None)` on submit. Set `disable_rounded_total`
+ * to skip that computation when the fields are present but unset.
+ *
+ * See docs/known-issues.md — P0 "Fresh instance: base_rounded_total = None".
+ */
+export function withRoundedTotalFallback(
+  doc: Record<string, unknown>,
+): Record<string, unknown> {
+  const hasNullRoundedTotal =
+    ("base_rounded_total" in doc && doc.base_rounded_total == null) ||
+    ("rounded_total" in doc && doc.rounded_total == null);
+
+  if (!hasNullRoundedTotal || doc.disable_rounded_total) {
+    return doc;
+  }
+
+  return { ...doc, disable_rounded_total: 1 };
+}

--- a/src/tools/submit-helpers.ts
+++ b/src/tools/submit-helpers.ts
@@ -11,6 +11,10 @@
  * crashes with `TypeError: abs(None)` on submit. Set `disable_rounded_total`
  * to skip that computation when the fields are present but unset.
  *
+ * The two fields move together on a fetched doc (both null on a fresh
+ * instance, both set otherwise), so `||` rather than `&&` is intentional —
+ * either one being null is enough to trigger the fallback.
+ *
  * See docs/known-issues.md — P0 "Fresh instance: base_rounded_total = None".
  */
 export function withRoundedTotalFallback(
@@ -25,4 +29,25 @@ export function withRoundedTotalFallback(
   }
 
   return { ...doc, disable_rounded_total: 1 };
+}
+
+/**
+ * Returns a warning to surface to the caller when `withRoundedTotalFallback`
+ * silently patched the doc — so an agent consumer can tell rounding was
+ * suppressed on its behalf rather than the totals genuinely being zero.
+ */
+export function roundedTotalFallbackWarning(
+  original: Record<string, unknown>,
+  patched: Record<string, unknown>,
+): string[] {
+  if (
+    patched.disable_rounded_total === 1 &&
+    original.disable_rounded_total !== 1
+  ) {
+    return [
+      "disable_rounded_total auto-set — rounded totals were null " +
+      "(rounding not configured on this instance)",
+    ];
+  }
+  return [];
 }

--- a/src/tools/submit-helpers_test.ts
+++ b/src/tools/submit-helpers_test.ts
@@ -5,7 +5,10 @@
  */
 
 import { assertEquals } from "@std/assert";
-import { withRoundedTotalFallback } from "./submit-helpers.ts";
+import {
+  roundedTotalFallbackWarning,
+  withRoundedTotalFallback,
+} from "./submit-helpers.ts";
 
 Deno.test("withRoundedTotalFallback - sets disable_rounded_total when base_rounded_total is null", () => {
   const doc = { name: "SO-001", base_rounded_total: null };
@@ -43,4 +46,33 @@ Deno.test("withRoundedTotalFallback - does not touch a doc that already has disa
   };
   const result = withRoundedTotalFallback(doc);
   assertEquals(result, doc);
+});
+
+Deno.test("roundedTotalFallbackWarning - warns when the fallback patched the doc", () => {
+  const original = { name: "SO-001", base_rounded_total: null };
+  const patched = withRoundedTotalFallback(original);
+  const warnings = roundedTotalFallbackWarning(original, patched);
+  assertEquals(warnings.length, 1);
+});
+
+Deno.test("roundedTotalFallbackWarning - no warning when totals were already set", () => {
+  const original = {
+    name: "SO-001",
+    base_rounded_total: 100,
+    rounded_total: 100,
+  };
+  const patched = withRoundedTotalFallback(original);
+  const warnings = roundedTotalFallbackWarning(original, patched);
+  assertEquals(warnings, []);
+});
+
+Deno.test("roundedTotalFallbackWarning - no warning when disable_rounded_total was already 1", () => {
+  const original = {
+    name: "SO-001",
+    base_rounded_total: null,
+    disable_rounded_total: 1,
+  };
+  const patched = withRoundedTotalFallback(original);
+  const warnings = roundedTotalFallbackWarning(original, patched);
+  assertEquals(warnings, []);
 });

--- a/src/tools/submit-helpers_test.ts
+++ b/src/tools/submit-helpers_test.ts
@@ -1,0 +1,46 @@
+/**
+ * Tests for submit-helpers.ts
+ *
+ * @module lib/erpnext/tests/tools/submit-helpers_test
+ */
+
+import { assertEquals } from "@std/assert";
+import { withRoundedTotalFallback } from "./submit-helpers.ts";
+
+Deno.test("withRoundedTotalFallback - sets disable_rounded_total when base_rounded_total is null", () => {
+  const doc = { name: "SO-001", base_rounded_total: null };
+  const result = withRoundedTotalFallback(doc);
+  assertEquals(result.disable_rounded_total, 1);
+});
+
+Deno.test("withRoundedTotalFallback - sets disable_rounded_total when rounded_total is null", () => {
+  const doc = { name: "SO-001", rounded_total: null };
+  const result = withRoundedTotalFallback(doc);
+  assertEquals(result.disable_rounded_total, 1);
+});
+
+Deno.test("withRoundedTotalFallback - leaves doc untouched when rounded totals are set", () => {
+  const doc = {
+    name: "SO-001",
+    base_rounded_total: 100,
+    rounded_total: 100,
+  };
+  const result = withRoundedTotalFallback(doc);
+  assertEquals(result, doc);
+});
+
+Deno.test("withRoundedTotalFallback - leaves doc untouched when fields are absent (non-transactional doctype)", () => {
+  const doc = { name: "Warehouse Type" };
+  const result = withRoundedTotalFallback(doc);
+  assertEquals(result, doc);
+});
+
+Deno.test("withRoundedTotalFallback - does not touch a doc that already has disable_rounded_total set to 1", () => {
+  const doc = {
+    name: "SO-001",
+    base_rounded_total: null,
+    disable_rounded_total: 1,
+  };
+  const result = withRoundedTotalFallback(doc);
+  assertEquals(result, doc);
+});


### PR DESCRIPTION
## Summary
- Fresh ERPNext instances leave `base_rounded_total`/`rounded_total` as `None` until the rounding config is initialized, crashing submit with `TypeError: abs(None)` in `validate_grand_total()`.
- Adds `withRoundedTotalFallback()` (`src/tools/submit-helpers.ts`) which sets `disable_rounded_total: 1` on the pre-submit doc when those fields are null and not already set, replacing the manual `disable_rounded_total: 1` workaround.
- Wired into all three `frappe.client.submit` call sites: `erpnext_doc_submit`, `erpnext_sales_order_submit`, `erpnext_sales_invoice_submit`.
- Moves the entry from "Open bugs" to "Fixed bugs" in `docs/known-issues.md`.

Fixes the P0 item tracked in `docs/known-issues.md`.

## Test plan
- [x] `deno test --allow-all src/` — 267 passed, 0 failed
- [x] `deno check mod.ts server.ts` — clean
- [x] New unit tests for `withRoundedTotalFallback()` covering: null `base_rounded_total`, null `rounded_total`, already-set totals, absent fields (non-transactional doctypes), already-disabled flag
- [x] Handler-level tests confirming the fallback reaches `frappe.client.submit` for all three call sites