### PR TITLE
feat: add native file upload tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `@casys/mcp-erpnext` will be documented in this file.
 
+## Unreleased
+
+### Features
+
+- **`erpnext_file_upload`** attaches base64-supplied bytes to any DocType as a
+  native Frappe `File`, with private-by-default uploads and a configurable
+  decoded-size limit. Tool count 123 → 124.
+
 ## [2.5.0](https://github.com/Casys-AI/mcp-erpnext/compare/v2.4.2...v2.5.0) (2026-07-21)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![MCP](https://img.shields.io/badge/MCP-server-1f6feb?logo=modelcontextprotocol&logoColor=white)](https://modelcontextprotocol.io)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-MCP server for [ERPNext](https://erpnext.com) / Frappe ERP — **123 tools**
+MCP server for [ERPNext](https://erpnext.com) / Frappe ERP — **124 tools**
 across **14 categories**, with **7 interactive UI viewers**.
 
 Connect any MCP-compatible AI agent (Claude Desktop, Claude Code, VS Code
@@ -239,9 +239,9 @@ npm install
 node build-all.mjs
 ```
 
-## Tools (123)
+## Tools (124)
 
-123 tools across 14 categories. Each `_list` tool returns interactive results
+124 tools across 14 categories. Each `_list` tool returns interactive results
 via the doclist-viewer with row click, inline detail, and cross-viewer
 navigation.
 
@@ -258,8 +258,8 @@ navigation.
 - **Manufacturing** (7) — BOMs, Work Orders, and Job Cards.
 - **CRM** (8) — Leads, Opportunities, Contacts, and Campaigns.
 - **Assets** (8) — Assets, Movements, Maintenance records, and Categories.
-- **Operations** (9) — Generic CRUD and native assignment for any DocType
-  (`erpnext_doc_*`).
+- **Operations** (10) — Generic CRUD, native assignment, and file upload for any
+  DocType (`erpnext_doc_*`, `erpnext_file_upload`).
 - **Kanban** (2) — Read-write boards for Task, Opportunity, and Issue with
   drag-and-drop.
 - **Analytics** (17) — 11 analytics charts (bar, area, treemap, radar, scatter,
@@ -270,11 +270,12 @@ Full per-tool reference with parameters: [`docs/tools.md`](docs/tools.md).
 
 ## Environment Variables
 
-| Variable             | Required | Description                                                                                                   |
-| -------------------- | -------- | ------------------------------------------------------------------------------------------------------------- |
-| `ERPNEXT_URL`        | Yes      | ERPNext base URL — self-hosted (e.g. `http://localhost:8000`) or cloud (e.g. `https://mycompany.erpnext.com`) |
-| `ERPNEXT_API_KEY`    | Yes      | API Key from User Settings                                                                                    |
-| `ERPNEXT_API_SECRET` | Yes      | API Secret from User Settings                                                                                 |
+| Variable                   | Required | Description                                                                                                   |
+| -------------------------- | -------- | ------------------------------------------------------------------------------------------------------------- |
+| `ERPNEXT_URL`              | Yes      | ERPNext base URL — self-hosted (e.g. `http://localhost:8000`) or cloud (e.g. `https://mycompany.erpnext.com`) |
+| `ERPNEXT_API_KEY`          | Yes      | API Key from User Settings                                                                                    |
+| `ERPNEXT_API_SECRET`       | Yes      | API Secret from User Settings                                                                                 |
+| `ERPNEXT_MAX_UPLOAD_BYTES` | No       | Maximum decoded file-upload size in bytes (positive integer; default: 10 MiB)                                 |
 
 ## Architecture
 
@@ -301,7 +302,7 @@ src/
     manufacturing.ts  # 7 manufacturing tools
     crm.ts            # 8 CRM tools
     assets.ts         # 8 asset tools
-    operations.ts     # 9 generic CRUD tools
+    operations.ts     # 10 generic operations tools
     setup.ts          # 3 company/setup tools
     kanban.ts         # 2 read-write kanban tools
     analytics.ts      # 17 analytics tools (charts, KPIs, funnel)

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,6 +1,6 @@
 # ERPNext MCP Library - Coverage
 
-## Covered (123 tools, 14 categories)
+## Covered (124 tools, 14 categories)
 
 ### Sales (17 tools)
 
@@ -199,7 +199,8 @@
 
 ## Available Operations (Generic)
 
-The `operations.ts` tools provide generic CRUD for any ERPNext DocType:
+The `operations.ts` tools provide generic CRUD and native file uploads for any
+ERPNext DocType:
 
 | Operation    | Tool                   | Notes                                                   |
 | ------------ | ---------------------- | ------------------------------------------------------- |
@@ -212,6 +213,9 @@ The `operations.ts` tools provide generic CRUD for any ERPNext DocType:
 | **List**     | `erpnext_doc_list`     | Full control: fields, filters, limit, order_by          |
 | **Assign**   | `erpnext_doc_assign`   | Add a native assignment (ToDo) to a user                |
 | **Unassign** | `erpnext_doc_unassign` | Remove a user's native assignment                       |
+
+| **Upload** | `erpnext_file_upload` | Attach base64 bytes as a native private
+File by default |
 
 Specific DocTypes also have dedicated submit/cancel tools:
 `erpnext_sales_order_submit/cancel`, `erpnext_sales_invoice_submit`.
@@ -299,7 +303,7 @@ Specific DocTypes also have dedicated submit/cancel tools:
 - **Linked document chains**: No tool to follow Sales Order → Delivery Note →
   Sales Invoice automatically
 - **Print format**: No tool to get printable HTML/PDF
-- **File attachments**: No upload/download support
+- **File attachments**: No download support
 - **Custom fields**: Work via Frappe REST but not documented/tested
 - **Amend**: Frappe amend workflow not implemented
 - **Get Report**: `callMethod()` exists but no report-specific tool

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,4 +1,4 @@
-# Tools Reference (123)
+# Tools Reference (124)
 
 Full reference for all ERPNext MCP tools. See [README](../README.md) for
 overview.
@@ -153,7 +153,7 @@ overview.
 | `erpnext_asset_maintenance_get`  | Asset Maintenance | Get with maintenance tasks                            |
 | `erpnext_asset_category_list`    | Asset Category    | List all categories                                   |
 
-## Generic Operations (9) → doclist-viewer
+## Generic Operations (10) → doclist-viewer
 
 | Tool                   | Operation | Notes                                             |
 | ---------------------- | --------- | ------------------------------------------------- |
@@ -166,6 +166,14 @@ overview.
 | `erpnext_doc_cancel`   | Cancel    | Any submitted document                            |
 | `erpnext_doc_assign`   | Assign    | Native assignment (ToDo + notification) to users  |
 | `erpnext_doc_unassign` | Unassign  | Remove one user's native assignment               |
+| `erpnext_file_upload`  | Upload    | Attach base64 data as a native File               |
+
+`erpnext_file_upload` requires `file_name`, `content_base64`,
+`attached_to_doctype`, and `attached_to_name`; `attached_to_field` is optional.
+Files are private by default (`is_private: false` makes them public), accept no
+local path or URL, are capped at 10 MiB decoded by default (override with
+positive-integer-byte `ERPNEXT_MAX_UPLOAD_BYTES`), require write permission on
+the DocType, and return native `File` metadata.
 
 ## Kanban (2) → kanban-viewer
 

--- a/mod.ts
+++ b/mod.ts
@@ -78,6 +78,8 @@ export type {
   ErpSalesOrder,
   ErpTask,
   FrappeDoc,
+  FrappeFile,
+  FrappeFileUploadInput,
   FrappeFilter,
   FrappeListOptions,
 } from "./src/api/types.ts";

--- a/src/api/frappe-client.ts
+++ b/src/api/frappe-client.ts
@@ -22,6 +22,8 @@
 import type {
   FrappeDoc,
   FrappeDocResponse,
+  FrappeFile,
+  FrappeFileUploadInput,
   FrappeListOptions,
   FrappeListResponse,
   FrappeMethodResponse,
@@ -60,6 +62,8 @@ export interface FrappeClientConfig {
   apiSecret: string;
   /** Request timeout in ms. Default: 30000 */
   timeoutMs?: number;
+  /** Maximum decoded file upload size in bytes. Default: 10 MiB. */
+  maxUploadBytes?: number;
   /**
    * Number of retry attempts on retryable failures (default: 3).
    * Set to 0 to disable retries entirely.
@@ -95,6 +99,44 @@ export interface FrappeClientConfig {
 
 const DEFAULT_RETRY_STATUSES = [408, 429, 502, 503, 504];
 const DEFAULT_RETRY_METHODS = ["GET"];
+const DEFAULT_MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+
+function decodeBase64File(contentBase64: string, maxBytes: number): Uint8Array {
+  if (contentBase64.length === 0) {
+    throw new Error("[FrappeClient] File content must not be empty");
+  }
+
+  const unpadded = contentBase64.replace(/=+$/, "");
+  const padding = contentBase64.slice(unpadded.length);
+  if (
+    !/^[A-Za-z0-9+/]+$/.test(unpadded) ||
+    !/^={0,2}$/.test(padding) ||
+    unpadded.length % 4 === 1
+  ) {
+    throw new Error("[FrappeClient] File content must be valid base64");
+  }
+
+  const decodedSize = Math.floor(unpadded.length * 6 / 8);
+  if (decodedSize > maxBytes) {
+    throw new Error(
+      `[FrappeClient] Decoded file size ${decodedSize} bytes exceeds the ${maxBytes}-byte upload limit`,
+    );
+  }
+
+  const normalized = unpadded + "=".repeat((4 - unpadded.length % 4) % 4);
+  let binary: string;
+  try {
+    binary = atob(normalized);
+  } catch {
+    throw new Error("[FrappeClient] File content must be valid base64");
+  }
+
+  if (binary.length === 0) {
+    throw new Error("[FrappeClient] File content must not be empty");
+  }
+
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+}
 
 /**
  * Error thrown when a Frappe REST API request fails.
@@ -189,6 +231,7 @@ export class FrappeClient {
   private baseUrl: string;
   private authHeader: string;
   private timeoutMs: number;
+  private maxUploadBytes: number;
   private retries: number;
   private retryStatuses: number[];
   private retryBackoffMs: number;
@@ -199,6 +242,12 @@ export class FrappeClient {
     this.baseUrl = config.baseUrl.replace(/\/$/, "");
     this.authHeader = `token ${config.apiKey}:${config.apiSecret}`;
     this.timeoutMs = config.timeoutMs ?? 30_000;
+    this.maxUploadBytes = config.maxUploadBytes ?? DEFAULT_MAX_UPLOAD_BYTES;
+    if (!Number.isInteger(this.maxUploadBytes) || this.maxUploadBytes <= 0) {
+      throw new Error(
+        "[FrappeClient] maxUploadBytes must be a positive integer",
+      );
+    }
     this.retries = config.retries ?? 3;
     this.retryStatuses = config.retryStatuses ?? DEFAULT_RETRY_STATUSES;
     this.retryBackoffMs = config.retryBackoffMs ?? 200;
@@ -208,12 +257,15 @@ export class FrappeClient {
 
   // ── Private HTTP helpers ────────────────────────────────────────────────────
 
-  private buildHeaders(): HeadersInit {
-    return {
+  private buildHeaders(includeJsonContentType = true): HeadersInit {
+    const headers: Record<string, string> = {
       "Authorization": this.authHeader,
       "Accept": "application/json",
-      "Content-Type": "application/json",
     };
+    if (includeJsonContentType) {
+      headers["Content-Type"] = "application/json";
+    }
+    return headers;
   }
 
   /**
@@ -242,11 +294,12 @@ export class FrappeClient {
     method: string,
     path: string,
     body?: unknown,
+    multipart = false,
   ): Promise<T> {
     let lastError: unknown;
     for (let attempt = 0; attempt <= this.retries; attempt++) {
       try {
-        return await this.requestOnce<T>(method, path, body);
+        return await this.requestOnce<T>(method, path, body, multipart);
       } catch (err) {
         lastError = err;
         if (
@@ -268,6 +321,7 @@ export class FrappeClient {
     method: string,
     path: string,
     body?: unknown,
+    multipart = false,
   ): Promise<T> {
     const url = `${this.baseUrl}${path}`;
     const controller = new AbortController();
@@ -277,8 +331,12 @@ export class FrappeClient {
     try {
       response = await fetch(url, {
         method,
-        headers: this.buildHeaders(),
-        body: body !== undefined ? JSON.stringify(body) : undefined,
+        headers: this.buildHeaders(!multipart),
+        body: body === undefined
+          ? undefined
+          : multipart
+          ? body as BodyInit
+          : JSON.stringify(body),
         signal: controller.signal,
       });
     } catch (err) {
@@ -499,6 +557,50 @@ export class FrappeClient {
   }
 
   /**
+   * Upload file bytes and attach the native File document to another document.
+   * POST /api/method/upload_file
+   */
+  async uploadFile(input: FrappeFileUploadInput): Promise<FrappeFile> {
+    const fileName = input.fileName.trim();
+    const attachedToDoctype = input.attachedToDoctype.trim();
+    const attachedToName = input.attachedToName.trim();
+    if (!fileName || /[\\/\0]/.test(fileName)) {
+      throw new Error(
+        "[FrappeClient] fileName must be a filename without path separators",
+      );
+    }
+    if (!attachedToDoctype) {
+      throw new Error("[FrappeClient] attachedToDoctype must not be empty");
+    }
+    if (!attachedToName) {
+      throw new Error("[FrappeClient] attachedToName must not be empty");
+    }
+
+    const bytes = decodeBase64File(
+      input.contentBase64,
+      this.maxUploadBytes,
+    );
+    const fileBuffer = new ArrayBuffer(bytes.byteLength);
+    new Uint8Array(fileBuffer).set(bytes);
+    const form = new FormData();
+    form.append("file", new Blob([fileBuffer]), fileName);
+    form.append("doctype", attachedToDoctype);
+    form.append("docname", attachedToName);
+    if (input.attachedToField?.trim()) {
+      form.append("fieldname", input.attachedToField.trim());
+    }
+    form.append("is_private", input.isPrivate === false ? "0" : "1");
+
+    const res = await this.request<FrappeMethodResponse<FrappeFile>>(
+      "POST",
+      "/api/method/upload_file",
+      form,
+      true,
+    );
+    return res.message;
+  }
+
+  /**
    * Call a whitelisted Frappe method.
    * POST /api/method/{method}
    */
@@ -532,6 +634,7 @@ export function getFrappeClient(): FrappeClient {
   const url = env("ERPNEXT_URL");
   const apiKey = env("ERPNEXT_API_KEY");
   const apiSecret = env("ERPNEXT_API_SECRET");
+  const maxUploadBytesRaw = env("ERPNEXT_MAX_UPLOAD_BYTES");
 
   if (!url) {
     throw new Error(
@@ -551,6 +654,9 @@ export function getFrappeClient(): FrappeClient {
     apiKey,
     apiSecret,
     cache: getCache(),
+    maxUploadBytes: maxUploadBytesRaw === undefined
+      ? undefined
+      : Number(maxUploadBytesRaw),
   });
   return _client;
 }

--- a/src/api/frappe-client.ts
+++ b/src/api/frappe-client.ts
@@ -564,6 +564,7 @@ export class FrappeClient {
     const fileName = input.fileName.trim();
     const attachedToDoctype = input.attachedToDoctype.trim();
     const attachedToName = input.attachedToName.trim();
+    const attachedToField = input.attachedToField?.trim();
     if (!fileName || /[\\/\0]/.test(fileName)) {
       throw new Error(
         "[FrappeClient] fileName must be a filename without path separators",
@@ -586,8 +587,8 @@ export class FrappeClient {
     form.append("file", new Blob([fileBuffer]), fileName);
     form.append("doctype", attachedToDoctype);
     form.append("docname", attachedToName);
-    if (input.attachedToField?.trim()) {
-      form.append("fieldname", input.attachedToField.trim());
+    if (attachedToField) {
+      form.append("fieldname", attachedToField);
     }
     form.append("is_private", input.isPrivate === false ? "0" : "1");
 
@@ -597,7 +598,19 @@ export class FrappeClient {
       form,
       true,
     );
-    return res.message;
+    const file = res.message;
+    this.invalidate("File", file.name);
+    this.invalidate(attachedToDoctype, attachedToName);
+
+    // Frappe records fieldname on File but does not populate the target Attach
+    // field itself, so mirror the Desk uploader's second mutation here.
+    if (attachedToField) {
+      await this.update(attachedToDoctype, attachedToName, {
+        [attachedToField]: file.file_url,
+      });
+    }
+
+    return file;
   }
 
   /**
@@ -654,14 +667,14 @@ export function getFrappeClient(): FrappeClient {
     apiKey,
     apiSecret,
     cache: getCache(),
-    maxUploadBytes: maxUploadBytesRaw === undefined
-      ? undefined
-      : Number(maxUploadBytesRaw),
+    maxUploadBytes: maxUploadBytesRaw?.trim()
+      ? Number(maxUploadBytesRaw)
+      : undefined,
   });
   return _client;
 }
 
 /** Override the singleton (useful for tests or dependency injection) */
-export function setFrappeClient(client: FrappeClient): void {
+export function setFrappeClient(client: FrappeClient | null): void {
   _client = client;
 }

--- a/src/api/frappe-client_test.ts
+++ b/src/api/frappe-client_test.ts
@@ -7,7 +7,7 @@
  * @module lib/erpnext/tests/api/frappe-client_test
  */
 
-import { assertEquals, assertRejects } from "@std/assert";
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
 import { FrappeAPIError, FrappeClient } from "./frappe-client.ts";
 import { MemoryCache } from "../cache/memory.ts";
 
@@ -202,6 +202,183 @@ Deno.test("FrappeClient.create() - sends POST with data", async () => {
   );
 
   globalThis.fetch = original;
+});
+
+// ── uploadFile() ─────────────────────────────────────────────────────────────
+
+Deno.test("FrappeClient.uploadFile() - sends native multipart attachment", async () => {
+  let capturedUrl = "";
+  let capturedMethod = "";
+  let capturedHeaders = new Headers();
+  let capturedBody: FormData | undefined;
+  const original = globalThis.fetch;
+
+  globalThis.fetch = async (
+    url: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    capturedUrl = url.toString();
+    capturedMethod = init?.method ?? "";
+    capturedHeaders = new Headers(init?.headers);
+    capturedBody = init?.body as FormData;
+    return new Response(
+      JSON.stringify({
+        message: {
+          doctype: "File",
+          name: "a1b2c3",
+          file_name: "proposal.pdf",
+          file_url: "/private/files/proposal.pdf",
+          is_private: 1,
+          attached_to_doctype: "CRM Deal",
+          attached_to_name: "CRM-DEAL-0001",
+          attached_to_field: "proposal",
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+
+  try {
+    const client = makeClient();
+    const result = await client.uploadFile({
+      fileName: "proposal.pdf",
+      contentBase64: btoa("PDF bytes"),
+      attachedToDoctype: "CRM Deal",
+      attachedToName: "CRM-DEAL-0001",
+      attachedToField: "proposal",
+    });
+
+    assertEquals(new URL(capturedUrl).pathname, "/api/method/upload_file");
+    assertEquals(capturedMethod, "POST");
+    assertEquals(
+      capturedHeaders.get("authorization"),
+      "token test-key:test-secret",
+    );
+    assertEquals(capturedHeaders.get("accept"), "application/json");
+    assertEquals(capturedHeaders.has("content-type"), false);
+    assertEquals(capturedBody?.get("doctype"), "CRM Deal");
+    assertEquals(capturedBody?.get("docname"), "CRM-DEAL-0001");
+    assertEquals(capturedBody?.get("fieldname"), "proposal");
+    assertEquals(capturedBody?.get("is_private"), "1");
+
+    const file = capturedBody?.get("file");
+    if (!(file instanceof File)) throw new Error("Expected multipart File");
+    assertEquals(file.name, "proposal.pdf");
+    assertEquals(await file.text(), "PDF bytes");
+    assertEquals(result.name, "a1b2c3");
+    assertEquals(result.file_url, "/private/files/proposal.pdf");
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("FrappeClient.uploadFile() - sends explicit public privacy", async () => {
+  let capturedBody: FormData | undefined;
+  const original = globalThis.fetch;
+
+  globalThis.fetch = async (
+    _url: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    capturedBody = init?.body as FormData;
+    return new Response(
+      JSON.stringify({
+        message: {
+          name: "public-file",
+          file_name: "brochure.pdf",
+          file_url: "/files/brochure.pdf",
+          is_private: 0,
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+
+  try {
+    const client = makeClient();
+    await client.uploadFile({
+      fileName: "brochure.pdf",
+      contentBase64: btoa("public"),
+      attachedToDoctype: "Lead",
+      attachedToName: "LEAD-0001",
+      isPrivate: false,
+    });
+
+    assertEquals(capturedBody?.get("is_private"), "0");
+    assertEquals(capturedBody?.has("fieldname"), false);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("FrappeClient.uploadFile() - rejects malformed or empty base64", async () => {
+  const client = makeClient();
+  const input = {
+    fileName: "proposal.pdf",
+    attachedToDoctype: "CRM Deal",
+    attachedToName: "CRM-DEAL-0001",
+  };
+
+  await assertRejects(
+    () => client.uploadFile({ ...input, contentBase64: "not-base64!" }),
+    Error,
+    "valid base64",
+  );
+  await assertRejects(
+    () => client.uploadFile({ ...input, contentBase64: "" }),
+    Error,
+    "must not be empty",
+  );
+});
+
+Deno.test("FrappeClient.uploadFile() - rejects decoded content over configured limit", async () => {
+  const client = makeClient({ maxUploadBytes: 2 });
+
+  await assertRejects(
+    () =>
+      client.uploadFile({
+        fileName: "proposal.pdf",
+        contentBase64: btoa("abc"),
+        attachedToDoctype: "CRM Deal",
+        attachedToName: "CRM-DEAL-0001",
+      }),
+    Error,
+    "exceeds",
+  );
+});
+
+Deno.test("FrappeClient - rejects a non-positive upload limit", () => {
+  assertThrows(
+    () => makeClient({ maxUploadBytes: 0 }),
+    Error,
+    "maxUploadBytes",
+  );
+});
+
+Deno.test("FrappeClient.uploadFile() - preserves Frappe permission errors", async () => {
+  const restore = mockFetch([
+    {
+      status: 403,
+      body: { message: "Not permitted", exc_type: "PermissionError" },
+    },
+  ]);
+
+  try {
+    const client = makeClient();
+    await assertRejects(
+      () =>
+        client.uploadFile({
+          fileName: "proposal.pdf",
+          contentBase64: btoa("PDF bytes"),
+          attachedToDoctype: "CRM Deal",
+          attachedToName: "CRM-DEAL-0001",
+        }),
+      FrappeAPIError,
+      "HTTP 403",
+    );
+  } finally {
+    restore();
+  }
 });
 
 // ── Error handling ────────────────────────────────────────────────────────────

--- a/src/api/frappe-client_test.ts
+++ b/src/api/frappe-client_test.ts
@@ -8,7 +8,12 @@
  */
 
 import { assertEquals, assertRejects, assertThrows } from "@std/assert";
-import { FrappeAPIError, FrappeClient } from "./frappe-client.ts";
+import {
+  FrappeAPIError,
+  FrappeClient,
+  getFrappeClient,
+  setFrappeClient,
+} from "./frappe-client.ts";
 import { MemoryCache } from "../cache/memory.ts";
 
 // ── Test helpers ──────────────────────────────────────────────────────────────
@@ -60,6 +65,22 @@ function makeClient(overrides: Record<string, unknown> = {}) {
     retryBackoffMs: 1,
     ...overrides,
   });
+}
+
+function withEnv(
+  key: string,
+  value: string | undefined,
+  fn: () => void,
+) {
+  const original = Deno.env.get(key);
+  if (value === undefined) Deno.env.delete(key);
+  else Deno.env.set(key, value);
+  try {
+    fn();
+  } finally {
+    if (original === undefined) Deno.env.delete(key);
+    else Deno.env.set(key, original);
+  }
 }
 
 // ── Auth header ───────────────────────────────────────────────────────────────
@@ -207,20 +228,35 @@ Deno.test("FrappeClient.create() - sends POST with data", async () => {
 // ── uploadFile() ─────────────────────────────────────────────────────────────
 
 Deno.test("FrappeClient.uploadFile() - sends native multipart attachment", async () => {
-  let capturedUrl = "";
-  let capturedMethod = "";
-  let capturedHeaders = new Headers();
-  let capturedBody: FormData | undefined;
+  const requests: Array<{
+    url: string;
+    method: string;
+    headers: Headers;
+    body: FormData | string | undefined;
+  }> = [];
   const original = globalThis.fetch;
 
   globalThis.fetch = async (
     url: string | URL | Request,
     init?: RequestInit,
   ): Promise<Response> => {
-    capturedUrl = url.toString();
-    capturedMethod = init?.method ?? "";
-    capturedHeaders = new Headers(init?.headers);
-    capturedBody = init?.body as FormData;
+    requests.push({
+      url: url.toString(),
+      method: init?.method ?? "",
+      headers: new Headers(init?.headers),
+      body: init?.body as FormData | string | undefined,
+    });
+    if (requests.length === 2) {
+      return new Response(
+        JSON.stringify({
+          data: {
+            name: "CRM-DEAL-0001",
+            proposal: "/private/files/proposal.pdf",
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
     return new Response(
       JSON.stringify({
         message: {
@@ -248,23 +284,38 @@ Deno.test("FrappeClient.uploadFile() - sends native multipart attachment", async
       attachedToField: "proposal",
     });
 
-    assertEquals(new URL(capturedUrl).pathname, "/api/method/upload_file");
-    assertEquals(capturedMethod, "POST");
+    const upload = requests[0];
+    assertEquals(new URL(upload.url).pathname, "/api/method/upload_file");
+    assertEquals(upload.method, "POST");
     assertEquals(
-      capturedHeaders.get("authorization"),
+      upload.headers.get("authorization"),
       "token test-key:test-secret",
     );
-    assertEquals(capturedHeaders.get("accept"), "application/json");
-    assertEquals(capturedHeaders.has("content-type"), false);
-    assertEquals(capturedBody?.get("doctype"), "CRM Deal");
-    assertEquals(capturedBody?.get("docname"), "CRM-DEAL-0001");
-    assertEquals(capturedBody?.get("fieldname"), "proposal");
-    assertEquals(capturedBody?.get("is_private"), "1");
+    assertEquals(upload.headers.get("accept"), "application/json");
+    assertEquals(upload.headers.has("content-type"), false);
+    if (!(upload.body instanceof FormData)) {
+      throw new Error("Expected FormData");
+    }
+    assertEquals(upload.body.get("doctype"), "CRM Deal");
+    assertEquals(upload.body.get("docname"), "CRM-DEAL-0001");
+    assertEquals(upload.body.get("fieldname"), "proposal");
+    assertEquals(upload.body.get("is_private"), "1");
 
-    const file = capturedBody?.get("file");
+    const file = upload.body.get("file");
     if (!(file instanceof File)) throw new Error("Expected multipart File");
     assertEquals(file.name, "proposal.pdf");
     assertEquals(await file.text(), "PDF bytes");
+
+    const fieldUpdate = requests[1];
+    assertEquals(
+      new URL(fieldUpdate.url).pathname,
+      "/api/resource/CRM%20Deal/CRM-DEAL-0001",
+    );
+    assertEquals(fieldUpdate.method, "PUT");
+    assertEquals(
+      JSON.parse(fieldUpdate.body as string),
+      { data: { proposal: "/private/files/proposal.pdf" } },
+    );
     assertEquals(result.name, "a1b2c3");
     assertEquals(result.file_url, "/private/files/proposal.pdf");
   } finally {
@@ -379,6 +430,63 @@ Deno.test("FrappeClient.uploadFile() - preserves Frappe permission errors", asyn
   } finally {
     restore();
   }
+});
+
+Deno.test("FrappeClient.uploadFile() - invalidates File and target caches", async () => {
+  const restore = mockFetch([
+    { status: 200, body: { data: [{ name: "FILE-OLD" }] } },
+    { status: 200, body: { data: { name: "TASK-001", subject: "Before" } } },
+    {
+      status: 200,
+      body: {
+        message: {
+          name: "FILE-NEW",
+          file_name: "report.pdf",
+          file_url: "/private/files/report.pdf",
+          is_private: 1,
+        },
+      },
+    },
+    { status: 200, body: { data: [{ name: "FILE-NEW" }] } },
+    { status: 200, body: { data: { name: "TASK-001", subject: "After" } } },
+  ]);
+
+  try {
+    const client = makeClient({ cache: new MemoryCache() });
+    await client.list("File");
+    await client.get("Task", "TASK-001");
+    await client.uploadFile({
+      fileName: "report.pdf",
+      contentBase64: btoa("report"),
+      attachedToDoctype: "Task",
+      attachedToName: "TASK-001",
+    });
+
+    const files = await client.list("File");
+    const task = await client.get("Task", "TASK-001");
+    assertEquals(files[0].name, "FILE-NEW");
+    assertEquals(task.subject, "After");
+    assertEquals(callCountRef.current, 5);
+  } finally {
+    restore();
+  }
+});
+
+Deno.test("getFrappeClient() - treats a blank upload limit as unset", () => {
+  withEnv("ERPNEXT_URL", "http://localhost:8000", () => {
+    withEnv("ERPNEXT_API_KEY", "test-key", () => {
+      withEnv("ERPNEXT_API_SECRET", "test-secret", () => {
+        withEnv("ERPNEXT_MAX_UPLOAD_BYTES", "  ", () => {
+          setFrappeClient(null);
+          try {
+            assertEquals(getFrappeClient() instanceof FrappeClient, true);
+          } finally {
+            setFrappeClient(null);
+          }
+        });
+      });
+    });
+  });
 });
 
 // ── Error handling ────────────────────────────────────────────────────────────

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -32,6 +32,38 @@ export interface FrappeDoc {
   [key: string]: unknown;
 }
 
+/** Native Frappe `File` document returned by the upload API. */
+export interface FrappeFile extends FrappeDoc {
+  /** Original uploaded filename. */
+  file_name: string;
+  /** Public or private URL assigned by Frappe. */
+  file_url: string;
+  /** 1 for private files, 0 for public files. */
+  is_private: 0 | 1;
+  /** DocType the file is attached to. */
+  attached_to_doctype?: string;
+  /** Document name the file is attached to. */
+  attached_to_name?: string;
+  /** Optional Attach/Attach Image field receiving the file. */
+  attached_to_field?: string;
+}
+
+/** Input for Frappe's native multipart file upload endpoint. */
+export interface FrappeFileUploadInput {
+  /** Filename only, without a local path. */
+  fileName: string;
+  /** Standard base64-encoded file bytes. */
+  contentBase64: string;
+  /** Target document's DocType. */
+  attachedToDoctype: string;
+  /** Target document's name/ID. */
+  attachedToName: string;
+  /** Optional Attach/Attach Image field on the target document. */
+  attachedToField?: string;
+  /** Whether Frappe should store the file privately. Defaults to true. */
+  isPrivate?: boolean;
+}
+
 /** Frappe list API response wrapper. Returned by `GET /api/resource/{doctype}`. */
 export interface FrappeListResponse<T extends FrappeDoc = FrappeDoc> {
   /** Array of documents matching the query */

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -21,6 +21,103 @@ import {
 } from "./assignment.ts";
 
 export const operationsTools: ErpNextTool[] = [
+  // ── File Attachments ───────────────────────────────────────────────────────
+
+  {
+    name: "erpnext_file_upload",
+    description:
+      "Upload base64-encoded file content and attach it to any ERPNext document. " +
+      "Files are private by default.",
+    category: "operations",
+    inputSchema: {
+      type: "object",
+      properties: {
+        file_name: {
+          type: "string",
+          description: "Filename only, without a path.",
+          minLength: 1,
+        },
+        content_base64: {
+          type: "string",
+          description: "File content as standard base64 (not a data URL).",
+          minLength: 1,
+        },
+        attached_to_doctype: {
+          type: "string",
+          description: "DocType of the document to attach the file to.",
+          minLength: 1,
+        },
+        attached_to_name: {
+          type: "string",
+          description: "Name/ID of the document to attach the file to.",
+          minLength: 1,
+        },
+        attached_to_field: {
+          type: "string",
+          description:
+            "Optional document field associated with this attachment.",
+        },
+        is_private: {
+          type: "boolean",
+          description: "Whether the attachment is private. Defaults to true.",
+          default: true,
+        },
+      },
+      required: [
+        "file_name",
+        "content_base64",
+        "attached_to_doctype",
+        "attached_to_name",
+      ],
+    },
+    handler: async (input, ctx) => {
+      const requiredStrings = [
+        "file_name",
+        "content_base64",
+        "attached_to_doctype",
+        "attached_to_name",
+      ] as const;
+      for (const field of requiredStrings) {
+        if (typeof input[field] !== "string" || !input[field].trim()) {
+          throw new Error(
+            `[erpnext_file_upload] '${field}' must be a non-empty string`,
+          );
+        }
+      }
+
+      const fileName = input.file_name as string;
+      if (/[\\/\0]/.test(fileName)) {
+        throw new Error(
+          "[erpnext_file_upload] 'file_name' must be a filename without a path",
+        );
+      }
+      if (
+        input.is_private !== undefined && typeof input.is_private !== "boolean"
+      ) {
+        throw new Error("[erpnext_file_upload] 'is_private' must be a boolean");
+      }
+
+      const file = await ctx.client.uploadFile({
+        fileName,
+        contentBase64: input.content_base64 as string,
+        attachedToDoctype: input.attached_to_doctype as string,
+        attachedToName: input.attached_to_name as string,
+        ...(input.attached_to_field !== undefined
+          ? { attachedToField: input.attached_to_field as string }
+          : {}),
+        isPrivate: input.is_private === undefined
+          ? true
+          : input.is_private as boolean,
+      });
+
+      return {
+        data: file,
+        message:
+          `${fileName} attached to ${input.attached_to_doctype} ${input.attached_to_name}`,
+      };
+    },
+  },
+
   // ── Generic Create ──────────────────────────────────────────────────────────
 
   {

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -25,6 +25,7 @@ export const operationsTools: ErpNextTool[] = [
 
   {
     name: "erpnext_file_upload",
+    annotations: { destructiveHint: true },
     description:
       "Upload base64-encoded file content and attach it to any ERPNext document. " +
       "Files are private by default.",
@@ -55,7 +56,7 @@ export const operationsTools: ErpNextTool[] = [
         attached_to_field: {
           type: "string",
           description:
-            "Optional document field associated with this attachment.",
+            "Optional Attach or Attach Image field to populate with the uploaded file.",
         },
         is_private: {
           type: "boolean",
@@ -96,6 +97,15 @@ export const operationsTools: ErpNextTool[] = [
       ) {
         throw new Error("[erpnext_file_upload] 'is_private' must be a boolean");
       }
+      if (
+        input.attached_to_field !== undefined &&
+        (typeof input.attached_to_field !== "string" ||
+          !input.attached_to_field.trim())
+      ) {
+        throw new Error(
+          "[erpnext_file_upload] 'attached_to_field' must be a non-empty string",
+        );
+      }
 
       const file = await ctx.client.uploadFile({
         fileName,
@@ -103,7 +113,7 @@ export const operationsTools: ErpNextTool[] = [
         attachedToDoctype: input.attached_to_doctype as string,
         attachedToName: input.attached_to_name as string,
         ...(input.attached_to_field !== undefined
-          ? { attachedToField: input.attached_to_field as string }
+          ? { attachedToField: input.attached_to_field.trim() }
           : {}),
         isPrivate: input.is_private === undefined
           ? true

--- a/src/tools/operations_test.ts
+++ b/src/tools/operations_test.ts
@@ -191,6 +191,70 @@ Deno.test("erpnext_doc_cancel - invalidates cache after cancel", async () => {
   assertEquals(invalidatedName, "SO-001");
 });
 
+// ── erpnext_file_upload ────────────────────────────────────────────────────
+
+Deno.test("erpnext_file_upload - validates input and delegates to the client", async () => {
+  const tool = getTool("erpnext_file_upload");
+  await assertRejects(
+    () =>
+      tool.handler({
+        file_name: "nested/report.pdf",
+        content_base64: "YQ==",
+        attached_to_doctype: "Task",
+        attached_to_name: "TASK-001",
+      }, makeCtx(makeMockClient())),
+    Error,
+    "filename without a path",
+  );
+
+  let captured: Record<string, unknown> = {};
+  const result = await tool.handler(
+    {
+      file_name: "report.pdf",
+      content_base64: "YQ==",
+      attached_to_doctype: "Task",
+      attached_to_name: "TASK-001",
+      attached_to_field: "attachment",
+      is_private: false,
+    },
+    makeCtx(makeMockClient({
+      uploadFile: async (input: Record<string, unknown>) => {
+        captured = input;
+        return { name: "FILE-001" };
+      },
+    })),
+  ) as Record<string, unknown>;
+
+  assertEquals(captured, {
+    fileName: "report.pdf",
+    contentBase64: "YQ==",
+    attachedToDoctype: "Task",
+    attachedToName: "TASK-001",
+    attachedToField: "attachment",
+    isPrivate: false,
+  });
+  assertEquals(result.message, "report.pdf attached to Task TASK-001");
+});
+
+Deno.test("erpnext_file_upload - defaults to private", async () => {
+  let isPrivate: boolean | undefined;
+  await getTool("erpnext_file_upload").handler(
+    {
+      file_name: "report.pdf",
+      content_base64: "YQ==",
+      attached_to_doctype: "Task",
+      attached_to_name: "TASK-001",
+    },
+    makeCtx(makeMockClient({
+      uploadFile: async (input: { isPrivate: boolean }) => {
+        isPrivate = input.isPrivate;
+        return { name: "FILE-001" };
+      },
+    })),
+  );
+  assertEquals(isPrivate, true);
+});
+
 // ── erpnext_doc_list ────────────────────────────────────────────────────────
 
 Deno.test("erpnext_doc_list - has _meta.ui for doclist-viewer", () => {

--- a/src/tools/operations_test.ts
+++ b/src/tools/operations_test.ts
@@ -206,6 +206,18 @@ Deno.test("erpnext_file_upload - validates input and delegates to the client", a
     Error,
     "filename without a path",
   );
+  await assertRejects(
+    () =>
+      tool.handler({
+        file_name: "report.pdf",
+        content_base64: "YQ==",
+        attached_to_doctype: "Task",
+        attached_to_name: "TASK-001",
+        attached_to_field: 42,
+      }, makeCtx(makeMockClient())),
+    Error,
+    "attached_to_field",
+  );
 
   let captured: Record<string, unknown> = {};
   const result = await tool.handler(
@@ -253,6 +265,13 @@ Deno.test("erpnext_file_upload - defaults to private", async () => {
     })),
   );
   assertEquals(isPrivate, true);
+});
+
+Deno.test("erpnext_file_upload - is marked destructive", () => {
+  assertEquals(
+    getTool("erpnext_file_upload").annotations?.destructiveHint,
+    true,
+  );
 });
 
 // ── erpnext_doc_list ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- add `erpnext_file_upload` for attaching base64-encoded content to ERPNext documents through Frappe's native multipart upload API
- validate filenames, base64 payloads, privacy options, and a configurable decoded-size limit
- expose native `File` response types and document the new tool and `ERPNEXT_MAX_UPLOAD_BYTES`
- cover multipart requests, validation, size limits, privacy defaults, and Frappe error propagation

## Type of change

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] chore
- [ ] test

## Related issues

N/A

## How tested

- `deno fmt --check` (repository files; local untracked `graphify-out/` excluded)
- `deno lint`
- `deno task check`
- `deno task test` — 267 passed, 4 ignored

## Checklist

- [x] `deno fmt` — no formatting issues
- [x] `deno lint` — no lint errors
- [x] `deno task check` — type-check passes
- [x] `deno task test` — all tests pass
- [x] PR title follows Conventional Commits (`type(scope): description`)
