### PR TITLE
Fix ERPNext viewer hydration and Item UOM mapping

### DIFF
--- a/src/tools/inventory.ts
+++ b/src/tools/inventory.ts
@@ -117,7 +117,8 @@ export const inventoryTools: ErpNextTool[] = [
         },
         uom: {
           type: "string",
-          description: "Unit of measure (default: 'Nos')",
+          description:
+            "Stock unit of measure, sent to ERPNext as stock_uom (for example 'Nos')",
         },
         is_stock_item: {
           type: "boolean",
@@ -141,7 +142,7 @@ export const inventoryTools: ErpNextTool[] = [
         item_name: input.item_name as string,
       };
       if (input.item_group) data.item_group = input.item_group as string;
-      if (input.uom) data.uom = input.uom as string;
+      if (input.uom) data.stock_uom = input.uom as string;
       if (input.is_stock_item !== undefined) {
         data.is_stock_item = input.is_stock_item;
       }

--- a/src/tools/inventory_test.ts
+++ b/src/tools/inventory_test.ts
@@ -74,7 +74,6 @@ Deno.test("erpnext_item_create - forwards optional fields", async () => {
       item_code: "WIDGET-1",
       item_name: "Widget",
       item_group: "Products",
-      uom: "Nos",
       is_stock_item: true,
       standard_rate: 25.5,
     },
@@ -83,9 +82,27 @@ Deno.test("erpnext_item_create - forwards optional fields", async () => {
 
   assertEquals(capturedData.item_code, "WIDGET-1");
   assertEquals(capturedData.item_group, "Products");
-  assertEquals(capturedData.uom, "Nos");
   assertEquals(capturedData.is_stock_item, true);
   assertEquals(capturedData.standard_rate, 25.5);
+});
+
+Deno.test("erpnext_item_create - maps public uom to ERPNext stock_uom", async () => {
+  let capturedData: Record<string, unknown> | undefined;
+  const mockClient = makeMockClient({
+    create: async (_doctype: string, data: Record<string, unknown>) => {
+      capturedData = data;
+      return { name: "WIDGET-1" };
+    },
+  });
+
+  const tool = getTool("erpnext_item_create");
+  await tool.handler(
+    { item_code: "WIDGET-1", item_name: "Widget", uom: "Nos" },
+    makeCtx(mockClient),
+  );
+
+  assertEquals(capturedData?.stock_uom, "Nos");
+  assertEquals(capturedData && "uom" in capturedData, false);
 });
 
 // ── erpnext_item_update ──────────────────────────────────────────────────────

--- a/src/ui/chart-viewer/src/ChartViewer.tsx
+++ b/src/ui/chart-viewer/src/ChartViewer.tsx
@@ -1304,8 +1304,6 @@ export function ChartViewer() {
   }
 
   useEffect(() => {
-    app.connect().catch(() => {});
-
     app.ontoolresult = (result: ToolResultPayload) => {
       consumeToolResult(result);
     };
@@ -1315,6 +1313,8 @@ export function ChartViewer() {
         setLoading(true);
       }
     };
+
+    app.connect().catch(() => {});
   }, []);
 
   useEffect(() => {

--- a/src/ui/doclist-viewer/src/DoclistViewer.tsx
+++ b/src/ui/doclist-viewer/src/DoclistViewer.tsx
@@ -147,13 +147,13 @@ export function DoclistViewer() {
   }
 
   useEffect(() => {
-    app.connect().catch(() => {});
     app.ontoolresult = (result: ToolResultPayload) => {
       consumeToolResult(result);
     };
     app.ontoolinputpartial = () => {
       if (!dataRef.current) setLoading(true);
     };
+    app.connect().catch(() => {});
   }, []);
 
   useEffect(() => {

--- a/src/ui/funnel-viewer/src/FunnelViewer.tsx
+++ b/src/ui/funnel-viewer/src/FunnelViewer.tsx
@@ -421,8 +421,6 @@ export function FunnelViewer() {
   }
 
   useEffect(() => {
-    app.connect().catch(() => {});
-
     app.ontoolresult = (result: ToolResultPayload) => {
       consumeToolResult(result);
     };
@@ -432,6 +430,8 @@ export function FunnelViewer() {
         setLoading(true);
       }
     };
+
+    app.connect().catch(() => {});
   }, []);
 
   useEffect(() => {

--- a/src/ui/invoice-viewer/src/InvoiceViewer.tsx
+++ b/src/ui/invoice-viewer/src/InvoiceViewer.tsx
@@ -335,13 +335,13 @@ export function InvoiceViewer() {
   }
 
   useEffect(() => {
-    app.connect().catch(() => {});
     app.ontoolresult = (result: ToolResultPayload) => {
       consumeToolResult(result);
     };
     app.ontoolinputpartial = () => {
       if (!dataRef.current) setLoading(true);
     };
+    app.connect().catch(() => {});
   }, []);
 
   useEffect(() => {

--- a/src/ui/kanban-viewer/src/KanbanViewer.tsx
+++ b/src/ui/kanban-viewer/src/KanbanViewer.tsx
@@ -1271,10 +1271,6 @@ export function KanbanViewer() {
   }
 
   useEffect(() => {
-    app.connect().catch(() => {
-      setError("Failed to connect MCP App host");
-    });
-
     app.ontoolinput = (params: { arguments?: Record<string, unknown> }) => {
       const toolName = app.getHostContext()?.toolInfo?.tool.name;
       if (toolName && params.arguments) {
@@ -1312,6 +1308,10 @@ export function KanbanViewer() {
         startLoading();
       }
     };
+
+    app.connect().catch(() => {
+      setError("Failed to connect MCP App host");
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/ui/kpi-viewer/src/KpiViewer.tsx
+++ b/src/ui/kpi-viewer/src/KpiViewer.tsx
@@ -467,8 +467,6 @@ export function KpiViewer() {
   }
 
   useEffect(() => {
-    app.connect().catch(() => {});
-
     app.ontoolresult = (result: ToolResultPayload) => {
       consumeToolResult(result);
     };
@@ -478,6 +476,8 @@ export function KpiViewer() {
         setLoading(true);
       }
     };
+
+    app.connect().catch(() => {});
   }, []);
 
   useEffect(() => {

--- a/src/ui/stock-viewer/src/StockViewer.tsx
+++ b/src/ui/stock-viewer/src/StockViewer.tsx
@@ -304,8 +304,6 @@ export function StockViewer() {
   }
 
   useEffect(() => {
-    app.connect().catch(() => {});
-
     app.ontoolresult = (result: ToolResultPayload) => {
       consumeToolResult(result);
     };
@@ -315,6 +313,8 @@ export function StockViewer() {
         setLoading(true);
       }
     };
+
+    app.connect().catch(() => {});
   }, []);
 
   useEffect(() => {

--- a/src/ui/viewer_handshake_test.ts
+++ b/src/ui/viewer_handshake_test.ts
@@ -1,0 +1,132 @@
+import { assert, assertEquals } from "@std/assert";
+
+interface ViewerHandshakeFixture {
+  directory: string;
+  component: string;
+  appName: string;
+  handlers: string[];
+}
+
+const VIEWERS: ViewerHandshakeFixture[] = [
+  {
+    directory: "chart-viewer",
+    component: "ChartViewer.tsx",
+    appName: "Chart Viewer",
+    handlers: ["ontoolresult", "ontoolinputpartial"],
+  },
+  {
+    directory: "doclist-viewer",
+    component: "DoclistViewer.tsx",
+    appName: "Doclist Viewer",
+    handlers: ["ontoolresult", "ontoolinputpartial"],
+  },
+  {
+    directory: "funnel-viewer",
+    component: "FunnelViewer.tsx",
+    appName: "Funnel Viewer",
+    handlers: ["ontoolresult", "ontoolinputpartial"],
+  },
+  {
+    directory: "invoice-viewer",
+    component: "InvoiceViewer.tsx",
+    appName: "Invoice Viewer",
+    handlers: ["ontoolresult", "ontoolinputpartial"],
+  },
+  {
+    directory: "kanban-viewer",
+    component: "KanbanViewer.tsx",
+    appName: "Kanban Viewer",
+    handlers: ["ontoolinput", "ontoolresult", "ontoolinputpartial"],
+  },
+  {
+    directory: "kpi-viewer",
+    component: "KpiViewer.tsx",
+    appName: "KPI Viewer",
+    handlers: ["ontoolresult", "ontoolinputpartial"],
+  },
+  {
+    directory: "stock-viewer",
+    component: "StockViewer.tsx",
+    appName: "Stock Viewer",
+    handlers: ["ontoolresult", "ontoolinputpartial"],
+  },
+];
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function assertBeforeConnect(
+  source: string,
+  viewer: string,
+  appIdentifier: string,
+  handlers: string[],
+): void {
+  const connectIndex = source.indexOf(`${appIdentifier}.connect(`);
+  assert(connectIndex >= 0, `${viewer}: app.connect() is missing`);
+
+  for (const handler of handlers) {
+    const assignment = new RegExp(
+      `${escapeRegExp(appIdentifier)}\\.${handler}\\s*=`,
+    ).exec(source);
+    const handlerIndex = assignment?.index ?? -1;
+    assert(handlerIndex >= 0, `${viewer}: app.${handler} is missing`);
+    assert(
+      handlerIndex < connectIndex,
+      `${viewer}: app.${handler} must be registered before app.connect()`,
+    );
+  }
+}
+
+Deno.test("ERPNext viewer sources register MCP handlers before connect", async () => {
+  assertEquals(VIEWERS.length, 7);
+  for (const viewer of VIEWERS) {
+    const source = await Deno.readTextFile(
+      new URL(
+        `./${viewer.directory}/src/${viewer.component}`,
+        import.meta.url,
+      ),
+    );
+    assertBeforeConnect(source, viewer.directory, "app", viewer.handlers);
+  }
+});
+
+Deno.test("ERPNext viewer bundles preserve handler-before-connect ordering", async () => {
+  assertEquals(VIEWERS.length, 7);
+  const builtViewers = await Promise.all(VIEWERS.map(async (viewer) => {
+    try {
+      const bundle = await Deno.readTextFile(
+        new URL(`./dist/${viewer.directory}/index.html`, import.meta.url),
+      );
+      return { viewer, bundle };
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) return undefined;
+      throw error;
+    }
+  }));
+  const present = builtViewers.filter((entry) => entry !== undefined);
+  if (present.length === 0) return;
+  assertEquals(
+    present.length,
+    VIEWERS.length,
+    "Either all viewer bundles must be built or none of them",
+  );
+
+  for (const { viewer, bundle } of present) {
+    const declaration = bundle.match(
+      new RegExp(
+        `const\\s+([A-Za-z_$][\\w$]*)=new\\s+[A-Za-z_$][\\w$]*\\(\\{name:"${
+          escapeRegExp(viewer.appName)
+        }"`,
+      ),
+    );
+    assert(declaration, `${viewer.directory}: MCP App declaration is missing`);
+    const appIdentifier = declaration[1];
+    assertBeforeConnect(
+      bundle.slice(declaration.index),
+      viewer.directory,
+      appIdentifier,
+      viewer.handlers,
+    );
+  }
+});


### PR DESCRIPTION
## What changed

- register every MCP App result handler before `connect()`
- add source and built-bundle ordering regressions for all seven viewers
- map the public Item `uom` input to ERPNext's native `stock_uom` field

## Root cause

The viewers registered `toolresult` after the UI handshake, so a fast host could deliver the initiating result before the handler existed. Item creation also forwarded a convenience field that ERPNext does not accept instead of its native field name.

## Impact

Compose panels hydrate from the real initiating result without the labelled demo fallback. Agents can create ERPNext Items through the documented `uom` input.

## Validation

- 324 tests pass, 4 integration tests ignored
- format, lint and type checks pass
- real ERPNext 16.30 smoke created 11 CM-01 Items
- real Compose host displayed the submitted CM-01 BOM with no handshake console errors