### PR TITLE
feat: document viewer and attachment workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 All notable changes to `@casys/mcp-erpnext` will be documented in this file.
 
+## [3.1.0-beta.2] - 2026-08-24
+
+### Added
+
+- **Generic `doc-viewer` for ERPNext records.** Twenty-six dedicated `*_get`
+  tools and `erpnext_doc_get` now open a responsive document surface with scalar
+  fields, long text, progress, system metadata, and ERPNext child tables. Sales
+  Order, Sales Invoice, and Quotation keep their specialized invoice viewer.
+- **Attachment workflows inside document surfaces.** Users can list and upload
+  private-by-default files, choose public visibility explicitly, and download an
+  attachment through the MCP Apps host. Uploads are single-flight and only
+  report success after the canonical File list has been read again.
+- **`erpnext_file_download`**, an app-only read tool. It re-fetches the File
+  document, verifies its exact parent and privacy, accepts only a local Frappe
+  file path, performs an authenticated no-redirect download, and returns one
+  bounded embedded resource. Tool count increases from 125 to 126; viewer count
+  increases from seven to eight.
+- **Transport-neutral document change events.** A confirmed update, submit,
+  cancel, or attachment addition carries its canonical DocType/name and marks
+  open navigation snapshots stale without discarding their UI state.
+
+### Changed
+
+- Drill-down record results retain their complete viewer envelope, including the
+  server-filtered tool manifest, navigation hints, and refresh request. Child
+  actions no longer inherit capabilities from the parent list.
+- Mutations invalidate older reads immediately, keep the affected action locked,
+  and clear a stale marker only after the corresponding surface has accepted a
+  canonical re-read. Hidden parent or child snapshots remain marked stale until
+  they are actually refreshed.
+- File downloads default to a 10 MiB decoded limit, independently configurable
+  with `ERPNEXT_MAX_DOWNLOAD_BYTES`. Uploads retain their separate
+  `ERPNEXT_MAX_UPLOAD_BYTES` limit.
+
+### Beta compatibility
+
+- No existing tool was removed and no existing input schema was made
+  incompatible. The new download tool is hidden from model tool lists and is
+  callable only by an MCP App.
+- This beta intentionally changes the presentation of generic and dedicated
+  record reads from raw JSON to `doc-viewer` in compatible hosts. Hosts without
+  MCP Apps continue to receive the normal tool result.
+- Synchronization is currently local to one viewer navigation stack. The event
+  contract can later be transported by a composition host, but beta 2 does not
+  claim automatic synchronization across separate viewers, conversations, or
+  external ERPNext edits.
+
 ## [3.1.0-beta.1] - 2026-08-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ English | [繁體中文](README.zh-TW.md)
 [![MCP](https://img.shields.io/badge/MCP-server-1f6feb?logo=modelcontextprotocol&logoColor=white)](https://modelcontextprotocol.io)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
+> [!IMPORTANT]
+> **Installing the 3.1 beta:** pin the prerelease while this UX is being
+> validated. For npm/Node use `npx -y @casys/mcp-erpnext@3.1.0-beta.2`; for Deno
+> use `deno run -A jsr:@casys/mcp-erpnext@3.1.0-beta.2/server`. The moving npm
+> alias is `@next`. Beta 2 adds the generic document viewer and attachment
+> workflows, so test it with the MCP host your users actually run before
+> replacing a stable deployment.
+
 Let any MCP-compatible AI agent operate your [ERPNext](https://erpnext.com) /
 Frappe instance — documents, workflows, and interactive viewers inside the host
 (Claude Desktop, Claude Code, VS Code Copilot, or custom).
@@ -72,10 +80,11 @@ See the [CHANGELOG](CHANGELOG.md) for the full release history, or the
 [latest release](https://github.com/Casys-AI/mcp-erpnext/releases/latest) for
 the current version's highlights.
 
-> **3.1 beta preview:** install with `npx -y @casys/mcp-erpnext@next`. The beta
-> remains compatible with the 3.0 tool surface and progressively enables in-view
-> navigation and active context according to the capabilities advertised by the
-> MCP host.
+> **3.1 beta 2 preview:** the beta keeps the 3.0 tool surface and adds a generic
+> document viewer, child tables, document attachments, in-view navigation, and
+> active context. Features remain capability-gated by the MCP host. In
+> particular, downloads require both proxied server tools and the MCP Apps
+> `downloadFile` capability.
 
 ## Documentation
 
@@ -181,13 +190,14 @@ until it exists. See
 
 ## UI Viewers
 
-Seven interactive [MCP Apps](https://github.com/modelcontextprotocol/ext-apps)
+Eight interactive [MCP Apps](https://github.com/modelcontextprotocol/ext-apps)
 viewers, registered as `ui://mcp-erpnext/{name}`:
 
 | Viewer           | Description                                                      | Interactive Features                                                                          |
 | ---------------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `doc-viewer`     | Generic ERPNext document with fields and child tables            | Capability-gated attachments, typed navigation, guarded Submit/Cancel, and raw JSON fallback. |
 | `doclist-viewer` | Generic document table with sort, filter, pagination, CSV export | Inline details, typed nested navigation, Submit/Cancel, and compact status filters.           |
-| `invoice-viewer` | Sales/Purchase documents with parties, items, totals             | Item, stock, party, and payment navigation plus guarded Submit/Cancel actions.                |
+| `invoice-viewer` | Sales Orders, Sales Invoices, and Quotations with line totals    | Item, stock, party, and payment navigation plus guarded Submit/Cancel actions.                |
 | `stock-viewer`   | Stock balance table with color-coded qty badges                  | Item details, recent movements, stock charts, and stock-entry navigation.                     |
 | `chart-viewer`   | Universal chart renderer (12 types via Recharts)                 | Exact point/series navigation and active-context selection across simple and composed charts. |
 | `kanban-viewer`  | Read-write kanban for Task, Opportunity, Issue                   | Drag-and-drop, inline editing, serialized saves, and typed related-document navigation.       |
@@ -201,6 +211,9 @@ Viewers progressively select the best interaction supported by the host:
 - `serverTools` opens typed list, record, and chart targets inside the current
   viewer through `app.callServerTool()`. Back and breadcrumb navigation restore
   the state of each level.
+- `downloadFile` lets the host confirm and save an attachment returned as a
+  bounded embedded resource. The viewer never opens an ERPNext file URL
+  directly.
 - `updateModelContext` lets chart, KPI, and funnel selections join a bounded
   active-context snapshot. The compact context chip keeps up to eight items and
   lets users remove one item or clear them all. The snapshot contains selected
@@ -219,7 +232,10 @@ that are not loaded.
 Read-only viewers revalidate on focus and through their refresh control.
 Mutations use an explicit read-only request to fetch committed state; a mutating
 tool is never replayed automatically. Overlapping or stale responses are ignored
-when a newer host payload or mutation has already won.
+when a newer host payload or mutation has already won. A confirmed document
+change marks every potentially derived snapshot in the current navigation stack
+as stale; each marker is removed only when that surface has actually been read
+again. Separate MCP Apps are not synchronized automatically in beta 2.
 
 ### Building UI viewers
 
@@ -231,8 +247,11 @@ node build-all.mjs
 
 ## Tools
 
-Each `_list` tool returns interactive results via the doclist-viewer with row
-click, inline detail, and cross-viewer navigation.
+Record `_list` tools return interactive results via the doclist-viewer with row
+click, inline detail, and cross-viewer navigation. The attachment-specific
+`erpnext_file_list` tool does not render doclist-viewer. Generic and dedicated
+document reads use `doc-viewer`, except Sales Order, Sales Invoice, and
+Quotation, which retain the specialized invoice surface.
 
 - **Sales** — Customers, Sales Orders, Invoices, and Quotations with full CRUD,
   Submit, and Cancel.
@@ -247,9 +266,9 @@ click, inline detail, and cross-viewer navigation.
 - **Manufacturing** — BOMs, Work Orders, and Job Cards.
 - **CRM** — Leads, Opportunities, Contacts, and Campaigns.
 - **Assets** — Assets, Movements, Maintenance records, and Categories.
-- **Operations** — Generic CRUD, native assignment, and attachment listing or
-  upload for any DocType (`erpnext_doc_*`, `erpnext_file_list`,
-  `erpnext_file_upload`).
+- **Operations** — Generic CRUD, native assignment, and attachment listing,
+  upload, or host-mediated download for any DocType (`erpnext_doc_*`,
+  `erpnext_file_*`).
 - **Kanban** — Read-write boards for Task, Opportunity, and Issue with
   drag-and-drop.
 - **Analytics** — Charts (bar, area, treemap, radar, scatter, P&L…), KPIs with
@@ -260,13 +279,14 @@ Full per-tool reference with parameters: [`docs/tools.md`](docs/tools.md).
 
 ## Environment Variables
 
-| Variable                   | Required | Description                                                                                                                      |
-| -------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `ERPNEXT_URL`              | Yes      | ERPNext base URL — self-hosted (e.g. `http://localhost:8000`) or cloud (e.g. `https://mycompany.erpnext.com`)                    |
-| `ERPNEXT_API_KEY`          | Yes      | API Key from User Settings                                                                                                       |
-| `ERPNEXT_API_SECRET`       | Yes      | API Secret from User Settings                                                                                                    |
-| `ERPNEXT_MAX_UPLOAD_BYTES` | No       | Maximum decoded file-upload size in bytes (positive integer; default: 10 MiB)                                                    |
-| `MCP_MRTR_SIGNING_KEY`     | No       | Exactly 64 lowercase hex characters; enables signed ambiguous-link elicitation. **Single-instance deployments only** — see below |
+| Variable                     | Required | Description                                                                                                                      |
+| ---------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `ERPNEXT_URL`                | Yes      | ERPNext base URL — self-hosted (e.g. `http://localhost:8000`) or cloud (e.g. `https://mycompany.erpnext.com`)                    |
+| `ERPNEXT_API_KEY`            | Yes      | API Key from User Settings                                                                                                       |
+| `ERPNEXT_API_SECRET`         | Yes      | API Secret from User Settings                                                                                                    |
+| `ERPNEXT_MAX_UPLOAD_BYTES`   | No       | Maximum decoded file-upload size in bytes (positive integer; default: 10 MiB)                                                    |
+| `ERPNEXT_MAX_DOWNLOAD_BYTES` | No       | Maximum attachment-download size in bytes (positive integer; default: 10 MiB)                                                    |
+| `MCP_MRTR_SIGNING_KEY`       | No       | Exactly 64 lowercase hex characters; enables signed ambiguous-link elicitation. **Single-instance deployments only** — see below |
 
 MRTR is opt-in. Without this key, or when the client does not advertise
 elicitation, ambiguous links keep returning the existing actionable ambiguity

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -8,6 +8,13 @@
 [![MCP](https://img.shields.io/badge/MCP-server-1f6feb?logo=modelcontextprotocol&logoColor=white)](https://modelcontextprotocol.io)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
+> [!IMPORTANT]
+> **安裝 3.1 Beta：** 在新版 UX 驗證期間，請固定使用預發布版本。npm/Node 請執行
+> `npx -y @casys/mcp-erpnext@3.1.0-beta.2`；Deno 請執行
+> `deno run -A jsr:@casys/mcp-erpnext@3.1.0-beta.2/server`。npm 的浮動標籤為
+> `@next`。Beta 2 新增通用文件檢視器及附件流程；在取代穩定版部署前，請務必
+> 使用實際的 MCP 主機進行測試。
+
 讓任何相容 MCP 的 AI 智慧代理操作您的 [ERPNext](https://erpnext.com) / Frappe
 執行個體 — 文件、工作流程，以及主機內的互動式檢視器（Claude Desktop、 Claude
 Code、VS Code Copilot 或自訂代理）。
@@ -69,9 +76,9 @@ Code、VS Code Copilot 或自訂代理）。
 完整的發布歷程請參閱
 [CHANGELOG](CHANGELOG.md)，目前版本的重點說明請參閱[最新發布](https://github.com/Casys-AI/mcp-erpnext/releases/latest)。
 
-> **3.1 Beta 預覽版：** 使用 `npx -y @casys/mcp-erpnext@next` 安裝。此版本維持與
-> 3.0 工具介面的相容性， 並依 MCP
-> 主機宣告的能力逐步啟用檢視器內導覽與作用中內容。
+> **3.1 Beta 2 預覽版：** 此版本維持與 3.0 工具介面的相容性，並新增通用文件
+> 檢視器、子表格、附件、檢視器內導覽及作用中內容。所有功能仍依 MCP 主機能力
+> 啟用；下載同時需要代理伺服器工具與 MCP Apps 的 `downloadFile` 能力。
 
 ## 文件
 
@@ -176,13 +183,14 @@ npx -y @casys/mcp-erpnext --categories=sales,inventory
 
 ## UI 檢視器
 
-七個互動式 [MCP Apps](https://github.com/modelcontextprotocol/ext-apps)
+八個互動式 [MCP Apps](https://github.com/modelcontextprotocol/ext-apps)
 檢視器，已登錄為 `ui://mcp-erpnext/{name}`：
 
 | 檢視器           | 說明                                               | 互動功能                                                       |
 | ---------------- | -------------------------------------------------- | -------------------------------------------------------------- |
+| `doc-viewer`     | 顯示欄位與子表格的通用 ERPNext 文件                | 依能力啟用附件、具型別導覽、受保護的提交／取消及原始 JSON。    |
 | `doclist-viewer` | 通用文件表格，支援排序、篩選、分頁與 CSV 匯出      | 內嵌詳情、具型別的巢狀導覽、提交／取消，以及精簡的狀態篩選器。 |
-| `invoice-viewer` | 含交易方、品項與金額合計的銷售／採購文件           | 品項、庫存、交易方與付款導覽，以及受保護的提交／取消操作。     |
+| `invoice-viewer` | 含交易方、品項及合計的銷售訂單、銷售發票與報價單   | 品項、庫存、交易方與付款導覽，以及受保護的提交／取消操作。     |
 | `stock-viewer`   | 含色碼數量標籤的庫存結餘表格                       | 品項詳情、近期異動、庫存圖表與庫存記錄導覽。                   |
 | `chart-viewer`   | 通用圖表渲染器（透過 Recharts 支援 12 種圖表類型） | 精確的資料點／數列導覽，以及簡單與組合圖表的作用中內容選取。   |
 | `kanban-viewer`  | 可讀寫的 Task、Opportunity、Issue 看板             | 拖放、內嵌編輯、循序儲存，以及具型別的相關文件導覽。           |
@@ -195,6 +203,8 @@ npx -y @casys/mcp-erpnext --categories=sales,inventory
 
 - `serverTools` 透過 `app.callServerTool()`，直接在目前檢視器內開啟具型別的
   清單、文件或圖表層級。麵包屑與返回導覽會還原各層級的介面狀態。
+- `downloadFile` 讓主機確認並儲存以大小上限保護的內嵌附件。檢視器不會直接開啟
+  ERPNext 的檔案 URL。
 - `updateModelContext` 可將圖表、KPI 與漏斗中的選取項目加入有上限的作用中內容。
   精簡的內容晶片最多保留八個項目，並可逐項移除或全部清除。傳送的快照只包含
   使用者選取的值，不含給模型的隱藏指令。
@@ -210,6 +220,8 @@ npx -y @casys/mcp-erpnext --categories=sales,inventory
 唯讀檢視器會在重新取得焦點或使用重新整理控制項時重新驗證。資料異動後只會
 透過明確的唯讀工具讀回已提交狀態，不會自動重播寫入工具。若較新的主機資料或
 異動結果已生效，較舊或重疊的重新整理回應會被忽略。
+已確認的文件異動會把目前導覽堆疊中可能衍生的快照標記為過期；只有在該畫面
+實際重新讀取後才會移除標記。Beta 2 不會自動同步彼此分離的 MCP Apps。
 
 ### 建置 UI 檢視器
 
@@ -221,8 +233,10 @@ node build-all.mjs
 
 ## 工具
 
-每個 `_list` 工具均透過 doclist-viewer 返回互動式結果，支援點擊列、內嵌詳情及
-跨檢視器導覽。
+資料列表類的 `_list` 工具會透過 doclist-viewer 返回互動式結果，支援點擊列、
+內嵌詳情及跨檢視器導覽；專用於附件的 `erpnext_file_list` 不會呈現
+doclist-viewer。通用與專用的文件讀取會使用 doc-viewer，但銷售訂單、銷售發票及
+報價單仍保留專用的 invoice-viewer。
 
 - **Sales（銷售）** — 客戶、銷售訂單、發票及報價單，含完整的 CRUD、提交與取消。
 - **Purchasing（採購）** — 供應商、採購訂單、採購發票、收貨單及供應商報價單。
@@ -234,8 +248,8 @@ node build-all.mjs
 - **Manufacturing（製造）** — 物料清單（BOM）、工單及工作卡。
 - **CRM** — 潛在客戶、商機、聯絡人及行銷活動。
 - **Assets（資產）** — 資產、異動、維護紀錄及類別。
-- **Operations（作業）** — 任何 DocType 的通用 CRUD、原生指派，以及附件清單
-  與上傳（`erpnext_doc_*`、`erpnext_file_list`、`erpnext_file_upload`）。
+- **Operations（作業）** — 任何 DocType 的通用 CRUD、原生指派，以及附件清單、
+  上傳或由主機代理下載（`erpnext_doc_*`、`erpnext_file_*`）。
 - **Kanban（看板）** — 支援拖放的 Task、Opportunity、Issue 可讀寫看板。
 - **Analytics（分析）** — 圖表（長條圖、面積圖、樹狀圖、雷達圖、散佈圖、損益表
   等）、含迷你圖的 KPI，以及銷售漏斗。
@@ -245,12 +259,14 @@ node build-all.mjs
 
 ## 環境變數
 
-| 變數                   | 必填 | 說明                                                                                                      |
-| ---------------------- | ---- | --------------------------------------------------------------------------------------------------------- |
-| `ERPNEXT_URL`          | 是   | ERPNext 基礎 URL — 自行託管（例如 `http://localhost:8000`）或雲端（例如 `https://mycompany.erpnext.com`） |
-| `ERPNEXT_API_KEY`      | 是   | 來自使用者設定的 API Key                                                                                  |
-| `ERPNEXT_API_SECRET`   | 是   | 來自使用者設定的 API Secret                                                                               |
-| `MCP_MRTR_SIGNING_KEY` | 否   | 恰為 64 個小寫十六進位字元；啟用已簽章的模糊連結 elicitation。**僅限單一執行個體部署**，詳見下方說明      |
+| 變數                         | 必填 | 說明                                                                                                      |
+| ---------------------------- | ---- | --------------------------------------------------------------------------------------------------------- |
+| `ERPNEXT_URL`                | 是   | ERPNext 基礎 URL — 自行託管（例如 `http://localhost:8000`）或雲端（例如 `https://mycompany.erpnext.com`） |
+| `ERPNEXT_API_KEY`            | 是   | 來自使用者設定的 API Key                                                                                  |
+| `ERPNEXT_API_SECRET`         | 是   | 來自使用者設定的 API Secret                                                                               |
+| `ERPNEXT_MAX_UPLOAD_BYTES`   | 否   | 解碼後檔案上傳大小上限（正整數位元組；預設 10 MiB）                                                       |
+| `ERPNEXT_MAX_DOWNLOAD_BYTES` | 否   | 附件下載大小上限（正整數位元組；預設 10 MiB）                                                             |
+| `MCP_MRTR_SIGNING_KEY`       | 否   | 恰為 64 個小寫十六進位字元；啟用已簽章的模糊連結 elicitation。**僅限單一執行個體部署**，詳見下方說明      |
 
 MRTR 為選用功能。未設定此金鑰，或用戶端未宣告 elicitation
 時，模糊連結會維持既有的 可操作歧義錯誤，而不會要求選擇。

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@casys/mcp-erpnext",
-  "version": "3.1.0-beta.1",
+  "version": "3.1.0-beta.2",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {
     "age": "PT24H",

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,16 +6,17 @@ The viewer and tooling layer is mature. This phase turns mcp-erpnext from a
 single-instance stdio/HTTP server into a multi-tenant, ERP-agnostic platform
 reachable through a shared MCP bridge with real identity.
 
-| Item                    | Description                                                                                                                                                                                                                      | Status      |
-| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| **MCP bridge wiring**   | Connect to a Deno Deploy relay (local tunnel → cloud → host) so viewers and KPI feeds can be published and shared outside a single host session, not just spawned per-client over stdio.                                         | In progress |
-| **ERP-agnostic core**   | Extract the Frappe/ERPNext REST client behind an adapter interface so the same tool catalog and viewers can target other ERP backends. ERPNext becomes the first adapter rather than a hard dependency.                          | Next        |
-| **Zitadel auth (OIDC)** | Wire [Zitadel](https://zitadel.com) as the OAuth2/OIDC provider for the HTTP transport: JWT/JWKS validation and per-tool scope enforcement (`erpnext:read` vs `erpnext:write`). Prerequisite for multi-tenant bridge deployment. | Done        |
+| Item                    | Description                                                                                                                                                                                                                    | Status      |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
+| **MCP bridge wiring**   | Connect to a Deno Deploy relay (local tunnel → cloud → host) so viewers and KPI feeds can be published and shared outside a single host session, not just spawned per-client over stdio.                                       | In progress |
+| **ERP-agnostic core**   | Extract the Frappe/ERPNext REST client behind an adapter interface so the same tool catalog and viewers can target other ERP backends. ERPNext becomes the first adapter rather than a hard dependency.                        | Next        |
+| **Zitadel auth (OIDC)** | Generic HTTP Bearer/JWT/JWKS validation and RFC 9728 metadata are wired. Validate the Zitadel deployment profile and add per-tool scope enforcement (`erpnext:read` vs `erpnext:write`) before multi-tenant bridge deployment. | In progress |
 
 ## Interactive Additions (P0)
 
-Core mutations and drill-down navigation are shipped across all seven viewers.
-What remains:
+Core mutations and drill-down navigation are shipped across all eight viewers.
+The generic document surface and attachment list/upload/download workflow ship
+in 3.1.0-beta.2. What remains:
 
 | Interaction                | Viewer                         | Tool Called                            | Description                                                                                            |
 | -------------------------- | ------------------------------ | -------------------------------------- | ------------------------------------------------------------------------------------------------------ |
@@ -40,6 +41,12 @@ What remains:
 
 ## Ideas / Nice-to-have (P2)
 
+- Experimental coordination transport for versioned `erpnext.document.changed`
+  facts between independently mounted MCP Apps. Keep ephemeral UI signals
+  separate, bind facts to an ERP authority, prevent loops, and let each
+  subscriber invalidate then perform its own canonical read. Dependency topics
+  stay explicit; do not infer which KPI or aggregate a document mutation
+  affects.
 - Manufacturing dashboard (Work Order status, machine utilization)
 - Multi-currency reconciliation viewer
 - Approval queue viewer (pending approvals across doctypes)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Repository layout
 
-Where things live. Tool counts are per file and sum to 124.
+Where things live. Tool counts are per file and sum to 126.
 
 ```
 server.ts           # MCP server (stdio + HTTP + inspector)
@@ -25,7 +25,7 @@ src/
     manufacturing.ts  # 7 manufacturing tools
     crm.ts            # 8 CRM tools
     assets.ts         # 8 asset tools
-    operations.ts     # 10 generic operations tools
+    operations.ts     # 12 generic operations and file tools
     setup.ts          # 3 company/setup tools
     kanban.ts         # 2 read-write kanban tools
     analytics.ts      # 17 analytics tools (charts, KPIs, funnel)
@@ -38,6 +38,7 @@ src/
   *_test.ts           # Tests are colocated with source files
   ui/
     shared/           # ActionButton, InfoField, theme, branding, refresh
+    doc-viewer/       # Generic document fields, child tables, attachments
     doclist-viewer/   # Generic document list (inline detail, chip filters)
     invoice-viewer/   # Invoice display (item drill-down, actions)
     stock-viewer/     # Stock balance (detail panel, sendMessage)

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -7,11 +7,11 @@
 | Tool                           | DocType       | Operations                                       | UI Viewer      |
 | ------------------------------ | ------------- | ------------------------------------------------ | -------------- |
 | `erpnext_customer_list`        | Customer      | List + filters (group, territory, disabled)      | doclist-viewer |
-| `erpnext_customer_get`         | Customer      | Get by name                                      | -              |
+| `erpnext_customer_get`         | Customer      | Get by name                                      | doc-viewer     |
 | `erpnext_customer_create`      | Customer      | Create (name, group, territory, email, type)     | -              |
 | `erpnext_customer_update`      | Customer      | Update (name, group, territory, email, disabled) | -              |
 | `erpnext_sales_order_list`     | Sales Order   | List + filters (customer, status, dates)         | doclist-viewer |
-| `erpnext_sales_order_get`      | Sales Order   | Get by name (with line items)                    | -              |
+| `erpnext_sales_order_get`      | Sales Order   | Get by name (with line items)                    | invoice-viewer |
 | `erpnext_sales_order_create`   | Sales Order   | Create (customer + items + delivery_date)        | -              |
 | `erpnext_sales_order_update`   | Sales Order   | Update (delivery_date, items)                    | -              |
 | `erpnext_sales_order_submit`   | Sales Order   | Submit (Draft → To Deliver and Bill)             | -              |
@@ -21,7 +21,7 @@
 | `erpnext_sales_invoice_create` | Sales Invoice | Create (customer + items + dates)                | -              |
 | `erpnext_sales_invoice_submit` | Sales Invoice | Submit (Draft → Unpaid)                          | -              |
 | `erpnext_quotation_list`       | Quotation     | List + filters (party, status)                   | doclist-viewer |
-| `erpnext_quotation_get`        | Quotation     | Get by name (with line items)                    | -              |
+| `erpnext_quotation_get`        | Quotation     | Get by name (with line items)                    | invoice-viewer |
 | `erpnext_quotation_create`     | Quotation     | Create (Customer/Lead + items + dates)           | -              |
 
 ### Inventory (9 tools)
@@ -29,13 +29,13 @@
 | Tool                         | DocType     | Operations                                        | UI Viewer      |
 | ---------------------------- | ----------- | ------------------------------------------------- | -------------- |
 | `erpnext_item_list`          | Item        | List + filters (group, stock flag, disabled)      | doclist-viewer |
-| `erpnext_item_get`           | Item        | Get by name/code                                  | -              |
+| `erpnext_item_get`           | Item        | Get by name/code                                  | doc-viewer     |
 | `erpnext_item_create`        | Item        | Create (code, name, group, uom, rate)             | -              |
 | `erpnext_item_update`        | Item        | Update (name, group, rate, description, disabled) | -              |
 | `erpnext_stock_balance`      | Bin         | List stock balances (item, warehouse)             | stock-viewer   |
 | `erpnext_warehouse_list`     | Warehouse   | List + filters (company, type)                    | doclist-viewer |
 | `erpnext_stock_entry_list`   | Stock Entry | List + filters (type, dates)                      | doclist-viewer |
-| `erpnext_stock_entry_get`    | Stock Entry | Get by name (with item details)                   | -              |
+| `erpnext_stock_entry_get`    | Stock Entry | Get by name (with item details)                   | doc-viewer     |
 | `erpnext_stock_entry_create` | Stock Entry | Create (type + items + warehouses)                | -              |
 
 ### Accounting (6 tools)
@@ -44,23 +44,23 @@
 | ------------------------------ | ------------- | ------------------------------------------------------ | -------------- |
 | `erpnext_account_list`         | Account       | List chart of accounts + filters (root_type, is_group) | doclist-viewer |
 | `erpnext_journal_entry_list`   | Journal Entry | List + filters (voucher_type, dates)                   | doclist-viewer |
-| `erpnext_journal_entry_get`    | Journal Entry | Get by name (with accounts)                            | -              |
+| `erpnext_journal_entry_get`    | Journal Entry | Get by name (with accounts)                            | doc-viewer     |
 | `erpnext_journal_entry_create` | Journal Entry | Create (voucher_type + balanced accounts)              | -              |
 | `erpnext_payment_entry_list`   | Payment Entry | List + filters (type, party, dates)                    | doclist-viewer |
-| `erpnext_payment_entry_get`    | Payment Entry | Get by name (with references)                          | -              |
+| `erpnext_payment_entry_get`    | Payment Entry | Get by name (with references)                          | doc-viewer     |
 
 ### HR (12 tools)
 
 | Tool                               | DocType           | Operations                                         | UI Viewer      |
 | ---------------------------------- | ----------------- | -------------------------------------------------- | -------------- |
 | `erpnext_employee_list`            | Employee          | List + filters (department, status, company)       | doclist-viewer |
-| `erpnext_employee_get`             | Employee          | Get by ID                                          | -              |
+| `erpnext_employee_get`             | Employee          | Get by ID                                          | doc-viewer     |
 | `erpnext_attendance_list`          | Attendance        | List + filters (employee, status, dates)           | doclist-viewer |
 | `erpnext_leave_application_list`   | Leave Application | List + filters (employee, status, type)            | doclist-viewer |
-| `erpnext_leave_application_get`    | Leave Application | Get by name                                        | -              |
+| `erpnext_leave_application_get`    | Leave Application | Get by name                                        | doc-viewer     |
 | `erpnext_leave_application_create` | Leave Application | Create (employee, type, dates, reason)             | -              |
 | `erpnext_salary_slip_list`         | Salary Slip       | List + filters (employee, status, dates)           | doclist-viewer |
-| `erpnext_salary_slip_get`          | Salary Slip       | Get by name (with earnings/deductions)             | -              |
+| `erpnext_salary_slip_get`          | Salary Slip       | Get by name (with earnings/deductions)             | doc-viewer     |
 | `erpnext_payroll_entry_list`       | Payroll Entry     | List + filters (company, status)                   | doclist-viewer |
 | `erpnext_expense_claim_list`       | Expense Claim     | List + filters (employee, status, approval_status) | doclist-viewer |
 | `erpnext_expense_claim_create`     | Expense Claim     | Create (employee + expenses[] child table)         | -              |
@@ -71,14 +71,14 @@
 | Tool                     | DocType   | Operations                                           | UI Viewer      |
 | ------------------------ | --------- | ---------------------------------------------------- | -------------- |
 | `erpnext_project_list`   | Project   | List + filters (status, company)                     | doclist-viewer |
-| `erpnext_project_get`    | Project   | Get by name                                          | -              |
+| `erpnext_project_get`    | Project   | Get by name                                          | doc-viewer     |
 | `erpnext_project_create` | Project   | Create (name, status, dates, budget, company)        | -              |
 | `erpnext_task_list`      | Task      | List + filters (project, status, priority)           | doclist-viewer |
-| `erpnext_task_get`       | Task      | Get by name (with dependencies)                      | -              |
+| `erpnext_task_get`       | Task      | Get by name (with dependencies)                      | doc-viewer     |
 | `erpnext_task_create`    | Task      | Create + native assignment (assignees, ToDo details) | -              |
 | `erpnext_task_update`    | Task      | Update + native assignment (assignees, ToDo details) | -              |
 | `erpnext_timesheet_list` | Timesheet | List + filters (employee, project, status)           | doclist-viewer |
-| `erpnext_timesheet_get`  | Timesheet | Get by name (with time log details)                  | -              |
+| `erpnext_timesheet_get`  | Timesheet | Get by name (with time log details)                  | doc-viewer     |
 
 ### Setup (3 tools)
 
@@ -88,26 +88,29 @@
 | `erpnext_company_list`   | Company | List companies (name, abbr, currency, country)         | doclist-viewer |
 | `erpnext_company_create` | Company | Create company (name, abbr, currency, country, domain) | -              |
 
-### Generic Operations (10 tools)
+### Generic Operations (12 tools)
 
-| Tool                   | DocType | Operations                                       | UI Viewer      |
-| ---------------------- | ------- | ------------------------------------------------ | -------------- |
-| `erpnext_doc_create`   | Any     | Create any document (doctype + data object)      | -              |
-| `erpnext_doc_update`   | Any     | Update any document (partial patch)              | -              |
-| `erpnext_doc_delete`   | Any     | Delete any document (Draft only)                 | -              |
-| `erpnext_doc_submit`   | Any     | Submit any submittable document                  | -              |
-| `erpnext_doc_cancel`   | Any     | Cancel any submitted document                    | -              |
-| `erpnext_doc_get`      | Any     | Get any document by DocType + name               | -              |
-| `erpnext_doc_list`     | Any     | List any DocType with field/filter/limit control | doclist-viewer |
-| `erpnext_doc_assign`   | Any     | Native assignment (ToDo + notification) to users | -              |
-| `erpnext_doc_unassign` | Any     | Remove one user's native assignment              | -              |
+| Tool                    | DocType | Operations                                       | UI Viewer      |
+| ----------------------- | ------- | ------------------------------------------------ | -------------- |
+| `erpnext_doc_create`    | Any     | Create any document (doctype + data object)      | -              |
+| `erpnext_doc_update`    | Any     | Update any document (partial patch)              | -              |
+| `erpnext_doc_delete`    | Any     | Delete any document (Draft only)                 | -              |
+| `erpnext_doc_submit`    | Any     | Submit any submittable document                  | -              |
+| `erpnext_doc_cancel`    | Any     | Cancel any submitted document                    | -              |
+| `erpnext_doc_get`       | Any     | Get any document by DocType + name               | doc-viewer     |
+| `erpnext_doc_list`      | Any     | List any DocType with field/filter/limit control | doclist-viewer |
+| `erpnext_doc_assign`    | Any     | Native assignment (ToDo + notification) to users | -              |
+| `erpnext_doc_unassign`  | Any     | Remove one user's native assignment              | -              |
+| `erpnext_file_list`     | File    | List files attached to an exact document         | -              |
+| `erpnext_file_upload`   | File    | Upload and attach private-by-default file data   | -              |
+| `erpnext_file_download` | File    | App-only authenticated bounded download          | doc-viewer     |
 
 ### Kanban (2 tools)
 
 | Tool                       | DocType                    | Operations                                                                                     | UI Viewer     |
 | -------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------- | ------------- |
 | `erpnext_kanban_get_board` | Task / Opportunity / Issue | Get normalized kanban board with columns, cards, transitions, pagination, and refresh metadata | kanban-viewer |
-| `erpnext_kanban_move_card` | Task / Opportunity / Issue | Execute validated move with optimistic reconciliation and business error payloads              | kanban-viewer |
+| `erpnext_kanban_move_card` | Task / Opportunity / Issue | Execute validated move with optimistic reconciliation and business error payloads              | -             |
 
 ### Analytics (17 tools)
 
@@ -136,15 +139,15 @@
 | Tool                              | DocType            | Operations                                    | UI Viewer      |
 | --------------------------------- | ------------------ | --------------------------------------------- | -------------- |
 | `erpnext_supplier_list`           | Supplier           | List + filters (group, type, disabled)        | doclist-viewer |
-| `erpnext_supplier_get`            | Supplier           | Get by name                                   | -              |
+| `erpnext_supplier_get`            | Supplier           | Get by name                                   | doc-viewer     |
 | `erpnext_supplier_create`         | Supplier           | Create (name, group, type, country, currency) | -              |
 | `erpnext_purchase_order_list`     | Purchase Order     | List + filters (supplier, status, dates)      | doclist-viewer |
-| `erpnext_purchase_order_get`      | Purchase Order     | Get by name (with line items)                 | -              |
+| `erpnext_purchase_order_get`      | Purchase Order     | Get by name (with line items)                 | doc-viewer     |
 | `erpnext_purchase_order_create`   | Purchase Order     | Create (supplier + items + schedule_date)     | -              |
 | `erpnext_purchase_invoice_list`   | Purchase Invoice   | List + filters (supplier, status, dates)      | doclist-viewer |
-| `erpnext_purchase_invoice_get`    | Purchase Invoice   | Get by name (with line items)                 | -              |
+| `erpnext_purchase_invoice_get`    | Purchase Invoice   | Get by name (with line items)                 | doc-viewer     |
 | `erpnext_purchase_receipt_list`   | Purchase Receipt   | List + filters (supplier, status, dates)      | doclist-viewer |
-| `erpnext_purchase_receipt_get`    | Purchase Receipt   | Get by name (with received items)             | -              |
+| `erpnext_purchase_receipt_get`    | Purchase Receipt   | Get by name (with received items)             | doc-viewer     |
 | `erpnext_supplier_quotation_list` | Supplier Quotation | List + filters (supplier, status)             | doclist-viewer |
 
 ### Delivery (5 tools)
@@ -152,34 +155,34 @@
 | Tool                           | DocType       | Operations                                      | UI Viewer      |
 | ------------------------------ | ------------- | ----------------------------------------------- | -------------- |
 | `erpnext_delivery_note_list`   | Delivery Note | List + filters (customer, status, dates)        | doclist-viewer |
-| `erpnext_delivery_note_get`    | Delivery Note | Get by name (with delivered items)              | -              |
+| `erpnext_delivery_note_get`    | Delivery Note | Get by name (with delivered items)              | doc-viewer     |
 | `erpnext_delivery_note_create` | Delivery Note | Create (customer + items + against_sales_order) | -              |
 | `erpnext_shipment_list`        | Shipment      | List + filters (status, carrier, dates)         | doclist-viewer |
-| `erpnext_shipment_get`         | Shipment      | Get by name (with parcels)                      | -              |
+| `erpnext_shipment_get`         | Shipment      | Get by name (with parcels)                      | doc-viewer     |
 
 ### Manufacturing (7 tools)
 
 | Tool                        | DocType    | Operations                                               | UI Viewer      |
 | --------------------------- | ---------- | -------------------------------------------------------- | -------------- |
 | `erpnext_bom_list`          | BOM        | List + filters (item, is_active, is_default)             | doclist-viewer |
-| `erpnext_bom_get`           | BOM        | Get by name (with raw materials + operations)            | -              |
+| `erpnext_bom_get`           | BOM        | Get by name (with raw materials + operations)            | doc-viewer     |
 | `erpnext_work_order_list`   | Work Order | List + filters (production_item, status, dates)          | doclist-viewer |
-| `erpnext_work_order_get`    | Work Order | Get by name (with operations + materials)                | -              |
+| `erpnext_work_order_get`    | Work Order | Get by name (with operations + materials)                | doc-viewer     |
 | `erpnext_work_order_create` | Work Order | Create (production_item, bom_no, qty, dates, warehouses) | -              |
 | `erpnext_job_card_list`     | Job Card   | List + filters (work_order, status, operation)           | doclist-viewer |
-| `erpnext_job_card_get`      | Job Card   | Get by name (with time logs + material transfers)        | -              |
+| `erpnext_job_card_get`      | Job Card   | Get by name (with time logs + material transfers)        | doc-viewer     |
 
 ### CRM (8 tools)
 
 | Tool                       | DocType     | Operations                                          | UI Viewer      |
 | -------------------------- | ----------- | --------------------------------------------------- | -------------- |
 | `erpnext_lead_list`        | Lead        | List + filters (status, lead_owner, source)         | doclist-viewer |
-| `erpnext_lead_get`         | Lead        | Get by name                                         | -              |
+| `erpnext_lead_get`         | Lead        | Get by name                                         | doc-viewer     |
 | `erpnext_lead_create`      | Lead        | Create (name, company, email, phone, source, owner) | -              |
 | `erpnext_opportunity_list` | Opportunity | List + filters (status, owner, party)               | doclist-viewer |
-| `erpnext_opportunity_get`  | Opportunity | Get by name (with items + competitors)              | -              |
+| `erpnext_opportunity_get`  | Opportunity | Get by name (with items + competitors)              | doc-viewer     |
 | `erpnext_contact_list`     | Contact     | List + filters (company, status)                    | doclist-viewer |
-| `erpnext_contact_get`      | Contact     | Get by name                                         | -              |
+| `erpnext_contact_get`      | Contact     | Get by name                                         | doc-viewer     |
 | `erpnext_campaign_list`    | Campaign    | List + filters (campaign_type)                      | doclist-viewer |
 
 ### Assets (8 tools)
@@ -187,35 +190,35 @@
 | Tool                             | DocType           | Operations                                             | UI Viewer      |
 | -------------------------------- | ----------------- | ------------------------------------------------------ | -------------- |
 | `erpnext_asset_list`             | Asset             | List + filters (status, category, location, custodian) | doclist-viewer |
-| `erpnext_asset_get`              | Asset             | Get by name (with depreciation + maintenance)          | -              |
+| `erpnext_asset_get`              | Asset             | Get by name (with depreciation + maintenance)          | doc-viewer     |
 | `erpnext_asset_create`           | Asset             | Create (name, category, company, purchase_date, cost)  | -              |
 | `erpnext_asset_movement_list`    | Asset Movement    | List + filters (purpose, dates)                        | doclist-viewer |
-| `erpnext_asset_movement_get`     | Asset Movement    | Get by name (with assets moved)                        | -              |
+| `erpnext_asset_movement_get`     | Asset Movement    | Get by name (with assets moved)                        | doc-viewer     |
 | `erpnext_asset_maintenance_list` | Asset Maintenance | List + filters (asset_name, maintenance_status)        | doclist-viewer |
-| `erpnext_asset_maintenance_get`  | Asset Maintenance | Get by name (with maintenance tasks)                   | -              |
+| `erpnext_asset_maintenance_get`  | Asset Maintenance | Get by name (with maintenance tasks)                   | doc-viewer     |
 | `erpnext_asset_category_list`    | Asset Category    | List all asset categories                              | doclist-viewer |
 
 ---
 
 ## Available Operations (Generic)
 
-The `operations.ts` tools provide generic CRUD and native file uploads for any
-ERPNext DocType:
+The `operations.ts` tools provide generic CRUD and native attachment workflows
+for any ERPNext DocType:
 
-| Operation    | Tool                   | Notes                                                   |
-| ------------ | ---------------------- | ------------------------------------------------------- |
-| **Create**   | `erpnext_doc_create`   | Create a document of any DocType                        |
-| **Update**   | `erpnext_doc_update`   | Partial patch — pass only fields to change              |
-| **Delete**   | `erpnext_doc_delete`   | Draft documents only; submitted must be cancelled first |
-| **Submit**   | `erpnext_doc_submit`   | Calls `frappe.client.submit`                            |
-| **Cancel**   | `erpnext_doc_cancel`   | Calls `frappe.client.cancel`                            |
-| **Get**      | `erpnext_doc_get`      | For DocTypes without a dedicated `_get` tool            |
-| **List**     | `erpnext_doc_list`     | Full control: fields, filters, limit, order_by          |
-| **Assign**   | `erpnext_doc_assign`   | Add a native assignment (ToDo) to a user                |
-| **Unassign** | `erpnext_doc_unassign` | Remove a user's native assignment                       |
-
-| **Upload** | `erpnext_file_upload` | Attach base64 bytes as a native private
-File by default |
+| Operation    | Tool                    | Notes                                                   |
+| ------------ | ----------------------- | ------------------------------------------------------- |
+| **Create**   | `erpnext_doc_create`    | Create a document of any DocType                        |
+| **Update**   | `erpnext_doc_update`    | Partial patch — pass only fields to change              |
+| **Delete**   | `erpnext_doc_delete`    | Draft documents only; submitted must be cancelled first |
+| **Submit**   | `erpnext_doc_submit`    | Calls `frappe.client.submit`                            |
+| **Cancel**   | `erpnext_doc_cancel`    | Calls `frappe.client.cancel`                            |
+| **Get**      | `erpnext_doc_get`       | For DocTypes without a dedicated `_get` tool            |
+| **List**     | `erpnext_doc_list`      | Full control: fields, filters, limit, order_by          |
+| **Assign**   | `erpnext_doc_assign`    | Add a native assignment (ToDo) to a user                |
+| **Unassign** | `erpnext_doc_unassign`  | Remove a user's native assignment                       |
+| **Files**    | `erpnext_file_list`     | List files attached to an exact document                |
+| **Upload**   | `erpnext_file_upload`   | Attach base64 bytes as a private File by default        |
+| **Download** | `erpnext_file_download` | App-only authenticated and bounded host download        |
 
 Specific DocTypes also have dedicated submit/cancel tools:
 `erpnext_sales_order_submit/cancel`, `erpnext_sales_invoice_submit`.
@@ -225,10 +228,11 @@ Specific DocTypes also have dedicated submit/cancel tools:
 
 ---
 
-## UI Viewers (7 active)
+## UI Viewers (8 active)
 
 | Viewer           | URI                               | Usage                                                                                                                                                                            |
 | ---------------- | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `doc-viewer`     | `ui://mcp-erpnext/doc-viewer`     | Generic record fields, child tables, guarded workflow actions, and capability-gated attachment list/upload/download                                                              |
 | `doclist-viewer` | `ui://mcp-erpnext/doclist-viewer` | Generic table with sort, filter, pagination, CSV export, and refresh-aware revalidation                                                                                          |
 | `invoice-viewer` | `ui://mcp-erpnext/invoice-viewer` | Single invoice display with refresh-aware revalidation                                                                                                                           |
 | `stock-viewer`   | `ui://mcp-erpnext/stock-viewer`   | Stock balance table with refresh-aware revalidation                                                                                                                              |
@@ -303,7 +307,8 @@ Specific DocTypes also have dedicated submit/cancel tools:
 - **Linked document chains**: No tool to follow Sales Order → Delivery Note →
   Sales Invoice automatically
 - **Print format**: No tool to get printable HTML/PDF
-- **File attachments**: No download support
+- **File attachments**: No delete, versioning, preview, or ranged/chunked
+  download support; list, upload, and bounded host-mediated download are covered
 - **Custom fields**: Work via Frappe REST but not documented/tested
 - **Amend**: Frappe amend workflow not implemented
 - **Get Report**: `callMethod()` exists but no report-specific tool
@@ -316,14 +321,14 @@ Specific DocTypes also have dedicated submit/cancel tools:
    `purchasing.ts` alongside suppliers, receipts, and quotations.
    `accounting.ts` focuses on accounts, journal entries, and payment entries.
 
-2. **`erpnext_doc_*` as escape hatch** — The 9 generic operations tools cover
+2. **`erpnext_doc_*` as escape hatch** — The generic document operations cover
    any DocType not yet wrapped. They are the recommended approach for one-off
    operations rather than adding more typed tools.
 
-3. **`_get` tools have no `_meta.ui`** — Only `sales_invoice_get` uses
-   `invoice-viewer`. Other `_get` tools return raw JSON. Typed viewers for
-   individual documents (customer detail, asset detail, etc.) remain a future
-   improvement.
+3. **Document reads use a generic surface** — Sales Order, Sales Invoice, and
+   Quotation retain `invoice-viewer`; the other dedicated `_get` tools and
+   `erpnext_doc_get` use `doc-viewer`. Hosts without MCP Apps still receive the
+   ordinary tool result.
 
 4. **Expense Claim child table pattern** — `erpnext_expense_claim_create`
    demonstrates the pattern for child tables via `expenses[]` array, reusable

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,15 +1,17 @@
 # Environment Variables
 
-Read at two different moments, which matters when diagnosing a failure:
+Read timing depends on the subsystem, which matters when diagnosing a failure:
 
-- **ERPNext connection variables** are read lazily, on the first tool call. The
-  server starts and lists its tools without them; the failure surfaces when a
-  tool first needs the client.
-- **Everything else** is read at process startup.
+- **ERPNext connection and file-limit variables** are read when the singleton
+  ERPNext client is first created. This is normally the first tool call, but a
+  configured cache warm-up can create it during startup.
+- **HTTP authentication and MRTR variables** are read at process startup.
+- **Cache variables are lazy:** `MCP_CACHE_ENABLED` is read when the cache
+  singleton is first created, while `MCP_CACHE_TTL_MS` is read for each Frappe
+  document/list cache insertion. `MCP_CACHE_WARM_TOOLS` is read during startup.
 
-Where a value is unrecognised, the listed default applies. The three ERPNext
-connection variables are the exception — a missing one throws, rather than
-falling back.
+Invalid-value behaviour is documented per variable below; there is no global
+fallback rule.
 
 ---
 
@@ -17,12 +19,13 @@ falling back.
 
 Always required, regardless of transport (stdio or HTTP).
 
-| Variable                   | Type                 | Default             | Required | Notes                                                                                                                  |
-| -------------------------- | -------------------- | ------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `ERPNEXT_URL`              | string (URL)         | —                   | **Yes**  | Base URL of the ERPNext instance, e.g. `http://localhost:8000`. No trailing slash.                                     |
-| `ERPNEXT_API_KEY`          | string               | —                   | **Yes**  | API key from ERPNext User Settings → API Access.                                                                       |
-| `ERPNEXT_API_SECRET`       | string               | —                   | **Yes**  | API secret paired with the key above.                                                                                  |
-| `ERPNEXT_MAX_UPLOAD_BYTES` | non-negative integer | `10485760` (10 MiB) | No       | Upper bound in bytes for file uploads. Must be a positive integer; invalid or missing values fall back to the default. |
+| Variable                     | Type             | Default             | Required | Notes                                                                                                                     |
+| ---------------------------- | ---------------- | ------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `ERPNEXT_URL`                | string (URL)     | —                   | **Yes**  | Base URL of the ERPNext instance, e.g. `http://localhost:8000`. No trailing slash.                                        |
+| `ERPNEXT_API_KEY`            | string           | —                   | **Yes**  | API key from ERPNext User Settings → API Access.                                                                          |
+| `ERPNEXT_API_SECRET`         | string           | —                   | **Yes**  | API secret paired with the key above.                                                                                     |
+| `ERPNEXT_MAX_UPLOAD_BYTES`   | positive integer | `10485760` (10 MiB) | No       | Upper bound in decoded bytes for file uploads. Missing or blank uses the default; an invalid value fails client creation. |
+| `ERPNEXT_MAX_DOWNLOAD_BYTES` | positive integer | `10485760` (10 MiB) | No       | Upper bound in bytes for attachment downloads. Missing or blank uses the default; an invalid value fails client creation. |
 
 ---
 
@@ -64,8 +67,9 @@ set.
 ---
 
 <!-- Maintainer source references (not user-facing):
-  ERPNEXT_URL / ERPNEXT_API_KEY / ERPNEXT_API_SECRET / ERPNEXT_MAX_UPLOAD_BYTES:
-    src/api/frappe-client.ts:102 (DEFAULT_MAX_UPLOAD_BYTES), :647-673 (getFrappeClient)
+  ERPNEXT_URL / ERPNEXT_API_KEY / ERPNEXT_API_SECRET /
+  ERPNEXT_MAX_UPLOAD_BYTES / ERPNEXT_MAX_DOWNLOAD_BYTES:
+    src/api/frappe-client.ts (file limits and getFrappeClient)
   MCP_MRTR_SIGNING_KEY:
     src/mrtr/config.ts:23-32 (loadMrtrConfig, regex validation)
   MCP_AUTH_TOKEN / MCP_AUTH_TOKENS / MCP_OAUTH_JWKS_URL:

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,4 +1,4 @@
-# Tools Reference (125)
+# Tools Reference (126)
 
 Full reference for all ERPNext MCP tools. See [README](../README.md) for
 overview.
@@ -11,7 +11,7 @@ overview.
 | `erpnext_company_list`   | Company | List companies                                 |
 | `erpnext_company_create` | Company | Create (name, abbr, currency, country, domain) |
 
-## Sales (17) → doclist-viewer / invoice-viewer
+## Sales (17) → doclist-viewer / doc-viewer / invoice-viewer
 
 | Tool                           | DocType       | Operations                                   |
 | ------------------------------ | ------------- | -------------------------------------------- |
@@ -33,7 +33,7 @@ overview.
 | `erpnext_quotation_get`        | Quotation     | Get with line items                          |
 | `erpnext_quotation_create`     | Quotation     | Create (Customer/Lead + items)               |
 
-## Inventory (9) → doclist-viewer / stock-viewer
+## Inventory (9) → doclist-viewer / doc-viewer / stock-viewer
 
 | Tool                         | DocType     | Operations                                   |
 | ---------------------------- | ----------- | -------------------------------------------- |
@@ -47,7 +47,7 @@ overview.
 | `erpnext_stock_entry_get`    | Stock Entry | Get with item details                        |
 | `erpnext_stock_entry_create` | Stock Entry | Create (type + items + warehouses)           |
 
-## Purchasing (11) → doclist-viewer / invoice-viewer
+## Purchasing (11) → doclist-viewer / doc-viewer
 
 | Tool                              | DocType            | Operations                                    |
 | --------------------------------- | ------------------ | --------------------------------------------- |
@@ -63,7 +63,7 @@ overview.
 | `erpnext_purchase_receipt_get`    | Purchase Receipt   | Get with received items                       |
 | `erpnext_supplier_quotation_list` | Supplier Quotation | List + filters                                |
 
-## Accounting (6) → doclist-viewer
+## Accounting (6) → doclist-viewer / doc-viewer
 
 | Tool                           | DocType       | Operations                                        |
 | ------------------------------ | ------------- | ------------------------------------------------- |
@@ -74,7 +74,7 @@ overview.
 | `erpnext_payment_entry_list`   | Payment Entry | List + filters (type, party, dates)               |
 | `erpnext_payment_entry_get`    | Payment Entry | Get with references                               |
 
-## HR (12) → doclist-viewer
+## HR (12) → doclist-viewer / doc-viewer
 
 | Tool                               | DocType           | Operations                                   |
 | ---------------------------------- | ----------------- | -------------------------------------------- |
@@ -91,7 +91,7 @@ overview.
 | `erpnext_expense_claim_create`     | Expense Claim     | Create (employee + expenses[])               |
 | `erpnext_leave_balance`            | Leave Allocation  | Get allocations by employee                  |
 
-## Project (9) → doclist-viewer
+## Project (9) → doclist-viewer / doc-viewer
 
 | Tool                     | DocType   | Operations                                           |
 | ------------------------ | --------- | ---------------------------------------------------- |
@@ -105,7 +105,7 @@ overview.
 | `erpnext_timesheet_list` | Timesheet | List + filters (employee, project, status)           |
 | `erpnext_timesheet_get`  | Timesheet | Get with time log details                            |
 
-## Delivery (5) → doclist-viewer
+## Delivery (5) → doclist-viewer / doc-viewer
 
 | Tool                           | DocType       | Operations                                      |
 | ------------------------------ | ------------- | ----------------------------------------------- |
@@ -115,7 +115,7 @@ overview.
 | `erpnext_shipment_list`        | Shipment      | List + filters (status, carrier, dates)         |
 | `erpnext_shipment_get`         | Shipment      | Get with parcels                                |
 
-## Manufacturing (7) → doclist-viewer
+## Manufacturing (7) → doclist-viewer / doc-viewer
 
 | Tool                        | DocType    | Operations                                      |
 | --------------------------- | ---------- | ----------------------------------------------- |
@@ -127,7 +127,7 @@ overview.
 | `erpnext_job_card_list`     | Job Card   | List + filters (work_order, status, operation)  |
 | `erpnext_job_card_get`      | Job Card   | Get with time logs + material transfers         |
 
-## CRM (8) → doclist-viewer
+## CRM (8) → doclist-viewer / doc-viewer
 
 | Tool                       | DocType     | Operations                                   |
 | -------------------------- | ----------- | -------------------------------------------- |
@@ -140,7 +140,7 @@ overview.
 | `erpnext_contact_get`      | Contact     | Get by name                                  |
 | `erpnext_campaign_list`    | Campaign    | List + filters (campaign_type)               |
 
-## Assets (8) → doclist-viewer
+## Assets (8) → doclist-viewer / doc-viewer
 
 | Tool                             | DocType           | Operations                                            |
 | -------------------------------- | ----------------- | ----------------------------------------------------- |
@@ -153,21 +153,22 @@ overview.
 | `erpnext_asset_maintenance_get`  | Asset Maintenance | Get with maintenance tasks                            |
 | `erpnext_asset_category_list`    | Asset Category    | List all categories                                   |
 
-## Generic Operations (11) → doclist-viewer
+## Generic Operations (12) → doc-viewer / doclist-viewer
 
-| Tool                   | Operation | Notes                                             |
-| ---------------------- | --------- | ------------------------------------------------- |
-| `erpnext_doc_create`   | Create    | Any DocType — essential for master data setup     |
-| `erpnext_doc_get`      | Get       | Any document by DocType + name                    |
-| `erpnext_doc_list`     | List      | Any DocType with fields, filters, limit, order_by |
-| `erpnext_doc_update`   | Update    | Partial patch — pass only fields to change        |
-| `erpnext_doc_delete`   | Delete    | Draft documents only                              |
-| `erpnext_doc_submit`   | Submit    | Any submittable document                          |
-| `erpnext_doc_cancel`   | Cancel    | Any submitted document                            |
-| `erpnext_doc_assign`   | Assign    | Native assignment (ToDo + notification) to users  |
-| `erpnext_doc_unassign` | Unassign  | Remove one user's native assignment               |
-| `erpnext_file_list`    | List      | Read attachments and native File metadata         |
-| `erpnext_file_upload`  | Upload    | Attach base64 data as a native File               |
+| Tool                    | Operation | Notes                                                   |
+| ----------------------- | --------- | ------------------------------------------------------- |
+| `erpnext_doc_create`    | Create    | Any DocType — essential for master data setup           |
+| `erpnext_doc_get`       | Get       | Any document by DocType + name                          |
+| `erpnext_doc_list`      | List      | Any DocType with fields, filters, limit, order_by       |
+| `erpnext_doc_update`    | Update    | Partial patch — pass only fields to change              |
+| `erpnext_doc_delete`    | Delete    | Draft documents only                                    |
+| `erpnext_doc_submit`    | Submit    | Any submittable document                                |
+| `erpnext_doc_cancel`    | Cancel    | Any submitted document                                  |
+| `erpnext_doc_assign`    | Assign    | Native assignment (ToDo + notification) to users        |
+| `erpnext_doc_unassign`  | Unassign  | Remove one user's native assignment                     |
+| `erpnext_file_list`     | List      | Read attachments and native File metadata               |
+| `erpnext_file_upload`   | Upload    | Attach base64 data as a native File                     |
+| `erpnext_file_download` | Download  | App-only, authenticated and bounded attachment download |
 
 `erpnext_file_list` requires `attached_to_doctype` and `attached_to_name`. Its
 optional `limit` is an integer from 1 to 500 and defaults to 50.
@@ -178,6 +179,15 @@ Files are private by default (`is_private: false` makes them public), accept no
 local path or URL, are capped at 10 MiB decoded by default (override with
 positive-integer-byte `ERPNEXT_MAX_UPLOAD_BYTES`), require write permission on
 the DocType, and return native `File` metadata.
+
+`erpnext_file_download` is hidden from model tool lists and is callable only by
+an MCP App. It accepts the native `File.name` plus the expected parent DocType
+and document name, re-fetches that File row without cache, verifies its exact
+attachment and private/public path, and downloads it through Frappe's
+authenticated handler. It never follows redirects or accepts an arbitrary URL.
+The response contains one inline MCP resource for the host's `downloadFile`
+channel. Downloads are capped at 10 MiB by default; override the positive byte
+limit with `ERPNEXT_MAX_DOWNLOAD_BYTES`.
 
 ## Kanban (2) → kanban-viewer
 

--- a/server.ts
+++ b/server.ts
@@ -102,7 +102,7 @@ async function main() {
   // Build MCP server
   const server = new McpApp({
     name: "mcp-erpnext",
-    version: "3.1.0-beta.1",
+    version: "3.1.0-beta.2",
     transport: "stateless",
     cache: {
       ttlMs: 3_600_000,

--- a/src/api/frappe-client.ts
+++ b/src/api/frappe-client.ts
@@ -23,6 +23,8 @@ import type {
   FrappeDoc,
   FrappeDocResponse,
   FrappeFile,
+  FrappeFileDownload,
+  FrappeFileDownloadInput,
   FrappeFileUploadInput,
   FrappeListOptions,
   FrappeListResponse,
@@ -64,6 +66,8 @@ export interface FrappeClientConfig {
   timeoutMs?: number;
   /** Maximum decoded file upload size in bytes. Default: 10 MiB. */
   maxUploadBytes?: number;
+  /** Maximum downloaded file size in bytes. Default: 10 MiB. */
+  maxDownloadBytes?: number;
   /**
    * Number of retry attempts on retryable failures (default: 3).
    * Set to 0 to disable retries entirely.
@@ -100,6 +104,156 @@ export interface FrappeClientConfig {
 const DEFAULT_RETRY_STATUSES = [408, 429, 502, 503, 504];
 const DEFAULT_RETRY_METHODS = ["GET"];
 const DEFAULT_MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+const DEFAULT_MAX_DOWNLOAD_BYTES = 10 * 1024 * 1024;
+const MAX_ERROR_BODY_BYTES = 64 * 1024;
+
+class ResponseBodyLimitError extends Error {
+  constructor(label: string, size: number, limit: number) {
+    super(
+      `[FrappeClient] ${label} size ${size} bytes exceeds the ${limit}-byte limit`,
+    );
+    this.name = "ResponseBodyLimitError";
+  }
+}
+
+async function readResponseBytes(
+  response: Response,
+  maxBytes: number,
+  label: string,
+): Promise<Uint8Array> {
+  const declaredLength = response.headers.get("content-length")?.trim();
+  if (declaredLength && /^\d+$/.test(declaredLength)) {
+    const size = Number(declaredLength);
+    if (size > maxBytes) {
+      try {
+        await response.body?.cancel();
+      } catch {
+        // The size rejection is authoritative even if cancelling the body fails.
+      }
+      throw new ResponseBodyLimitError(label, size, maxBytes);
+    }
+  }
+
+  if (!response.body) return new Uint8Array();
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        try {
+          await reader.cancel();
+        } catch {
+          // The size rejection is authoritative even if cancelling fails.
+        }
+        throw new ResponseBodyLimitError(label, total, maxBytes);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+function isUnsafeControl(character: string): boolean {
+  const codePoint = character.codePointAt(0) ?? 0;
+  return codePoint <= 0x1f ||
+    (codePoint >= 0x7f && codePoint <= 0x9f) ||
+    (codePoint >= 0x202a && codePoint <= 0x202e) ||
+    (codePoint >= 0x2066 && codePoint <= 0x2069);
+}
+
+function validateLocalFileUrl(fileUrl: unknown, isPrivate: boolean): string {
+  if (typeof fileUrl !== "string" || fileUrl.length === 0) {
+    throw new Error("[FrappeClient] File.file_url must be a non-empty string");
+  }
+  if (fileUrl !== fileUrl.trim()) {
+    throw new Error(
+      "[FrappeClient] File.file_url must not contain whitespace padding",
+    );
+  }
+
+  const expectedPrefix = isPrivate ? "/private/files/" : "/files/";
+  let decoded = fileUrl;
+  for (let depth = 0; depth < 5; depth++) {
+    if (
+      Array.from(decoded).some(isUnsafeControl) || decoded.includes("\\") ||
+      decoded.includes("?") || decoded.includes("#")
+    ) {
+      throw new Error(
+        "[FrappeClient] File.file_url must be a local Frappe file path without query, fragment, NUL, or backslash",
+      );
+    }
+    if (!decoded.startsWith(expectedPrefix)) {
+      throw new Error(
+        `[FrappeClient] File.file_url does not match is_private=${
+          isPrivate ? 1 : 0
+        }`,
+      );
+    }
+    const fileSegment = decoded.slice(expectedPrefix.length);
+    if (
+      !fileSegment || fileSegment === "." || fileSegment === ".." ||
+      fileSegment.includes("/")
+    ) {
+      throw new Error(
+        "[FrappeClient] File.file_url must contain exactly one safe file segment",
+      );
+    }
+
+    let next: string;
+    try {
+      next = decodeURIComponent(decoded);
+    } catch {
+      throw new Error(
+        "[FrappeClient] File.file_url contains malformed percent encoding",
+      );
+    }
+    if (next === decoded) return fileUrl;
+    decoded = next;
+  }
+
+  throw new Error(
+    "[FrappeClient] File.file_url contains excessive nested percent encoding",
+  );
+}
+
+function sanitizeDownloadFileName(raw: unknown, fileId: string): string {
+  const fallbackId = fileId.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 80) ||
+    "file";
+  if (typeof raw !== "string") return `erpnext-${fallbackId}`;
+
+  const normalized = Array.from(raw.normalize("NFC"))
+    .filter((character) => !isUnsafeControl(character))
+    .join("")
+    .replace(/[\\/:*?"<>|]/g, "_")
+    .trim()
+    .replace(/[. ]+$/g, "");
+  const bounded = Array.from(normalized).slice(0, 255).join("");
+  return !bounded || bounded === "." || bounded === ".."
+    ? `erpnext-${fallbackId}`
+    : bounded;
+}
+
+function normalizeMimeType(raw: string | null): string {
+  const candidate = (raw ?? "").split(";", 1)[0].trim().toLowerCase();
+  return /^[a-z0-9][a-z0-9!#$&^_.+-]*\/[a-z0-9][a-z0-9!#$&^_.+-]*$/i
+      .test(candidate) && candidate !== "application/unknown"
+    ? candidate
+    : "application/octet-stream";
+}
 
 function decodeBase64File(contentBase64: string, maxBytes: number): Uint8Array {
   if (contentBase64.length === 0) {
@@ -232,6 +386,7 @@ export class FrappeClient {
   private authHeader: string;
   private timeoutMs: number;
   private maxUploadBytes: number;
+  private maxDownloadBytes: number;
   private retries: number;
   private retryStatuses: number[];
   private retryBackoffMs: number;
@@ -246,6 +401,15 @@ export class FrappeClient {
     if (!Number.isInteger(this.maxUploadBytes) || this.maxUploadBytes <= 0) {
       throw new Error(
         "[FrappeClient] maxUploadBytes must be a positive integer",
+      );
+    }
+    this.maxDownloadBytes = config.maxDownloadBytes ??
+      DEFAULT_MAX_DOWNLOAD_BYTES;
+    if (
+      !Number.isInteger(this.maxDownloadBytes) || this.maxDownloadBytes <= 0
+    ) {
+      throw new Error(
+        "[FrappeClient] maxDownloadBytes must be a positive integer",
       );
     }
     this.retries = config.retries ?? 3;
@@ -403,6 +567,178 @@ export class FrappeClient {
     return responseBody as T;
   }
 
+  private buildSameOriginUrl(path: string): string {
+    if (!path.startsWith("/")) {
+      throw new Error("[FrappeClient] Download path must be root-relative");
+    }
+    let base: URL;
+    let target: URL;
+    try {
+      base = new URL(this.baseUrl);
+      target = new URL(`${this.baseUrl}${path}`);
+    } catch {
+      throw new Error("[FrappeClient] baseUrl must be a valid absolute URL");
+    }
+    if (target.origin !== base.origin) {
+      throw new Error("[FrappeClient] Refusing a cross-origin download");
+    }
+    return target.href;
+  }
+
+  private async requestBinary(
+    path: string,
+  ): Promise<{ bytes: Uint8Array; mimeType: string }> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= this.retries; attempt++) {
+      try {
+        return await this.requestBinaryOnce(path);
+      } catch (err) {
+        lastError = err;
+        if (attempt === this.retries || !this.isRetryable(err, "GET")) {
+          throw err;
+        }
+        const delay = this.computeBackoff(attempt, err);
+        if (delay > 0) {
+          await new Promise((resolve) => setTimeout(resolve, delay));
+        }
+      }
+    }
+    throw lastError;
+  }
+
+  private async requestBinaryOnce(
+    path: string,
+  ): Promise<{ bytes: Uint8Array; mimeType: string }> {
+    const url = this.buildSameOriginUrl(path);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "GET",
+        headers: {
+          "Authorization": this.authHeader,
+          "Accept": "*/*",
+          "Cache-Control": "no-store",
+        },
+        cache: "no-store",
+        redirect: "manual",
+        signal: controller.signal,
+      });
+    } catch (err) {
+      clearTimeout(timer);
+      if (err instanceof Error && err.name === "AbortError") {
+        throw new FrappeAPIError(
+          `Request timed out after ${this.timeoutMs}ms: GET ${path}`,
+          408,
+          null,
+        );
+      }
+      throw new FrappeAPIError(
+        `Network error on GET ${path}: ${(err as Error).message}`,
+        0,
+        null,
+      );
+    }
+
+    try {
+      if (
+        response.redirected || response.type === "opaqueredirect" ||
+        (response.status >= 300 && response.status < 400)
+      ) {
+        try {
+          await response.body?.cancel();
+        } catch {
+          // The redirect rejection is authoritative even if cancellation fails.
+        }
+        throw new FrappeAPIError(
+          `GET ${path} refused an HTTP redirect`,
+          response.status,
+          null,
+        );
+      }
+
+      if (!response.ok) {
+        let rawText: string;
+        try {
+          const errorBytes = await readResponseBytes(
+            response,
+            MAX_ERROR_BODY_BYTES,
+            "Error response body",
+          );
+          rawText = new TextDecoder().decode(errorBytes);
+        } catch (err) {
+          if (!(err instanceof ResponseBodyLimitError)) throw err;
+          rawText = err.message;
+        }
+
+        const contentType = response.headers.get("content-type") ?? "";
+        let responseBody: unknown = rawText;
+        if (contentType.includes("application/json") && rawText.length > 0) {
+          try {
+            responseBody = JSON.parse(rawText);
+          } catch {
+            responseBody = rawText;
+          }
+        }
+
+        let message = response.statusText;
+        if (typeof responseBody === "object" && responseBody !== null) {
+          const body = responseBody as Record<string, unknown>;
+          const baseMessage = (body.message as string) ??
+            (body.exc_type as string) ?? response.statusText;
+          const serverDetails = extractServerMessages(body._server_messages);
+          message = serverDetails
+            ? `${baseMessage}: ${serverDetails}`
+            : baseMessage;
+        } else if (
+          typeof responseBody === "string" && responseBody.length > 0
+        ) {
+          message = responseBody.slice(0, 200);
+        }
+
+        throw new FrappeAPIError(
+          `GET ${path} failed: ${message}`,
+          response.status,
+          responseBody,
+          parseRetryAfter(response.headers.get("retry-after")),
+        );
+      }
+
+      const bytes = await readResponseBytes(
+        response,
+        this.maxDownloadBytes,
+        "Downloaded file",
+      );
+      return {
+        bytes,
+        mimeType: normalizeMimeType(response.headers.get("content-type")),
+      };
+    } catch (err) {
+      if (
+        err instanceof FrappeAPIError ||
+        err instanceof ResponseBodyLimitError
+      ) {
+        throw err;
+      }
+      if (err instanceof Error && err.name === "AbortError") {
+        throw new FrappeAPIError(
+          `Request timed out after ${this.timeoutMs}ms: GET ${path}`,
+          408,
+          null,
+        );
+      }
+      throw new FrappeAPIError(
+        `Network error while reading GET ${path}: ${(err as Error).message}`,
+        0,
+        null,
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
   // ── Resource CRUD ───────────────────────────────────────────────────────────
 
   /**
@@ -557,6 +893,87 @@ export class FrappeClient {
   }
 
   /**
+   * Download one File row through Frappe's authenticated download handler.
+   *
+   * The caller supplies the expected attachment owner as a confused-deputy
+   * guard. The File row is fetched fresh, its local path is validated, and the
+   * response stream is stopped as soon as it exceeds `maxDownloadBytes`.
+   */
+  async downloadFile(
+    input: FrappeFileDownloadInput,
+  ): Promise<FrappeFileDownload> {
+    const fileId = input.fileId.trim();
+    const attachedToDoctype = input.attachedToDoctype.trim();
+    const attachedToName = input.attachedToName.trim();
+    if (!fileId) {
+      throw new Error("[FrappeClient] fileId must not be empty");
+    }
+    if (!attachedToDoctype) {
+      throw new Error("[FrappeClient] attachedToDoctype must not be empty");
+    }
+    if (!attachedToName) {
+      throw new Error("[FrappeClient] attachedToName must not be empty");
+    }
+
+    // Deliberately bypass get() so neither stale metadata nor a cached File row
+    // can authorize a download after its attachment or privacy changed.
+    const metadata = await this.request<FrappeDocResponse<FrappeFile>>(
+      "GET",
+      `/api/resource/File/${encodeURIComponent(fileId)}`,
+    );
+    const file = metadata.data;
+    if (file.name !== fileId) {
+      throw new Error("[FrappeClient] File response identity mismatch");
+    }
+    if (
+      file.attached_to_doctype !== attachedToDoctype ||
+      file.attached_to_name !== attachedToName
+    ) {
+      throw new Error(
+        "[FrappeClient] File is not attached to the requested document",
+      );
+    }
+    if (file.is_private !== 0 && file.is_private !== 1) {
+      throw new Error("[FrappeClient] File.is_private must be 0 or 1");
+    }
+
+    const fileUrl = validateLocalFileUrl(
+      file.file_url,
+      file.is_private === 1,
+    );
+    const fileSize = (file as Record<string, unknown>).file_size;
+    if (fileSize !== undefined && fileSize !== null) {
+      if (
+        typeof fileSize !== "number" || !Number.isInteger(fileSize) ||
+        fileSize < 0
+      ) {
+        throw new Error(
+          "[FrappeClient] File.file_size must be a non-negative integer",
+        );
+      }
+      if (fileSize > this.maxDownloadBytes) {
+        throw new ResponseBodyLimitError(
+          "File metadata",
+          fileSize,
+          this.maxDownloadBytes,
+        );
+      }
+    }
+
+    const params = new URLSearchParams({ file_url: fileUrl });
+    const download = await this.requestBinary(
+      `/api/method/frappe.handler.download_file?${params.toString()}`,
+    );
+    return {
+      fileId,
+      fileName: sanitizeDownloadFileName(file.file_name, fileId),
+      mimeType: download.mimeType,
+      bytes: download.bytes,
+      isPrivate: file.is_private === 1,
+    };
+  }
+
+  /**
    * Upload file bytes and attach the native File document to another document.
    * POST /api/method/upload_file
    */
@@ -648,6 +1065,7 @@ export function getFrappeClient(): FrappeClient {
   const apiKey = env("ERPNEXT_API_KEY");
   const apiSecret = env("ERPNEXT_API_SECRET");
   const maxUploadBytesRaw = env("ERPNEXT_MAX_UPLOAD_BYTES");
+  const maxDownloadBytesRaw = env("ERPNEXT_MAX_DOWNLOAD_BYTES");
 
   if (!url) {
     throw new Error(
@@ -669,6 +1087,9 @@ export function getFrappeClient(): FrappeClient {
     cache: getCache(),
     maxUploadBytes: maxUploadBytesRaw?.trim()
       ? Number(maxUploadBytesRaw)
+      : undefined,
+    maxDownloadBytes: maxDownloadBytesRaw?.trim()
+      ? Number(maxDownloadBytesRaw)
       : undefined,
   });
   return _client;

--- a/src/api/frappe-client_test.ts
+++ b/src/api/frappe-client_test.ts
@@ -56,6 +56,14 @@ function mockFetch(responses: Array<MockResponse>) {
   };
 }
 
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  const headers = new Headers(init.headers);
+  if (!headers.has("content-type")) {
+    headers.set("content-type", "application/json");
+  }
+  return new Response(JSON.stringify(body), { ...init, headers });
+}
+
 function makeClient(overrides: Record<string, unknown> = {}) {
   return new FrappeClient({
     baseUrl: "http://localhost:8000",
@@ -480,6 +488,424 @@ Deno.test("getFrappeClient() - treats a blank upload limit as unset", () => {
           setFrappeClient(null);
           try {
             assertEquals(getFrappeClient() instanceof FrappeClient, true);
+          } finally {
+            setFrappeClient(null);
+          }
+        });
+      });
+    });
+  });
+});
+
+// ── downloadFile() ──────────────────────────────────────────────────────────
+
+Deno.test("FrappeClient.downloadFile() - downloads a private attachment with auth and no redirects", async () => {
+  const requests: Array<{ url: string; init?: RequestInit }> = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = async (
+    url: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    requests.push({ url: url.toString(), init });
+    if (requests.length === 1) {
+      return jsonResponse({
+        data: {
+          name: "FILE-001",
+          file_name: "folder/report\u0000.pdf",
+          file_url: "/private/files/report.pdf",
+          file_size: 3,
+          is_private: 1,
+          attached_to_doctype: "Task",
+          attached_to_name: "TASK-001",
+        },
+      });
+    }
+    return new Response(new Uint8Array([0, 255, 1]), {
+      status: 200,
+      headers: {
+        "content-type": "Application/PDF; charset=binary",
+        "content-length": "3",
+        "content-disposition": "attachment; filename=attacker.exe",
+      },
+    });
+  };
+
+  try {
+    const result = await makeClient().downloadFile({
+      fileId: "FILE-001",
+      attachedToDoctype: "Task",
+      attachedToName: "TASK-001",
+    });
+
+    assertEquals(
+      new URL(requests[0].url).pathname,
+      "/api/resource/File/FILE-001",
+    );
+    const downloadUrl = new URL(requests[1].url);
+    assertEquals(downloadUrl.origin, "http://localhost:8000");
+    assertEquals(
+      downloadUrl.pathname,
+      "/api/method/frappe.handler.download_file",
+    );
+    assertEquals(
+      downloadUrl.searchParams.get("file_url"),
+      "/private/files/report.pdf",
+    );
+    assertEquals(requests[1].init?.redirect, "manual");
+    assertEquals(requests[1].init?.cache, "no-store");
+    assertEquals(
+      new Headers(requests[1].init?.headers).get("authorization"),
+      "token test-key:test-secret",
+    );
+    assertEquals(result.fileName, "folder_report.pdf");
+    assertEquals(result.mimeType, "application/pdf");
+    assertEquals(result.bytes, new Uint8Array([0, 255, 1]));
+    assertEquals(result.isPrivate, true);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("FrappeClient.downloadFile() - supports a public local file and MIME fallback", async () => {
+  const original = globalThis.fetch;
+  let call = 0;
+  globalThis.fetch = async (): Promise<Response> => {
+    call++;
+    if (call === 1) {
+      return jsonResponse({
+        data: {
+          name: "FILE-PUBLIC",
+          file_name: "brochure.bin",
+          file_url: "/files/brochure.bin",
+          is_private: 0,
+          attached_to_doctype: "Lead",
+          attached_to_name: "LEAD-001",
+        },
+      });
+    }
+    return new Response(new Uint8Array([7]), {
+      headers: { "content-type": "application/unknown; charset=utf-8" },
+    });
+  };
+
+  try {
+    const result = await makeClient().downloadFile({
+      fileId: "FILE-PUBLIC",
+      attachedToDoctype: "Lead",
+      attachedToName: "LEAD-001",
+    });
+    assertEquals(result.isPrivate, false);
+    assertEquals(result.mimeType, "application/octet-stream");
+    assertEquals(result.bytes, new Uint8Array([7]));
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("FrappeClient.downloadFile() - rejects a mismatched attachment before fetching bytes", async () => {
+  const original = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async (): Promise<Response> => {
+    calls++;
+    return jsonResponse({
+      data: {
+        name: "FILE-001",
+        file_name: "report.pdf",
+        file_url: "/private/files/report.pdf",
+        is_private: 1,
+        attached_to_doctype: "Task",
+        attached_to_name: "TASK-OTHER",
+      },
+    });
+  };
+
+  try {
+    await assertRejects(
+      () =>
+        makeClient().downloadFile({
+          fileId: "FILE-001",
+          attachedToDoctype: "Task",
+          attachedToName: "TASK-001",
+        }),
+      Error,
+      "not attached",
+    );
+    assertEquals(calls, 1);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("FrappeClient.downloadFile() - rejects remote, traversing, encoded, and privacy-mismatched file URLs", async () => {
+  const cases: Array<{ fileUrl: string; isPrivate: 0 | 1 }> = [
+    { fileUrl: "https://evil.example/report.pdf", isPrivate: 1 },
+    { fileUrl: "//evil.example/report.pdf", isPrivate: 0 },
+    { fileUrl: "/api/method/evil", isPrivate: 0 },
+    { fileUrl: "/private/files/../secret.txt", isPrivate: 1 },
+    { fileUrl: "/private/files/%2e%2e", isPrivate: 1 },
+    { fileUrl: "/private/files/%252e%252e", isPrivate: 1 },
+    { fileUrl: "/private/files/a%2fb.pdf", isPrivate: 1 },
+    { fileUrl: "/private/files/a\\b.pdf", isPrivate: 1 },
+    { fileUrl: "/private/files/a.pdf?token=secret", isPrivate: 1 },
+    { fileUrl: "/private/files/%ZZ.pdf", isPrivate: 1 },
+    { fileUrl: "/files/public.pdf", isPrivate: 1 },
+  ];
+
+  for (const testCase of cases) {
+    const original = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = async (): Promise<Response> => {
+      calls++;
+      return jsonResponse({
+        data: {
+          name: "FILE-001",
+          file_name: "report.pdf",
+          file_url: testCase.fileUrl,
+          is_private: testCase.isPrivate,
+          attached_to_doctype: "Task",
+          attached_to_name: "TASK-001",
+        },
+      });
+    };
+
+    try {
+      await assertRejects(
+        () =>
+          makeClient().downloadFile({
+            fileId: "FILE-001",
+            attachedToDoctype: "Task",
+            attachedToName: "TASK-001",
+          }),
+        Error,
+        "file_url",
+      );
+      assertEquals(calls, 1, `must not fetch bytes for ${testCase.fileUrl}`);
+    } finally {
+      globalThis.fetch = original;
+    }
+  }
+});
+
+Deno.test("FrappeClient.downloadFile() - enforces metadata and Content-Length limits", async () => {
+  const input = {
+    fileId: "FILE-001",
+    attachedToDoctype: "Task",
+    attachedToName: "TASK-001",
+  };
+
+  for (const source of ["metadata", "header"] as const) {
+    const original = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = async (): Promise<Response> => {
+      calls++;
+      if (calls === 1) {
+        return jsonResponse({
+          data: {
+            name: "FILE-001",
+            file_name: "report.pdf",
+            file_url: "/private/files/report.pdf",
+            ...(source === "metadata" ? { file_size: 4 } : {}),
+            is_private: 1,
+            attached_to_doctype: "Task",
+            attached_to_name: "TASK-001",
+          },
+        });
+      }
+      return new Response(new Uint8Array([1]), {
+        headers: { "content-length": "4" },
+      });
+    };
+
+    try {
+      await assertRejects(
+        () => makeClient({ maxDownloadBytes: 3 }).downloadFile(input),
+        Error,
+        "exceeds",
+      );
+      assertEquals(calls, source === "metadata" ? 1 : 2);
+    } finally {
+      globalThis.fetch = original;
+    }
+  }
+});
+
+Deno.test("FrappeClient.downloadFile() - stops a lying stream at max plus one", async () => {
+  const original = globalThis.fetch;
+  let calls = 0;
+  let cancelled = false;
+  globalThis.fetch = async (): Promise<Response> => {
+    calls++;
+    if (calls === 1) {
+      return jsonResponse({
+        data: {
+          name: "FILE-001",
+          file_name: "report.pdf",
+          file_url: "/private/files/report.pdf",
+          file_size: 1,
+          is_private: 1,
+          attached_to_doctype: "Task",
+          attached_to_name: "TASK-001",
+        },
+      });
+    }
+    return new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2]));
+          controller.enqueue(new Uint8Array([3, 4]));
+        },
+        cancel() {
+          cancelled = true;
+        },
+      }),
+      { headers: { "content-length": "1" } },
+    );
+  };
+
+  try {
+    await assertRejects(
+      () =>
+        makeClient({ maxDownloadBytes: 3 }).downloadFile({
+          fileId: "FILE-001",
+          attachedToDoctype: "Task",
+          attachedToName: "TASK-001",
+        }),
+      Error,
+      "exceeds",
+    );
+    assertEquals(cancelled, true);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("FrappeClient.downloadFile() - refuses redirects instead of following them", async () => {
+  const original = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async (): Promise<Response> => {
+    calls++;
+    if (calls === 1) {
+      return jsonResponse({
+        data: {
+          name: "FILE-001",
+          file_name: "report.pdf",
+          file_url: "/private/files/report.pdf",
+          is_private: 1,
+          attached_to_doctype: "Task",
+          attached_to_name: "TASK-001",
+        },
+      });
+    }
+    return new Response(null, {
+      status: 302,
+      headers: { location: "https://evil.example/report.pdf" },
+    });
+  };
+
+  try {
+    await assertRejects(
+      () =>
+        makeClient().downloadFile({
+          fileId: "FILE-001",
+          attachedToDoctype: "Task",
+          attachedToName: "TASK-001",
+        }),
+      FrappeAPIError,
+      "refused an HTTP redirect",
+    );
+    assertEquals(calls, 2);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("FrappeClient.downloadFile() - does not reuse cached File metadata", async () => {
+  const original = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async (): Promise<Response> => {
+    calls++;
+    if (calls % 2 === 1) {
+      return jsonResponse({
+        data: {
+          name: "FILE-001",
+          file_name: "report.pdf",
+          file_url: "/private/files/report.pdf",
+          is_private: 1,
+          attached_to_doctype: "Task",
+          attached_to_name: "TASK-001",
+        },
+      });
+    }
+    return new Response(new Uint8Array([calls]));
+  };
+
+  try {
+    const client = makeClient({ cache: new MemoryCache() });
+    const input = {
+      fileId: "FILE-001",
+      attachedToDoctype: "Task",
+      attachedToName: "TASK-001",
+    };
+    await client.downloadFile(input);
+    await client.downloadFile(input);
+    assertEquals(calls, 4);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("FrappeClient - defaults downloads to 10 MiB and validates the limit", async () => {
+  assertThrows(
+    () => makeClient({ maxDownloadBytes: 0 }),
+    Error,
+    "maxDownloadBytes",
+  );
+
+  const original = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async (): Promise<Response> => {
+    calls++;
+    return jsonResponse({
+      data: {
+        name: "FILE-001",
+        file_name: "large.bin",
+        file_url: "/private/files/large.bin",
+        file_size: 10 * 1024 * 1024 + 1,
+        is_private: 1,
+        attached_to_doctype: "Task",
+        attached_to_name: "TASK-001",
+      },
+    });
+  };
+  try {
+    await assertRejects(
+      () =>
+        makeClient().downloadFile({
+          fileId: "FILE-001",
+          attachedToDoctype: "Task",
+          attachedToName: "TASK-001",
+        }),
+      Error,
+      "10485760-byte limit",
+    );
+    assertEquals(calls, 1);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("getFrappeClient() - reads ERPNEXT_MAX_DOWNLOAD_BYTES", () => {
+  withEnv("ERPNEXT_URL", "http://localhost:8000", () => {
+    withEnv("ERPNEXT_API_KEY", "test-key", () => {
+      withEnv("ERPNEXT_API_SECRET", "test-secret", () => {
+        withEnv("ERPNEXT_MAX_DOWNLOAD_BYTES", "0", () => {
+          setFrappeClient(null);
+          try {
+            assertThrows(
+              () => getFrappeClient(),
+              Error,
+              "maxDownloadBytes",
+            );
           } finally {
             setFrappeClient(null);
           }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -66,6 +66,30 @@ export interface FrappeFileUploadInput {
   isPrivate?: boolean;
 }
 
+/** Input for a bounded, authenticated download of an attached Frappe File. */
+export interface FrappeFileDownloadInput {
+  /** Native `File.name` identifier. Never a URL. */
+  fileId: string;
+  /** Expected parent DocType. Used to prevent cross-document downloads. */
+  attachedToDoctype: string;
+  /** Expected parent document name. Used to prevent cross-document downloads. */
+  attachedToName: string;
+}
+
+/** Bytes and trusted metadata returned by a bounded Frappe File download. */
+export interface FrappeFileDownload {
+  /** Native `File.name` identifier. */
+  fileId: string;
+  /** Sanitized filename safe to expose through a `file:///` resource URI. */
+  fileName: string;
+  /** Response MIME type, or `application/octet-stream` when unavailable. */
+  mimeType: string;
+  /** Fully read file bytes, bounded by the configured download limit. */
+  bytes: Uint8Array;
+  /** Whether the File row is private. */
+  isPrivate: boolean;
+}
+
 /** Frappe list API response wrapper. Returned by `GET /api/resource/{doctype}`. */
 export interface FrappeListResponse<T extends FrappeDoc = FrappeDoc> {
   /** Array of documents matching the query */

--- a/src/client.ts
+++ b/src/client.ts
@@ -36,6 +36,33 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
+ * The attachment download tool returns an already-formed MCP result. Keep the
+ * guard deliberately narrow so an ordinary business object with a `content`
+ * property cannot bypass viewer enrichment or JSON serialization.
+ */
+function isSingleEmbeddedBlobResult(value: unknown): boolean {
+  if (!isRecord(value) || !Array.isArray(value.content)) return false;
+  if (Object.keys(value).some((key) => key !== "content")) return false;
+  if (value.content.length !== 2) return false;
+
+  const [summary, embedded] = value.content;
+  if (
+    !isRecord(summary) || summary.type !== "text" ||
+    typeof summary.text !== "string"
+  ) {
+    return false;
+  }
+  if (!isRecord(embedded) || embedded.type !== "resource") return false;
+  if (!isRecord(embedded.resource)) return false;
+
+  const resource = embedded.resource;
+  return typeof resource.uri === "string" &&
+    resource.uri.startsWith("file:///") &&
+    typeof resource.mimeType === "string" &&
+    typeof resource.blob === "string";
+}
+
+/**
  * A mutating tool may opt into viewer refresh only by returning an explicit,
  * valid request for a safe read-back tool. Read-only tools keep the generic
  * same-tool refresh behaviour.
@@ -250,6 +277,12 @@ export class ErpNextToolsClient {
         ) {
           return execution.result;
         }
+        if (
+          tool.name === "erpnext_file_download" &&
+          isSingleEmbeddedBlobResult(execution.result)
+        ) {
+          return execution.result;
+        }
         const result = withSafeUiRefresh(
           execution.result,
           tool,
@@ -293,6 +326,12 @@ export class ErpNextToolsClient {
     }
     const client = getFrappeClient();
     const result = await tool.handler(args, { client });
+    if (
+      tool.name === "erpnext_file_download" &&
+      isSingleEmbeddedBlobResult(result)
+    ) {
+      return result;
+    }
     return withSafeUiRefresh(
       result,
       tool,

--- a/src/client_test.ts
+++ b/src/client_test.ts
@@ -467,6 +467,115 @@ Deno.test("buildHandlersMap - detail objects remain machine-readable without a v
   }
 });
 
+Deno.test("buildHandlersMap - preserves the download EmbeddedResource without duplicating its base64", async () => {
+  const prepared = {
+    content: [
+      { type: "text", text: "Prepared report.pdf for download." },
+      {
+        type: "resource",
+        resource: {
+          uri: "file:///report.pdf",
+          mimeType: "application/pdf",
+          blob: "AP8=",
+        },
+      },
+    ],
+  };
+  const tool: ErpNextTool = {
+    name: "erpnext_file_download",
+    description: "Test-only download probe",
+    category: "operations",
+    inputSchema: { type: "object" },
+    annotations: { readOnlyHint: true },
+    _meta: {
+      ui: {
+        resourceUri: "ui://mcp-erpnext/doc-viewer",
+        visibility: ["app"],
+      },
+    },
+    handler: async () => prepared,
+  };
+  const client = new ErpNextToolsClient();
+  (client as unknown as { tools: ErpNextTool[] }).tools = [tool];
+  setFrappeClient({} as FrappeClient);
+  try {
+    const result = await client.buildHandlersMap().get(tool.name)!({});
+    assertEquals(result, prepared);
+    assertEquals(JSON.stringify(result).split("AP8=").length - 1, 1);
+    assertEquals(
+      "structuredContent" in (result as Record<string, unknown>),
+      false,
+    );
+  } finally {
+    setFrappeClient(null);
+  }
+});
+
+Deno.test("buildHandlersMap - does not grant the preformatted bypass to another tool", async () => {
+  const prepared = {
+    content: [
+      { type: "text", text: "Domain content" },
+      {
+        type: "resource",
+        resource: {
+          uri: "file:///report.pdf",
+          mimeType: "application/pdf",
+          blob: "AP8=",
+        },
+      },
+    ],
+  };
+  const tool: ErpNextTool = {
+    name: "erpnext_domain_content_probe",
+    description: "Test-only domain content probe",
+    category: "setup",
+    inputSchema: { type: "object" },
+    handler: async () => prepared,
+  };
+  const client = new ErpNextToolsClient();
+  (client as unknown as { tools: ErpNextTool[] }).tools = [tool];
+  setFrappeClient({} as FrappeClient);
+  try {
+    const result = await client.buildHandlersMap().get(tool.name)!({}) as {
+      structuredContent: Record<string, unknown>;
+    };
+    assertEquals(result.structuredContent, prepared);
+  } finally {
+    setFrappeClient(null);
+  }
+});
+
+Deno.test("execute - preserves the download EmbeddedResource result", async () => {
+  const prepared = {
+    content: [
+      { type: "text", text: "Prepared report.pdf for download." },
+      {
+        type: "resource",
+        resource: {
+          uri: "file:///report.pdf",
+          mimeType: "application/pdf",
+          blob: "AP8=",
+        },
+      },
+    ],
+  };
+  const tool: ErpNextTool = {
+    name: "erpnext_file_download",
+    description: "Test-only download probe",
+    category: "operations",
+    inputSchema: { type: "object" },
+    handler: async () => prepared,
+  };
+  const client = new ErpNextToolsClient();
+  (client as unknown as { tools: ErpNextTool[] }).tools = [tool];
+  setFrappeClient({} as FrappeClient);
+  try {
+    assertEquals(await client.execute(tool.name, {}), prepared);
+  } finally {
+    setFrappeClient(null);
+  }
+});
+
 Deno.test("execute - bounded tools stay bounded on the direct-execution path", async () => {
   // `execute()` calls handlers directly, with no schema validator in between.
   // A bound declared only in `inputSchema` therefore protects the MCP route and

--- a/src/tools/accounting.ts
+++ b/src/tools/accounting.ts
@@ -9,7 +9,7 @@
 
 import type { FrappeFilter } from "../api/types.ts";
 import type { ErpNextTool } from "./types.ts";
-import { DOCLIST_META } from "./viewer-meta.ts";
+import { DOC_META, DOCLIST_META } from "./viewer-meta.ts";
 import { resolveDynamicLink } from "../api/resolve.ts";
 
 export const accountingTools: ErpNextTool[] = [
@@ -142,6 +142,7 @@ export const accountingTools: ErpNextTool[] = [
   {
     name: "erpnext_journal_entry_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single Journal Entry by name (e.g. JV-00001). Returns full document with accounts.",
     category: "accounting",
@@ -160,7 +161,7 @@ export const accountingTools: ErpNextTool[] = [
         throw new Error("[erpnext_journal_entry_get] 'name' is required");
       }
       const doc = await ctx.client.get("Journal Entry", input.name as string);
-      return { data: doc };
+      return { data: { ...doc, doctype: "Journal Entry" } };
     },
   },
 
@@ -259,6 +260,7 @@ export const accountingTools: ErpNextTool[] = [
   {
     name: "erpnext_payment_entry_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single Payment Entry by name (e.g. PE-00001). Returns full document including references.",
     category: "accounting",
@@ -277,7 +279,7 @@ export const accountingTools: ErpNextTool[] = [
         throw new Error("[erpnext_payment_entry_get] 'name' is required");
       }
       const doc = await ctx.client.get("Payment Entry", input.name as string);
-      return { data: doc };
+      return { data: { ...doc, doctype: "Payment Entry" } };
     },
   },
 

--- a/src/tools/assets.ts
+++ b/src/tools/assets.ts
@@ -9,7 +9,7 @@
 
 import type { FrappeFilter } from "../api/types.ts";
 import type { ErpNextTool } from "./types.ts";
-import { DOCLIST_META } from "./viewer-meta.ts";
+import { DOC_META, DOCLIST_META } from "./viewer-meta.ts";
 import { resolveEmployee } from "../api/resolve.ts";
 
 export const assetsTools: ErpNextTool[] = [
@@ -110,6 +110,7 @@ export const assetsTools: ErpNextTool[] = [
   {
     name: "erpnext_asset_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single Asset by name. Returns full details including depreciation schedule and maintenance logs.",
     category: "assets",
@@ -125,7 +126,7 @@ export const assetsTools: ErpNextTool[] = [
         throw new Error("[erpnext_asset_get] 'name' is required");
       }
       const doc = await ctx.client.get("Asset", input.name as string);
-      return { data: doc };
+      return { data: { ...doc, doctype: "Asset" } };
     },
   },
 
@@ -273,6 +274,7 @@ export const assetsTools: ErpNextTool[] = [
   {
     name: "erpnext_asset_movement_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single Asset Movement by name. Returns full details including assets moved.",
     category: "assets",
@@ -288,7 +290,7 @@ export const assetsTools: ErpNextTool[] = [
         throw new Error("[erpnext_asset_movement_get] 'name' is required");
       }
       const doc = await ctx.client.get("Asset Movement", input.name as string);
-      return { data: doc };
+      return { data: { ...doc, doctype: "Asset Movement" } };
     },
   },
 
@@ -353,6 +355,7 @@ export const assetsTools: ErpNextTool[] = [
   {
     name: "erpnext_asset_maintenance_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single Asset Maintenance record by name. Returns full details including maintenance tasks.",
     category: "assets",
@@ -371,7 +374,7 @@ export const assetsTools: ErpNextTool[] = [
         "Asset Maintenance",
         input.name as string,
       );
-      return { data: doc };
+      return { data: { ...doc, doctype: "Asset Maintenance" } };
     },
   },
 

--- a/src/tools/crm.ts
+++ b/src/tools/crm.ts
@@ -9,7 +9,7 @@
 
 import type { FrappeFilter } from "../api/types.ts";
 import type { ErpNextTool } from "./types.ts";
-import { DOCLIST_META } from "./viewer-meta.ts";
+import { DOC_META, DOCLIST_META } from "./viewer-meta.ts";
 import { resolveDynamicLink } from "../api/resolve.ts";
 
 export const crmTools: ErpNextTool[] = [
@@ -74,6 +74,7 @@ export const crmTools: ErpNextTool[] = [
   {
     name: "erpnext_lead_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single CRM Lead by name. Returns all lead details including contact info.",
     category: "crm",
@@ -89,7 +90,7 @@ export const crmTools: ErpNextTool[] = [
         throw new Error("[erpnext_lead_get] 'name' is required");
       }
       const doc = await ctx.client.get("Lead", input.name as string);
-      return { data: doc };
+      return { data: { ...doc, doctype: "Lead" } };
     },
   },
 
@@ -237,6 +238,7 @@ export const crmTools: ErpNextTool[] = [
   {
     name: "erpnext_opportunity_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single CRM Opportunity by name. Returns full details including items and competitors.",
     category: "crm",
@@ -252,7 +254,7 @@ export const crmTools: ErpNextTool[] = [
         throw new Error("[erpnext_opportunity_get] 'name' is required");
       }
       const doc = await ctx.client.get("Opportunity", input.name as string);
-      return { data: doc };
+      return { data: { ...doc, doctype: "Opportunity" } };
     },
   },
 
@@ -313,6 +315,7 @@ export const crmTools: ErpNextTool[] = [
   {
     name: "erpnext_contact_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description: "Get a single Contact by name. Returns all contact details.",
     category: "crm",
     inputSchema: {
@@ -327,7 +330,7 @@ export const crmTools: ErpNextTool[] = [
         throw new Error("[erpnext_contact_get] 'name' is required");
       }
       const doc = await ctx.client.get("Contact", input.name as string);
-      return { data: doc };
+      return { data: { ...doc, doctype: "Contact" } };
     },
   },
 

--- a/src/tools/delivery.ts
+++ b/src/tools/delivery.ts
@@ -8,7 +8,7 @@
 
 import type { FrappeFilter } from "../api/types.ts";
 import type { ErpNextTool } from "./types.ts";
-import { DOCLIST_META } from "./viewer-meta.ts";
+import { DOC_META, DOCLIST_META } from "./viewer-meta.ts";
 import { resolveCustomer } from "../api/resolve.ts";
 
 export const deliveryTools: ErpNextTool[] = [
@@ -91,6 +91,7 @@ export const deliveryTools: ErpNextTool[] = [
   {
     name: "erpnext_delivery_note_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single Delivery Note by name (e.g. MAT-DN-00001). Returns full document with delivered items.",
     category: "delivery",
@@ -109,7 +110,7 @@ export const deliveryTools: ErpNextTool[] = [
         throw new Error("[erpnext_delivery_note_get] 'name' is required");
       }
       const doc = await ctx.client.get("Delivery Note", input.name as string);
-      return { data: doc };
+      return { data: { ...doc, doctype: "Delivery Note" } };
     },
   },
 
@@ -262,6 +263,7 @@ export const deliveryTools: ErpNextTool[] = [
   {
     name: "erpnext_shipment_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single Shipment by name. Returns full shipment details including parcels.",
     category: "delivery",
@@ -277,7 +279,7 @@ export const deliveryTools: ErpNextTool[] = [
         throw new Error("[erpnext_shipment_get] 'name' is required");
       }
       const doc = await ctx.client.get("Shipment", input.name as string);
-      return { data: doc };
+      return { data: { ...doc, doctype: "Shipment" } };
     },
   },
 ];

--- a/src/tools/doc-viewer-bindings_test.ts
+++ b/src/tools/doc-viewer-bindings_test.ts
@@ -1,0 +1,94 @@
+import { assertEquals } from "@std/assert";
+import type { FrappeClient } from "../api/frappe-client.ts";
+import { allTools, getToolByName } from "./mod.ts";
+
+const DOC_VIEWER_URI = "ui://mcp-erpnext/doc-viewer";
+const INVOICE_VIEWER_URI = "ui://mcp-erpnext/invoice-viewer";
+
+const DOC_VIEWER_GET_BINDINGS = [
+  ["erpnext_journal_entry_get", "Journal Entry"],
+  ["erpnext_payment_entry_get", "Payment Entry"],
+  ["erpnext_asset_get", "Asset"],
+  ["erpnext_asset_movement_get", "Asset Movement"],
+  ["erpnext_asset_maintenance_get", "Asset Maintenance"],
+  ["erpnext_lead_get", "Lead"],
+  ["erpnext_opportunity_get", "Opportunity"],
+  ["erpnext_contact_get", "Contact"],
+  ["erpnext_delivery_note_get", "Delivery Note"],
+  ["erpnext_shipment_get", "Shipment"],
+  ["erpnext_employee_get", "Employee"],
+  ["erpnext_leave_application_get", "Leave Application"],
+  ["erpnext_salary_slip_get", "Salary Slip"],
+  ["erpnext_item_get", "Item"],
+  ["erpnext_stock_entry_get", "Stock Entry"],
+  ["erpnext_bom_get", "BOM"],
+  ["erpnext_work_order_get", "Work Order"],
+  ["erpnext_job_card_get", "Job Card"],
+  ["erpnext_project_get", "Project"],
+  ["erpnext_task_get", "Task"],
+  ["erpnext_timesheet_get", "Timesheet"],
+  ["erpnext_supplier_get", "Supplier"],
+  ["erpnext_purchase_order_get", "Purchase Order"],
+  ["erpnext_purchase_invoice_get", "Purchase Invoice"],
+  ["erpnext_purchase_receipt_get", "Purchase Receipt"],
+  ["erpnext_customer_get", "Customer"],
+] as const;
+
+const SPECIALIZED_GET_BINDINGS = [
+  "erpnext_sales_order_get",
+  "erpnext_sales_invoice_get",
+  "erpnext_quotation_get",
+] as const;
+
+Deno.test("document get tools have an exhaustive viewer binding matrix", () => {
+  const fixedGetNames = allTools
+    .filter((tool) =>
+      tool.name.endsWith("_get") && tool.name !== "erpnext_doc_get"
+    )
+    .map((tool) => tool.name)
+    .sort();
+  const expectedNames = [
+    ...DOC_VIEWER_GET_BINDINGS.map(([name]) => name),
+    ...SPECIALIZED_GET_BINDINGS,
+  ].sort();
+
+  assertEquals(fixedGetNames, expectedNames);
+
+  for (const [name] of DOC_VIEWER_GET_BINDINGS) {
+    assertEquals(
+      getToolByName(name)?._meta?.ui?.resourceUri,
+      DOC_VIEWER_URI,
+      `${name} should use doc-viewer`,
+    );
+  }
+  for (const name of SPECIALIZED_GET_BINDINGS) {
+    assertEquals(
+      getToolByName(name)?._meta?.ui?.resourceUri,
+      INVOICE_VIEWER_URI,
+      `${name} should keep invoice-viewer`,
+    );
+  }
+});
+
+Deno.test("doc-viewer get results expose exact DocType and preserve canonical name", async () => {
+  const canonicalName = "CANONICAL-001";
+  const client = {
+    get: async () => ({
+      name: canonicalName,
+      doctype: "Incorrect upstream DocType",
+    }),
+  } as unknown as FrappeClient;
+
+  for (const [name, doctype] of DOC_VIEWER_GET_BINDINGS) {
+    const tool = getToolByName(name);
+    if (!tool) throw new Error(`Missing tool ${name}`);
+
+    const result = await tool.handler(
+      { name: "human-readable-or-requested-name" },
+      { client },
+    ) as { data: Record<string, unknown> };
+
+    assertEquals(result.data.name, canonicalName, `${name} canonical name`);
+    assertEquals(result.data.doctype, doctype, `${name} explicit DocType`);
+  }
+});

--- a/src/tools/hr.ts
+++ b/src/tools/hr.ts
@@ -8,7 +8,7 @@
 
 import type { FrappeFilter } from "../api/types.ts";
 import type { ErpNextTool } from "./types.ts";
-import { DOCLIST_META } from "./viewer-meta.ts";
+import { DOC_META, DOCLIST_META } from "./viewer-meta.ts";
 import { resolveEmployee, resolveLink } from "../api/resolve.ts";
 
 export const hrTools: ErpNextTool[] = [
@@ -74,6 +74,7 @@ export const hrTools: ErpNextTool[] = [
   {
     name: "erpnext_employee_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single Employee by name/ID (e.g. HR-EMP-00001). Returns all fields.",
     category: "hr",
@@ -103,7 +104,7 @@ export const hrTools: ErpNextTool[] = [
         { allowPartialMatch: false, inputPath: "name" },
       );
       const doc = await ctx.client.get("Employee", employeeId);
-      return { data: doc };
+      return { data: { ...doc, doctype: "Employee" } };
     },
   },
 
@@ -269,6 +270,7 @@ export const hrTools: ErpNextTool[] = [
   {
     name: "erpnext_leave_application_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single Leave Application by name. Returns full document.",
     category: "hr",
@@ -287,7 +289,7 @@ export const hrTools: ErpNextTool[] = [
         "Leave Application",
         input.name as string,
       );
-      return { data: doc };
+      return { data: { ...doc, doctype: "Leave Application" } };
     },
   },
 
@@ -447,6 +449,7 @@ export const hrTools: ErpNextTool[] = [
   {
     name: "erpnext_salary_slip_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single Salary Slip by name/ID. Returns all fields including earnings and deductions.",
     category: "hr",
@@ -465,7 +468,7 @@ export const hrTools: ErpNextTool[] = [
         throw new Error("[erpnext_salary_slip_get] 'name' is required");
       }
       const doc = await ctx.client.get("Salary Slip", input.name as string);
-      return { data: doc };
+      return { data: { ...doc, doctype: "Salary Slip" } };
     },
   },
 

--- a/src/tools/inventory.ts
+++ b/src/tools/inventory.ts
@@ -8,7 +8,7 @@
 
 import type { FrappeFilter } from "../api/types.ts";
 import type { ErpNextTool } from "./types.ts";
-import { DOCLIST_META, STOCK_META } from "./viewer-meta.ts";
+import { DOC_META, DOCLIST_META, STOCK_META } from "./viewer-meta.ts";
 import { resolveItem } from "../api/resolve.ts";
 
 export const inventoryTools: ErpNextTool[] = [
@@ -81,6 +81,7 @@ export const inventoryTools: ErpNextTool[] = [
   {
     name: "erpnext_item_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single ERPNext Item by name/item_code. Returns all fields including pricing and stock details.",
     category: "inventory",
@@ -96,7 +97,7 @@ export const inventoryTools: ErpNextTool[] = [
         throw new Error("[erpnext_item_get] 'name' is required");
       }
       const doc = await ctx.client.get("Item", input.name as string);
-      return { data: doc };
+      return { data: { ...doc, doctype: "Item" } };
     },
   },
 
@@ -398,6 +399,7 @@ export const inventoryTools: ErpNextTool[] = [
   {
     name: "erpnext_stock_entry_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single Stock Entry by name. Returns full document with item details.",
     category: "inventory",
@@ -416,7 +418,7 @@ export const inventoryTools: ErpNextTool[] = [
         throw new Error("[erpnext_stock_entry_get] 'name' is required");
       }
       const doc = await ctx.client.get("Stock Entry", input.name as string);
-      return { data: doc };
+      return { data: { ...doc, doctype: "Stock Entry" } };
     },
   },
 

--- a/src/tools/manufacturing.ts
+++ b/src/tools/manufacturing.ts
@@ -9,7 +9,7 @@
 
 import type { FrappeFilter } from "../api/types.ts";
 import type { ErpNextTool } from "./types.ts";
-import { DOCLIST_META } from "./viewer-meta.ts";
+import { DOC_META, DOCLIST_META } from "./viewer-meta.ts";
 import { resolveItem } from "../api/resolve.ts";
 
 export const manufacturingTools: ErpNextTool[] = [
@@ -93,6 +93,7 @@ export const manufacturingTools: ErpNextTool[] = [
   {
     name: "erpnext_bom_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single BOM by name (e.g. BOM-ITEM-00001). Returns full document with raw materials and operations.",
     category: "manufacturing",
@@ -108,7 +109,7 @@ export const manufacturingTools: ErpNextTool[] = [
         throw new Error("[erpnext_bom_get] 'name' is required");
       }
       const doc = await ctx.client.get("BOM", input.name as string);
-      return { data: doc };
+      return { data: { ...doc, doctype: "BOM" } };
     },
   },
 
@@ -195,6 +196,7 @@ export const manufacturingTools: ErpNextTool[] = [
   {
     name: "erpnext_work_order_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single Work Order by name (e.g. MFG-WO-00001). Returns full document with operations and materials.",
     category: "manufacturing",
@@ -213,7 +215,7 @@ export const manufacturingTools: ErpNextTool[] = [
         throw new Error("[erpnext_work_order_get] 'name' is required");
       }
       const doc = await ctx.client.get("Work Order", input.name as string);
-      return { data: doc };
+      return { data: { ...doc, doctype: "Work Order" } };
     },
   },
 
@@ -342,6 +344,7 @@ export const manufacturingTools: ErpNextTool[] = [
   {
     name: "erpnext_job_card_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single Job Card by name. Returns full document with time logs and material transfers.",
     category: "manufacturing",
@@ -357,7 +360,7 @@ export const manufacturingTools: ErpNextTool[] = [
         throw new Error("[erpnext_job_card_get] 'name' is required");
       }
       const doc = await ctx.client.get("Job Card", input.name as string);
-      return { data: doc };
+      return { data: { ...doc, doctype: "Job Card" } };
     },
   },
 ];

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -10,7 +10,7 @@
 
 import type { FrappeFile, FrappeFilter } from "../api/types.ts";
 import type { ErpNextTool } from "./types.ts";
-import { DOCLIST_META } from "./viewer-meta.ts";
+import { DOC_META, DOCLIST_META } from "./viewer-meta.ts";
 import {
   roundedTotalFallbackWarning,
   withRoundedTotalFallback,
@@ -23,6 +23,17 @@ import {
   removeAssignment,
   validateAssignees,
 } from "./assignment.ts";
+
+function bytesToBase64(bytes: Uint8Array): string {
+  const chunkSize = 32 * 1024;
+  let binary = "";
+  for (let offset = 0; offset < bytes.byteLength; offset += chunkSize) {
+    binary += String.fromCharCode(
+      ...bytes.subarray(offset, Math.min(offset + chunkSize, bytes.byteLength)),
+    );
+  }
+  return btoa(binary);
+}
 
 export const operationsTools: ErpNextTool[] = [
   // ── File Attachments ───────────────────────────────────────────────────────
@@ -112,6 +123,80 @@ export const operationsTools: ErpNextTool[] = [
           modified: file.modified,
           owner: file.owner,
         })),
+      };
+    },
+  },
+
+  {
+    name: "erpnext_file_download",
+    annotations: { readOnlyHint: true },
+    _meta: {
+      ui: {
+        resourceUri: DOC_META.ui!.resourceUri,
+        visibility: ["app"],
+      },
+    },
+    description:
+      "Download one ERPNext attachment for the document viewer. The tool accepts a File ID, verifies its document attachment, and returns one embedded binary resource.",
+    category: "operations",
+    inputSchema: {
+      type: "object",
+      properties: {
+        file_id: {
+          type: "string",
+          description: "Native ERPNext File.name identifier, never a URL.",
+          minLength: 1,
+        },
+        attached_to_doctype: {
+          type: "string",
+          description: "Expected parent document DocType.",
+          minLength: 1,
+        },
+        attached_to_name: {
+          type: "string",
+          description: "Expected parent document name/ID.",
+          minLength: 1,
+        },
+      },
+      required: ["file_id", "attached_to_doctype", "attached_to_name"],
+      additionalProperties: false,
+    },
+    handler: async (input, ctx) => {
+      for (
+        const field of [
+          "file_id",
+          "attached_to_doctype",
+          "attached_to_name",
+        ] as const
+      ) {
+        if (typeof input[field] !== "string" || !input[field].trim()) {
+          throw new Error(
+            `[erpnext_file_download] '${field}' must be a non-empty string`,
+          );
+        }
+      }
+
+      const file = await ctx.client.downloadFile({
+        fileId: (input.file_id as string).trim(),
+        attachedToDoctype: (input.attached_to_doctype as string).trim(),
+        attachedToName: (input.attached_to_name as string).trim(),
+      });
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Prepared ${file.fileName} for download (${file.bytes.byteLength} bytes).`,
+          },
+          {
+            type: "resource",
+            resource: {
+              uri: `file:///${encodeURIComponent(file.fileName)}`,
+              mimeType: file.mimeType,
+              blob: bytesToBase64(file.bytes),
+            },
+          },
+        ],
       };
     },
   },
@@ -479,6 +564,7 @@ export const operationsTools: ErpNextTool[] = [
   {
     name: "erpnext_doc_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get any ERPNext document by DocType and name. Useful for DocTypes not covered " +
       "by dedicated tools. Returns the full document with all fields.",
@@ -498,18 +584,19 @@ export const operationsTools: ErpNextTool[] = [
       required: ["doctype", "name"],
     },
     handler: async (input, ctx) => {
-      if (!input.doctype) {
+      if (typeof input.doctype !== "string" || !input.doctype.trim()) {
         throw new Error("[erpnext_doc_get] 'doctype' is required");
       }
-      if (!input.name) {
+      if (typeof input.name !== "string" || !input.name.trim()) {
         throw new Error("[erpnext_doc_get] 'name' is required");
       }
 
+      const doctype = input.doctype.trim();
       const doc = await ctx.client.get(
-        input.doctype as string,
-        input.name as string,
+        doctype,
+        input.name.trim(),
       );
-      return { data: doc };
+      return { data: { ...doc, doctype } };
     },
   },
 

--- a/src/tools/operations_test.ts
+++ b/src/tools/operations_test.ts
@@ -27,6 +27,13 @@ function makeMockClient(overrides: Record<string, AnyFn> = {}): FrappeClient {
     delete: async () => {},
     callMethod: async () => null,
     invalidate: () => {},
+    downloadFile: async () => ({
+      fileId: "FILE-001",
+      fileName: "report.pdf",
+      mimeType: "application/pdf",
+      bytes: new Uint8Array([1]),
+      isPrivate: true,
+    }),
     ...overrides,
   };
   return mock as unknown as FrappeClient;
@@ -406,6 +413,126 @@ Deno.test("erpnext_file_upload - is marked destructive", () => {
     getTool("erpnext_file_upload").annotations?.destructiveHint,
     true,
   );
+});
+
+// ── erpnext_file_download ──────────────────────────────────────────────────
+
+Deno.test("erpnext_file_download - is read-only, app-only, and rejects extra schema properties", () => {
+  const tool = getTool("erpnext_file_download");
+  assertEquals(tool.annotations?.readOnlyHint, true);
+  assertEquals(tool._meta?.ui?.visibility, ["app"]);
+  assertEquals(tool._meta?.ui?.resourceUri, "ui://mcp-erpnext/doc-viewer");
+
+  const validator = new SchemaValidator();
+  validator.addSchema(tool.name, tool.inputSchema as Record<string, unknown>);
+  assertEquals(
+    validator.validate(tool.name, {
+      file_id: "FILE-001",
+      attached_to_doctype: "Task",
+      attached_to_name: "TASK-001",
+      file_url: "https://evil.example/report.pdf",
+    }).valid,
+    false,
+  );
+});
+
+Deno.test("erpnext_file_download - validates identifiers before delegation", async () => {
+  const tool = getTool("erpnext_file_download");
+  for (
+    const input of [
+      { attached_to_doctype: "Task", attached_to_name: "TASK-001" },
+      {
+        file_id: " ",
+        attached_to_doctype: "Task",
+        attached_to_name: "TASK-001",
+      },
+      {
+        file_id: "FILE-001",
+        attached_to_doctype: 42,
+        attached_to_name: "TASK-001",
+      },
+    ]
+  ) {
+    await assertRejects(
+      () => tool.handler(input, makeCtx(makeMockClient())),
+      Error,
+      "must be a non-empty string",
+    );
+  }
+});
+
+Deno.test("erpnext_file_download - returns one embedded blob with one base64 copy", async () => {
+  let captured: Record<string, unknown> = {};
+  const result = await getTool("erpnext_file_download").handler(
+    {
+      file_id: " FILE-001 ",
+      attached_to_doctype: " Task ",
+      attached_to_name: " TASK-001 ",
+    },
+    makeCtx(makeMockClient({
+      downloadFile: async (input: Record<string, unknown>) => {
+        captured = input;
+        return {
+          fileId: "FILE-001",
+          fileName: "Q1 report.pdf",
+          mimeType: "application/pdf",
+          bytes: new Uint8Array([0, 255]),
+          isPrivate: true,
+        };
+      },
+    })),
+  ) as {
+    content: Array<{
+      type: string;
+      text?: string;
+      resource?: { uri: string; mimeType: string; blob: string };
+    }>;
+  };
+
+  assertEquals(captured, {
+    fileId: "FILE-001",
+    attachedToDoctype: "Task",
+    attachedToName: "TASK-001",
+  });
+  assertEquals(result.content.length, 2);
+  assertEquals(result.content[0].type, "text");
+  assertEquals(
+    result.content.filter((block) => block.type === "resource").length,
+    1,
+  );
+  assertEquals(result.content[1].resource, {
+    uri: "file:///Q1%20report.pdf",
+    mimeType: "application/pdf",
+    blob: "AP8=",
+  });
+  assertEquals(JSON.stringify(result).split("AP8=").length - 1, 1);
+});
+
+// ── erpnext_doc_get ────────────────────────────────────────────────────────
+
+Deno.test("erpnext_doc_get - binds DOC_META and normalizes doctype without replacing the returned name", async () => {
+  const tool = getTool("erpnext_doc_get");
+  assertEquals(tool._meta?.ui?.resourceUri, "ui://mcp-erpnext/doc-viewer");
+
+  let getArgs: unknown[] = [];
+  const result = await tool.handler(
+    { doctype: " Task ", name: " TASK-001 " },
+    makeCtx(makeMockClient({
+      get: async (...args: unknown[]) => {
+        getArgs = args;
+        return {
+          name: "SERVER-NAME",
+          doctype: "Wrong Type",
+          subject: "Preserved",
+        };
+      },
+    })),
+  ) as { data: Record<string, unknown> };
+
+  assertEquals(getArgs, ["Task", "TASK-001"]);
+  assertEquals(result.data.name, "SERVER-NAME");
+  assertEquals(result.data.doctype, "Task");
+  assertEquals(result.data.subject, "Preserved");
 });
 
 // ── erpnext_doc_list ────────────────────────────────────────────────────────

--- a/src/tools/project.ts
+++ b/src/tools/project.ts
@@ -8,7 +8,7 @@
 
 import type { FrappeFilter } from "../api/types.ts";
 import type { ErpNextTool } from "./types.ts";
-import { DOCLIST_META } from "./viewer-meta.ts";
+import { DOC_META, DOCLIST_META } from "./viewer-meta.ts";
 import {
   applyAssignment,
   ASSIGNMENT_INPUT_PROPERTIES,
@@ -89,6 +89,7 @@ export const projectTools: ErpNextTool[] = [
   {
     name: "erpnext_project_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single Project by name. Returns full document including tasks summary.",
     category: "project",
@@ -104,7 +105,7 @@ export const projectTools: ErpNextTool[] = [
         throw new Error("[erpnext_project_get] 'name' is required");
       }
       const doc = await ctx.client.get("Project", input.name as string);
-      return { data: doc };
+      return { data: { ...doc, doctype: "Project" } };
     },
   },
 
@@ -283,6 +284,7 @@ export const projectTools: ErpNextTool[] = [
   {
     name: "erpnext_task_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single Task by name. Returns full document including description and dependencies.",
     category: "project",
@@ -298,7 +300,7 @@ export const projectTools: ErpNextTool[] = [
         throw new Error("[erpnext_task_get] 'name' is required");
       }
       const doc = await ctx.client.get("Task", input.name as string);
-      return { data: doc };
+      return { data: { ...doc, doctype: "Task" } };
     },
   },
 
@@ -493,6 +495,7 @@ export const projectTools: ErpNextTool[] = [
   {
     name: "erpnext_timesheet_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single Timesheet by name. Returns full document with time log details.",
     category: "project",
@@ -508,7 +511,7 @@ export const projectTools: ErpNextTool[] = [
         throw new Error("[erpnext_timesheet_get] 'name' is required");
       }
       const doc = await ctx.client.get("Timesheet", input.name as string);
-      return { data: doc };
+      return { data: { ...doc, doctype: "Timesheet" } };
     },
   },
 

--- a/src/tools/purchasing.ts
+++ b/src/tools/purchasing.ts
@@ -9,7 +9,7 @@
 
 import type { FrappeFilter } from "../api/types.ts";
 import type { ErpNextTool } from "./types.ts";
-import { DOCLIST_META } from "./viewer-meta.ts";
+import { DOC_META, DOCLIST_META } from "./viewer-meta.ts";
 import { resolveLink, resolveSupplier } from "../api/resolve.ts";
 
 export const purchasingTools: ErpNextTool[] = [
@@ -80,6 +80,7 @@ export const purchasingTools: ErpNextTool[] = [
   {
     name: "erpnext_supplier_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single ERPNext supplier by name (ID). Returns all fields including contact details.",
     category: "purchasing",
@@ -95,7 +96,7 @@ export const purchasingTools: ErpNextTool[] = [
         throw new Error("[erpnext_supplier_get] 'name' is required");
       }
       const doc = await ctx.client.get("Supplier", input.name as string);
-      return { data: doc };
+      return { data: { ...doc, doctype: "Supplier" } };
     },
   },
 
@@ -239,6 +240,7 @@ export const purchasingTools: ErpNextTool[] = [
   {
     name: "erpnext_purchase_order_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single Purchase Order by name (e.g. PO-00001). Returns full document with line items.",
     category: "purchasing",
@@ -257,7 +259,7 @@ export const purchasingTools: ErpNextTool[] = [
         throw new Error("[erpnext_purchase_order_get] 'name' is required");
       }
       const doc = await ctx.client.get("Purchase Order", input.name as string);
-      return { data: doc };
+      return { data: { ...doc, doctype: "Purchase Order" } };
     },
   },
 
@@ -428,6 +430,7 @@ export const purchasingTools: ErpNextTool[] = [
   {
     name: "erpnext_purchase_invoice_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single Purchase Invoice by name (e.g. PINV-00001). Returns full document with line items.",
     category: "purchasing",
@@ -449,7 +452,7 @@ export const purchasingTools: ErpNextTool[] = [
         "Purchase Invoice",
         input.name as string,
       );
-      return { data: doc };
+      return { data: { ...doc, doctype: "Purchase Invoice" } };
     },
   },
 
@@ -532,6 +535,7 @@ export const purchasingTools: ErpNextTool[] = [
   {
     name: "erpnext_purchase_receipt_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single Purchase Receipt by name (e.g. MAT-PRE-00001). Returns full document with received items.",
     category: "purchasing",
@@ -553,7 +557,7 @@ export const purchasingTools: ErpNextTool[] = [
         "Purchase Receipt",
         input.name as string,
       );
-      return { data: doc };
+      return { data: { ...doc, doctype: "Purchase Receipt" } };
     },
   },
 

--- a/src/tools/sales.ts
+++ b/src/tools/sales.ts
@@ -8,7 +8,7 @@
 
 import type { FrappeFilter } from "../api/types.ts";
 import type { ErpNextTool } from "./types.ts";
-import { DOCLIST_META, INVOICE_META } from "./viewer-meta.ts";
+import { DOC_META, DOCLIST_META, INVOICE_META } from "./viewer-meta.ts";
 import { resolveCustomer, resolveDynamicLink } from "../api/resolve.ts";
 import {
   roundedTotalFallbackWarning,
@@ -147,6 +147,7 @@ export const salesTools: ErpNextTool[] = [
   {
     name: "erpnext_customer_get",
     annotations: { readOnlyHint: true },
+    _meta: DOC_META,
     description:
       "Get a single ERPNext customer by name (ID). Returns all fields including contact details.",
     category: "sales",
@@ -162,7 +163,7 @@ export const salesTools: ErpNextTool[] = [
         throw new Error("[erpnext_customer_get] 'name' is required");
       }
       const doc = await ctx.client.get("Customer", input.name as string);
-      return { data: doc };
+      return { data: { ...doc, doctype: "Customer" } };
     },
   },
 

--- a/src/tools/ui-refresh.ts
+++ b/src/tools/ui-refresh.ts
@@ -1022,6 +1022,11 @@ function isDoclistViewer(result: UiRefreshableResult): boolean {
   return uri === "ui://mcp-erpnext/doclist-viewer";
 }
 
+function isDocViewer(result: UiRefreshableResult): boolean {
+  const uri = result._meta?.ui?.resourceUri;
+  return uri === "ui://mcp-erpnext/doc-viewer";
+}
+
 /**
  * Appels codés dans les viewers, donc invisibles dans les hints dynamiques.
  * La liste envoyée reste bornée à la surface du viewer courant : elle ne
@@ -1031,8 +1036,16 @@ const VIEWER_TOOL_CANDIDATES: Record<string, readonly string[]> = {
   "ui://mcp-erpnext/invoice-viewer": [
     "erpnext_item_get",
     "erpnext_stock_balance",
+    "erpnext_file_list",
+    "erpnext_file_upload",
+    "erpnext_file_download",
   ],
   "ui://mcp-erpnext/doclist-viewer": [],
+  "ui://mcp-erpnext/doc-viewer": [
+    "erpnext_file_list",
+    "erpnext_file_upload",
+    "erpnext_file_download",
+  ],
   "ui://mcp-erpnext/kanban-viewer": [
     "erpnext_doc_get",
     "erpnext_doc_update",
@@ -1092,7 +1105,8 @@ function addDoctypeMutationCandidates(
   if (!doctype || !SUBMITTABLE_VIEWER_DOCTYPES.has(doctype)) return;
   if (
     uri === "ui://mcp-erpnext/invoice-viewer" ||
-    uri === "ui://mcp-erpnext/doclist-viewer"
+    uri === "ui://mcp-erpnext/doclist-viewer" ||
+    uri === "ui://mcp-erpnext/doc-viewer"
   ) {
     target.add("erpnext_doc_submit");
     target.add("erpnext_doc_cancel");
@@ -1370,7 +1384,9 @@ export function withUiRefreshRequest(
       if (hints) enriched._sendMessageHints = hints;
     } else if (isStockViewer(enriched)) {
       enriched._sendMessageHints = STOCK_HINTS;
-    } else if (isKanbanViewer(enriched) && doctype) {
+    } else if (
+      (isKanbanViewer(enriched) || isDocViewer(enriched)) && doctype
+    ) {
       const hints = DOCTYPE_SEND_MESSAGE_HINTS[doctype];
       if (hints) enriched._sendMessageHints = hints;
     }

--- a/src/tools/ui-refresh_test.ts
+++ b/src/tools/ui-refresh_test.ts
@@ -693,6 +693,39 @@ Deno.test("ui refresh - viewer capabilities expose only referenced registered to
   );
 });
 
+Deno.test("ui refresh - doc viewer exposes only registered document actions", () => {
+  const result = withUiRefreshRequest(
+    {
+      _meta: { ui: { resourceUri: "ui://mcp-erpnext/doc-viewer" } },
+      data: { doctype: "Task", name: "TASK-1" },
+    },
+    "erpnext_task_get",
+    { name: "TASK-1" },
+    new Date(2026, 7, 24),
+    new Set([
+      "erpnext_task_get",
+      "erpnext_file_list",
+      "erpnext_file_upload",
+      "erpnext_file_download",
+      "erpnext_doc_submit",
+      "unrelated_tool",
+    ]),
+  ) as {
+    _availableTools?: string[];
+    _sendMessageHints?: { key?: string }[];
+  };
+
+  assertEquals(result._availableTools, [
+    "erpnext_file_download",
+    "erpnext_file_list",
+    "erpnext_file_upload",
+    "erpnext_task_get",
+  ]);
+  assertEquals(result._sendMessageHints?.map((hint) => hint.key), [
+    "timesheets",
+  ]);
+});
+
 Deno.test("ui refresh - mutation capabilities are bounded by the explicit doctype", () => {
   const available = new Set([
     "erpnext_doc_submit",
@@ -706,6 +739,9 @@ Deno.test("ui refresh - mutation capabilities are bounded by the explicit doctyp
   };
   const doclistUri = {
     ui: { resourceUri: "ui://mcp-erpnext/doclist-viewer" },
+  };
+  const docUri = {
+    ui: { resourceUri: "ui://mcp-erpnext/doc-viewer" },
   };
 
   assertEquals(
@@ -752,6 +788,13 @@ Deno.test("ui refresh - mutation capabilities are bounded by the explicit doctyp
       _meta: doclistUri,
       doctype: "Quotation",
       data: [],
+    }, available),
+    ["erpnext_doc_cancel", "erpnext_doc_submit"],
+  );
+  assertEquals(
+    availableViewerToolNames({
+      _meta: docUri,
+      data: { doctype: "BOM", name: "BOM-1" },
     }, available),
     ["erpnext_doc_cancel", "erpnext_doc_submit"],
   );

--- a/src/tools/viewer-meta.ts
+++ b/src/tools/viewer-meta.ts
@@ -17,6 +17,7 @@ const viewer = (name: string): MCPToolMeta => ({
 });
 
 export const DOCLIST_META = viewer("doclist-viewer");
+export const DOC_META = viewer("doc-viewer");
 export const INVOICE_META = viewer("invoice-viewer");
 export const STOCK_META = viewer("stock-viewer");
 export const CHART_META = viewer("chart-viewer");

--- a/src/ui/chart-viewer/src/ChartViewer.tsx
+++ b/src/ui/chart-viewer/src/ChartViewer.tsx
@@ -4,7 +4,7 @@
  * Handshake stays on ext-apps (refresh / callServerTool / sendMessage).
  */
 
-import { useEffect, useRef, useState } from "preact/hooks";
+import { useEffect, useLayoutEffect, useRef, useState } from "preact/hooks";
 import type { Ref } from "preact";
 import { App } from "@modelcontextprotocol/ext-apps";
 import { bindHostContext } from "~/shared/host-context-hook";
@@ -1320,11 +1320,32 @@ function ChartRouter(
  * automatique (interval + focus + visibilitychange).
  */
 function ChartContent(
-  { data, error, layout, containerRef }: {
+  {
+    data,
+    error,
+    layout,
+    containerRef,
+    refreshing,
+    rootRefreshRequest,
+    rootFreshEvent,
+    rootMutationEvent,
+    canRefreshRoot,
+    onRefreshRoot,
+    onMutationInvalidate,
+    onMutationRefresh,
+  }: {
     data: ChartData;
     error: string | null;
     layout: ViewerLayout;
     containerRef: Ref<HTMLDivElement>;
+    refreshing: boolean;
+    rootRefreshRequest: UiRefreshRequestData | null;
+    rootFreshEvent: number;
+    rootMutationEvent: number;
+    canRefreshRoot: boolean;
+    onRefreshRoot: () => void;
+    onMutationInvalidate: () => void;
+    onMutationRefresh: () => void;
   },
 ) {
   const [shared, setShared] = useState<DrillDownChannel | null>(null);
@@ -1337,7 +1358,7 @@ function ChartContent(
   const narrow = layout !== "wide";
   const t = useT();
   const fixture = isFixtureMode();
-  const rootKey = viewerRootKey("chart", data.refreshRequest, {
+  const rootKey = viewerRootKey("chart", rootRefreshRequest ?? undefined, {
     title: data.title,
   });
   const activeContext = useActiveContext(app, rootKey);
@@ -1353,6 +1374,12 @@ function ChartContent(
   const { list } = viewerNav;
   const [levelError, setLevelError] = useState<string | null>(null);
   const { ask } = viewerNav;
+  useLayoutEffect(() => {
+    const root = nav.stack.levels[0];
+    if (rootFreshEvent > rootMutationEvent && root?.stale) {
+      nav.clearStale(root.id);
+    }
+  }, [rootFreshEvent, rootMutationEvent]);
   // Un point, une barre, une part : le segment exact prime sur le saut plus
   // général de sa catégorie. Sans saut typé, la sélection reste du contexte.
   const tryJump = jumpsEnabled &&
@@ -1475,6 +1502,33 @@ function ChartContent(
           )}
         </div>
         <div class="flex min-w-0 shrink-0 items-center gap-2">
+          {isRoot && current.stale && (
+            <div
+              role="status"
+              title={t("nav.stale_title")}
+              class="flex items-center gap-1.5 font-mono text-[9.5px] text-warn"
+            >
+              <span
+                aria-hidden="true"
+                class="size-[5px] rounded-full bg-warn"
+              />
+              {!narrow && (
+                <span>{t("nav.stale_values", { at: current.stale.at })}</span>
+              )}
+              {canRefreshRoot && (
+                <button
+                  type="button"
+                  disabled={refreshing}
+                  onClick={onRefreshRoot}
+                  aria-label={t("nav.refresh")}
+                  title={t("nav.refresh")}
+                  class="rounded-[3px] px-1 text-[12px] leading-none text-warn hover:bg-warn/10 disabled:opacity-50"
+                >
+                  {refreshing ? "…" : "↻"}
+                </button>
+              )}
+            </div>
+          )}
           <ActiveContextChip
             compact={narrow}
             selections={activeContext.selections}
@@ -1512,6 +1566,9 @@ function ChartContent(
         onAsk={ask}
         onError={setLevelError}
         onMutated={nav.markStale}
+        onDocumentChanged={nav.reportDocumentChange}
+        onMutationInvalidate={onMutationInvalidate}
+        onMutationRefresh={onMutationRefresh}
         onRefresh={() => void nav.refreshLevel()}
       >
         {/* Zone de rendu du chart */}
@@ -1572,12 +1629,15 @@ export function ChartViewer() {
   );
   const [loading, setLoading] = useState(!fixture);
   const [refreshing, setRefreshing] = useState(false);
+  const [rootFreshEvent, setRootFreshEvent] = useState(0);
+  const [rootMutationEvent, setRootMutationEvent] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const dataRef = useRef<ChartData | null>(
     fixture ? fixtureFromSearch() : null,
   );
   const refreshRequestRef = useRef<UiRefreshRequestData | null>(null);
   const refreshSequenceRef = useRef(createUiRefreshSequence());
+  const rootEventRef = useRef(0);
   const lastRefreshStartedAtRef = useRef(0);
 
   const { ref: containerRef, layout } = useViewerLayout<HTMLDivElement>();
@@ -1589,6 +1649,7 @@ export function ChartViewer() {
       refreshRequestRef.current,
     );
     setData(nextData);
+    setRootFreshEvent(++rootEventRef.current);
   }
 
   function consumeToolResult(result: ToolResultPayload): boolean {
@@ -1611,28 +1672,14 @@ export function ChartViewer() {
     }
   }
 
-  async function requestRefresh(options: { ignoreInterval?: boolean } = {}) {
+  async function requestRefresh(
+    options: { ignoreInterval?: boolean; force?: boolean } = {},
+  ) {
     if (fixture) return false;
     const request = resolveUiRefreshRequest(
       dataRef.current,
       refreshRequestRef.current,
     );
-    const sequence = refreshSequenceRef.current;
-    if (
-      !canRequestUiRefresh({
-        request,
-        visibilityState: typeof document === "undefined"
-          ? "visible"
-          : document.visibilityState,
-        refreshInFlight: sequence.inFlight !== null,
-        now: Date.now(),
-        lastRefreshStartedAt: lastRefreshStartedAtRef.current,
-        minIntervalMs: CHART_REFRESH_INTERVAL_MS,
-      }, options)
-    ) {
-      return false;
-    }
-
     if (
       !request ||
       !canCallViewerTool(
@@ -1644,7 +1691,32 @@ export function ChartViewer() {
       return false;
     }
 
-    const started = beginUiRefresh(sequence);
+    const sequence = refreshSequenceRef.current;
+    if (sequence.inFlight !== null) {
+      if (options.force) {
+        refreshSequenceRef.current = beginUiRefresh(sequence, {
+          force: true,
+        }).state;
+      }
+      return false;
+    }
+    const forced = Boolean(options.force || sequence.pendingForced);
+    if (
+      !canRequestUiRefresh({
+        request,
+        visibilityState: typeof document === "undefined"
+          ? "visible"
+          : document.visibilityState,
+        refreshInFlight: false,
+        now: Date.now(),
+        lastRefreshStartedAt: lastRefreshStartedAtRef.current,
+        minIntervalMs: CHART_REFRESH_INTERVAL_MS,
+      }, { ignoreInterval: options.ignoreInterval || forced })
+    ) {
+      return false;
+    }
+
+    const started = beginUiRefresh(sequence, { force: forced });
     if (started.generation === null) return false;
     refreshSequenceRef.current = started.state;
     lastRefreshStartedAtRef.current = Date.now();
@@ -1679,6 +1751,9 @@ export function ChartViewer() {
       }
     }
     setRefreshing(false);
+    if (completed.runPending) {
+      void requestRefresh({ ignoreInterval: true, force: true });
+    }
     return succeeded;
   }
 
@@ -1737,12 +1812,41 @@ export function ChartViewer() {
     );
   }
 
+  const rootRefreshRequest = resolveUiRefreshRequest(
+    data,
+    refreshRequestRef.current,
+  );
+  const canRefreshRoot = Boolean(
+    !fixture &&
+      rootRefreshRequest &&
+      app.getHostCapabilities()?.serverTools &&
+      readAvailableTools(data)?.includes(rootRefreshRequest.toolName),
+  );
+
   return (
     <ChartContent
       data={data}
       error={error}
       layout={layout}
       containerRef={containerRef}
+      refreshing={refreshing}
+      rootRefreshRequest={rootRefreshRequest}
+      rootFreshEvent={rootFreshEvent}
+      rootMutationEvent={rootMutationEvent}
+      canRefreshRoot={canRefreshRoot}
+      onRefreshRoot={() =>
+        void requestRefresh({ ignoreInterval: true, force: true })}
+      onMutationInvalidate={() => {
+        setRootMutationEvent(++rootEventRef.current);
+        refreshSequenceRef.current = invalidateUiRefresh(
+          refreshSequenceRef.current,
+        );
+      }}
+      onMutationRefresh={() => {
+        if (canRefreshRoot) {
+          void requestRefresh({ ignoreInterval: true, force: true });
+        }
+      }}
     />
   );
 }

--- a/src/ui/chart-viewer/src/root-refresh-wiring_test.ts
+++ b/src/ui/chart-viewer/src/root-refresh-wiring_test.ts
@@ -1,0 +1,170 @@
+import {
+  assert,
+  assertEquals,
+  assertMatch,
+  assertStringIncludes,
+} from "@std/assert";
+import type { DocumentChangeEvent } from "../../shared/document-events.ts";
+import {
+  clearStale,
+  createStack,
+  pushLevel,
+  reportDocumentChange,
+} from "../../shared/nav-stack.ts";
+import {
+  beginUiRefresh,
+  completeUiRefresh,
+  createUiRefreshSequence,
+  invalidateUiRefresh,
+} from "../../shared/refresh.ts";
+
+const VIEWERS = [
+  ["chart", new URL("./ChartViewer.tsx", import.meta.url)],
+  ["kpi", new URL("../../kpi-viewer/src/KpiViewer.tsx", import.meta.url)],
+  [
+    "funnel",
+    new URL("../../funnel-viewer/src/FunnelViewer.tsx", import.meta.url),
+  ],
+  ["stock", new URL("../../stock-viewer/src/StockViewer.tsx", import.meta.url)],
+  [
+    "kanban",
+    new URL("../../kanban-viewer/src/KanbanViewer.tsx", import.meta.url),
+  ],
+] as const;
+
+Deno.test("root refresh sequence rejects pre-mutation data and coalesces one forced reread", () => {
+  let sequence = createUiRefreshSequence();
+  const oldRefresh = beginUiRefresh(sequence);
+  assert(oldRefresh.generation !== null);
+  sequence = oldRefresh.state;
+
+  const mutationEvent = 1;
+  sequence = invalidateUiRefresh(sequence);
+  const queued = beginUiRefresh(sequence, { force: true });
+  assertEquals(queued.generation, null);
+  assertEquals(queued.state.pendingForced, true);
+
+  const oldCompletion = completeUiRefresh(
+    queued.state,
+    oldRefresh.generation,
+  );
+  assertEquals(oldCompletion.accept, false);
+  assertEquals(oldCompletion.runPending, true);
+
+  const canonicalRefresh = beginUiRefresh(oldCompletion.state, {
+    force: true,
+  });
+  assert(canonicalRefresh.generation !== null);
+  const canonicalCompletion = completeUiRefresh(
+    canonicalRefresh.state,
+    canonicalRefresh.generation,
+  );
+  assertEquals(canonicalCompletion.accept, true);
+  assertEquals(canonicalCompletion.runPending, false);
+
+  const freshEvent = mutationEvent + 1;
+  assert(freshEvent > mutationEvent);
+});
+
+Deno.test("canonical root reread clears only the root stale marker", () => {
+  const rootBody = { rows: ["root"] };
+  const parentBody = { rows: ["parent"] };
+  const childBody = { rows: ["child"] };
+  let stack = createStack({ title: "Root", kind: "root", body: rootBody });
+  stack = pushLevel(stack, {
+    title: "Parent",
+    kind: "record",
+    body: parentBody,
+  });
+  stack = pushLevel(stack, {
+    title: "Child",
+    kind: "list",
+    body: childBody,
+  });
+  const change: DocumentChangeEvent = {
+    doctype: "Sales Invoice",
+    name: "SINV-0001",
+    mutation: "submit",
+    committedAt: "2026-08-24T12:00:00.000Z",
+    source: "document-viewer",
+  };
+  stack = reportDocumentChange(stack, "20:00", change);
+
+  const cleared = clearStale(stack, stack.levels[0].id);
+  assertEquals(cleared.levels.map((level) => level.stale?.at), [
+    undefined,
+    "20:00",
+    "20:00",
+  ]);
+  assertEquals(cleared.levels.map((level) => level.body), [
+    rootBody,
+    parentBody,
+    childBody,
+  ]);
+});
+
+Deno.test("all custom-root viewers wire document mutations to an exact forced root reread", async () => {
+  for (const [name, url] of VIEWERS) {
+    const source = await Deno.readTextFile(url);
+    assertStringIncludes(
+      source,
+      "onDocumentChanged={nav.reportDocumentChange}",
+      `${name}: structured document change`,
+    );
+    assertStringIncludes(
+      source,
+      "onMutationInvalidate={onMutationInvalidate}",
+      `${name}: immediate invalidation`,
+    );
+    assertStringIncludes(
+      source,
+      "onMutationRefresh={onMutationRefresh}",
+      `${name}: canonical reread`,
+    );
+    assertStringIncludes(
+      source,
+      "rootFreshEvent > rootMutationEvent",
+      `${name}: freshness ordering`,
+    );
+    assertStringIncludes(
+      source,
+      "nav.clearStale(root.id)",
+      `${name}: root-only stale clearing`,
+    );
+    assertStringIncludes(
+      source,
+      "rootRefreshRequest ?? undefined",
+      `${name}: stable root identity uses the resolved request`,
+    );
+    assertMatch(
+      source,
+      /(?:readAvailableTools\(data\)|data\._availableTools|state\.board\._availableTools)\?\.includes\(rootRefreshRequest\.toolName\)/,
+      `${name}: refresh requires the exact advertised tool`,
+    );
+    assertMatch(
+      source,
+      /onMutationInvalidate=\{\(\) => \{\s*setRootMutationEvent\(\+\+rootEventRef\.current\);\s*refreshSequenceRef\.current = invalidateUiRefresh/s,
+      `${name}: mutation is ordered before refresh invalidation`,
+    );
+    assertStringIncludes(
+      source,
+      "force: true",
+      `${name}: mutation reread bypasses the passive throttle`,
+    );
+  }
+});
+
+Deno.test("kanban counts only canonical board payloads as fresh", async () => {
+  const source = await Deno.readTextFile(
+    new URL("../../kanban-viewer/src/KanbanViewer.tsx", import.meta.url),
+  );
+  assertMatch(
+    source,
+    /\?\.refreshRequest \?\?\s*resolveKanbanRefreshRequest/s,
+  );
+  assertEquals(
+    [...source.matchAll(/acceptCanonicalBoard\(parseBoard\(text\)\)/g)].length,
+    2,
+  );
+  assertEquals(source.includes("updateBoard(parseBoard(text))"), false);
+});

--- a/src/ui/chart-viewer/src/types.ts
+++ b/src/ui/chart-viewer/src/types.ts
@@ -75,6 +75,8 @@ export interface ChartData {
   treeData?: TreeNode[];
   height?: number;
   refreshRequest?: UiRefreshRequestData;
+  /** Outils exacts autorisés par le registre serveur pour ce viewer. */
+  _availableTools?: string[];
   /** sendMessage template — `{label}` is replaced with the clicked label */
   _drillDown?: string;
 }

--- a/src/ui/dev-host/index.html
+++ b/src/ui/dev-host/index.html
@@ -93,6 +93,7 @@
       <select id="viewer">
         <option value="invoice">invoice-viewer</option>
         <option value="doclist">doclist-viewer</option>
+        <option value="doc">doc-viewer</option>
         <option value="kanban">kanban-viewer</option>
         <option value="stock">stock-viewer</option>
         <option value="funnel">funnel-viewer</option>
@@ -101,9 +102,11 @@
       </select>
       <select id="caps">
         <option value="full">
-          profil : full (serverTools + contexte + message)
+          profil : full (serverTools + download + contexte + message)
         </option>
-        <option value="serverTools-only">profil : serverTools-only</option>
+        <option value="serverTools-only">
+          profil : serverTools-only (download refusé)
+        </option>
         <option value="context-only">profil : context-only</option>
         <option value="message-only">
           profil : message-only (ancien hôte)

--- a/src/ui/dev-host/src/canned.ts
+++ b/src/ui/dev-host/src/canned.ts
@@ -9,20 +9,21 @@
 import {
   INVOICE_FIXTURE,
   ITEM_FIXTURES,
-} from "~/invoice-viewer/src/fixture.ts";
-import { DOCLIST_FIXTURE } from "~/doclist-viewer/src/fixture.ts";
+} from "../../invoice-viewer/src/fixture.ts";
+import { DOCLIST_FIXTURE } from "../../doclist-viewer/src/fixture.ts";
 import {
   KANBAN_FIXTURE,
   KANBAN_FIXTURE_DETAILS,
   KANBAN_FIXTURE_USERS,
-} from "~/kanban-viewer/src/fixture.ts";
-import { STOCK_FIXTURE } from "~/stock-viewer/src/fixture.ts";
-import { FUNNEL_FIXTURE } from "~/funnel-viewer/src/fixture.ts";
-import { KPI_FIXTURE } from "~/kpi-viewer/src/fixture.ts";
+} from "../../kanban-viewer/src/fixture.ts";
+import { STOCK_FIXTURE } from "../../stock-viewer/src/fixture.ts";
+import { FUNNEL_FIXTURE } from "../../funnel-viewer/src/fixture.ts";
+import { KPI_FIXTURE } from "../../kpi-viewer/src/fixture.ts";
 
 export type ViewerKey =
   | "invoice"
   | "doclist"
+  | "doc"
   | "kanban"
   | "stock"
   | "funnel"
@@ -48,6 +49,14 @@ const DEV_AVAILABLE_TOOLS: Partial<Record<ViewerKey, readonly string[]>> = {
     "erpnext_doc_list",
     "erpnext_doc_submit",
     "erpnext_doc_cancel",
+  ],
+  doc: [
+    "erpnext_doc_cancel",
+    "erpnext_doc_get",
+    "erpnext_doc_submit",
+    "erpnext_file_download",
+    "erpnext_file_list",
+    "erpnext_file_upload",
   ],
   kanban: [
     "erpnext_kanban_get_board",
@@ -80,6 +89,268 @@ export function withDevViewerTools(
 }
 
 type Row = Record<string, unknown>;
+
+export const DEV_DOCUMENT_DOCTYPE = "BOM";
+export const DEV_DOCUMENT_NAME = "BOM-2026-00042";
+
+/**
+ * Fiche générique volontairement différente des viewers métier dédiés. Les
+ * deux tables enfant permettent de vérifier le rendu récursif du doc-viewer.
+ */
+export const DEV_DOCUMENT_FIXTURE = {
+  data: {
+    doctype: DEV_DOCUMENT_DOCTYPE,
+    name: DEV_DOCUMENT_NAME,
+    item: "PACK-LINE-CONTROL-CABINET",
+    item_name: "Packaging line control cabinet",
+    company: "Casys Taiwan",
+    quantity: 1,
+    uom: "Nos",
+    is_active: 1,
+    is_default: 0,
+    docstatus: 0,
+    description:
+      "Manufacturing definition for the control cabinet used on the Taichung packaging line.",
+    items: [
+      {
+        idx: 1,
+        item_code: "PLC-CPU-1516",
+        item_name: "Fail-safe PLC CPU",
+        qty: 1,
+        uom: "Nos",
+        source_warehouse: "Stores - CS",
+        rate: 2_840,
+        amount: 2_840,
+      },
+      {
+        idx: 2,
+        item_code: "IO-REMOTE-ET200",
+        item_name: "Remote I/O station",
+        qty: 2,
+        uom: "Nos",
+        source_warehouse: "Stores - CS",
+        rate: 680,
+        amount: 1_360,
+      },
+      {
+        idx: 3,
+        item_code: "ENCLOSURE-IP55",
+        item_name: "IP55 floor-standing enclosure",
+        qty: 1,
+        uom: "Nos",
+        source_warehouse: "Fabrication - CS",
+        rate: 940,
+        amount: 940,
+      },
+    ],
+    operations: [
+      {
+        idx: 1,
+        operation: "Electrical assembly",
+        workstation: "Panel Shop - CS",
+        time_in_mins: 180,
+        hourly_rate: 54,
+        operating_cost: 162,
+      },
+      {
+        idx: 2,
+        operation: "Factory acceptance test",
+        workstation: "FAT Bench - CS",
+        time_in_mins: 120,
+        hourly_rate: 72,
+        operating_cost: 144,
+      },
+    ],
+    owner: "engineering@casys.ai",
+    creation: "2026-08-21 09:18:00",
+    modified: "2026-08-24 16:42:00",
+  },
+  refreshRequest: {
+    toolName: "erpnext_doc_get",
+    arguments: {
+      doctype: DEV_DOCUMENT_DOCTYPE,
+      name: DEV_DOCUMENT_NAME,
+    },
+  },
+};
+
+interface CannedAttachment {
+  name: string;
+  file_name: string;
+  file_url: string;
+  file_size: number;
+  is_private: boolean;
+  attached_to_field: string | null;
+  creation: string;
+  modified: string;
+  owner: string;
+  mimeType: string;
+  blob: string;
+}
+
+const INITIAL_DOCUMENT_FILES: readonly CannedAttachment[] = [
+  {
+    name: "FILE-BOM-001",
+    file_name: "control-cabinet-drawing.pdf",
+    file_url: "/private/files/control-cabinet-drawing.pdf",
+    file_size: 16,
+    is_private: true,
+    attached_to_field: null,
+    creation: "2026-08-24 15:10:00",
+    modified: "2026-08-24 15:10:00",
+    owner: "engineering@casys.ai",
+    mimeType: "application/pdf",
+    blob: "JVBERi0xLjQKJcTl8uXrCg==",
+  },
+  {
+    name: "FILE-BOM-002",
+    file_name: "bill-of-materials.csv",
+    file_url: "/files/bill-of-materials.csv",
+    file_size: 27,
+    is_private: false,
+    attached_to_field: null,
+    creation: "2026-08-23 11:20:00",
+    modified: "2026-08-23 11:20:00",
+    owner: "planner@casys.ai",
+    mimeType: "text/csv",
+    blob: "aXRlbV9jb2RlLHF0eQpQTEMtQ1BVLDEK",
+  },
+];
+
+let documentFiles: CannedAttachment[] = [];
+let uploadSequence = 0;
+
+/** Reset mutable upload state whenever the dev-host remounts a viewer. */
+export function resetCannedState(): void {
+  documentFiles = INITIAL_DOCUMENT_FILES.map((file) => ({ ...file }));
+  uploadSequence = 0;
+}
+
+resetCannedState();
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+export function approximateBase64Bytes(blob: string): number {
+  const compact = blob.replace(/\s/g, "");
+  if (!compact) return 0;
+  const padding = compact.endsWith("==") ? 2 : compact.endsWith("=") ? 1 : 0;
+  return Math.max(0, Math.floor(compact.length * 3 / 4) - padding);
+}
+
+function mimeTypeForFileName(fileName: string): string {
+  const extension = fileName.toLowerCase().split(".").pop();
+  return {
+    csv: "text/csv",
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    json: "application/json",
+    pdf: "application/pdf",
+    png: "image/png",
+    txt: "text/plain",
+  }[extension ?? ""] ?? "application/octet-stream";
+}
+
+function fileListRow(file: CannedAttachment): Row {
+  return {
+    name: file.name,
+    file_name: file.file_name,
+    file_url: file.file_url,
+    file_size: file.file_size,
+    is_private: file.is_private,
+    attached_to_field: file.attached_to_field,
+    creation: file.creation,
+    modified: file.modified,
+    owner: file.owner,
+  };
+}
+
+function targetsDevDocument(args: Record<string, unknown>): boolean {
+  return args.attached_to_doctype === DEV_DOCUMENT_DOCTYPE &&
+    args.attached_to_name === DEV_DOCUMENT_NAME;
+}
+
+export interface CannedDownloadToolResult {
+  [key: string]: unknown;
+  content: [
+    { type: "text"; text: string },
+    {
+      type: "resource";
+      resource: { uri: string; mimeType: string; blob: string };
+    },
+  ];
+}
+
+/** Narrow guard used by the host to avoid JSON-wrapping binary tool results. */
+export function isCannedDownloadToolResult(
+  value: unknown,
+): value is CannedDownloadToolResult {
+  const result = record(value);
+  if (
+    !result || !Array.isArray(result.content) || result.content.length !== 2
+  ) {
+    return false;
+  }
+  const text = record(result.content[0]);
+  const embedded = record(result.content[1]);
+  const resource = record(embedded?.resource);
+  return text?.type === "text" && typeof text.text === "string" &&
+    embedded?.type === "resource" && typeof resource?.uri === "string" &&
+    typeof resource.mimeType === "string" && typeof resource.blob === "string";
+}
+
+function fileNameFromUri(uri: string): string {
+  try {
+    const path = new URL(uri).pathname;
+    const segment = path.slice(path.lastIndexOf("/") + 1);
+    return decodeURIComponent(segment) || "download";
+  } catch {
+    return "download";
+  }
+}
+
+export interface DownloadLogSummary {
+  name: string;
+  mimeType: string;
+  approximateBytes: number;
+}
+
+/** Reduce a host download request to metadata; never retain or return its blob. */
+export function summarizeDownloadContents(
+  contents: readonly unknown[],
+): DownloadLogSummary[] {
+  return contents.flatMap((raw) => {
+    const block = record(raw);
+    const resource = record(block?.resource);
+    if (
+      block?.type !== "resource" || typeof resource?.uri !== "string" ||
+      typeof resource.blob !== "string"
+    ) return [];
+    return [{
+      name: fileNameFromUri(resource.uri),
+      mimeType: typeof resource.mimeType === "string"
+        ? resource.mimeType
+        : "application/octet-stream",
+      approximateBytes: approximateBase64Bytes(resource.blob),
+    }];
+  });
+}
+
+/** Keep uploaded bytes out of the visible journal as well. */
+export function toolArgumentsForLog(
+  args: Record<string, unknown>,
+): Record<string, unknown> {
+  if (typeof args.content_base64 !== "string") return args;
+  return {
+    ...args,
+    content_base64: `[base64 omitted; approximately ${
+      approximateBase64Bytes(args.content_base64)
+    } bytes]`,
+  };
+}
 /**
  * Une liste telle que le serveur la renvoie : avec le `_rowAction` qu'il
  * injecte sur toute liste (une ligne s'ouvre dans l'inspecteur du niveau).
@@ -571,6 +842,8 @@ export function initialResult(viewer: ViewerKey): unknown {
           },
         }],
       };
+    case "doc":
+      return DEV_DOCUMENT_FIXTURE;
     case "kanban":
       return {
         ...KANBAN_FIXTURE,
@@ -592,6 +865,7 @@ export function initialResult(viewer: ViewerKey): unknown {
 export const INITIAL_TOOL: Record<ViewerKey, string> = {
   invoice: "erpnext_sales_invoice_get",
   doclist: "erpnext_sales_invoice_list",
+  doc: "erpnext_doc_get",
   kanban: "erpnext_kanban_get_board",
   stock: "erpnext_stock_balance",
   funnel: "erpnext_sales_funnel",
@@ -607,6 +881,92 @@ export function cannedResult(
 ): unknown | null {
   if (name === INITIAL_TOOL[viewer]) return initialResult(viewer);
   switch (name) {
+    case "erpnext_file_list": {
+      if (viewer !== "doc" || !targetsDevDocument(args)) return null;
+      const limit = typeof args.limit === "number" &&
+          Number.isInteger(args.limit) && args.limit > 0
+        ? args.limit
+        : 50;
+      const data = documentFiles.slice(0, limit).map(fileListRow);
+      return { count: data.length, data };
+    }
+    case "erpnext_file_upload": {
+      if (viewer !== "doc" || !targetsDevDocument(args)) return null;
+      const fileName = typeof args.file_name === "string"
+        ? args.file_name.trim()
+        : "";
+      const blob = typeof args.content_base64 === "string"
+        ? args.content_base64.trim()
+        : "";
+      if (!fileName || /[\\/\0]/.test(fileName) || !blob) return null;
+      if (
+        args.is_private !== undefined && typeof args.is_private !== "boolean"
+      ) {
+        return null;
+      }
+      if (
+        args.attached_to_field !== undefined &&
+        (typeof args.attached_to_field !== "string" ||
+          !args.attached_to_field.trim())
+      ) return null;
+
+      uploadSequence += 1;
+      const isPrivate = args.is_private !== false;
+      const sequence = String(uploadSequence).padStart(3, "0");
+      const timestamp = `2026-08-24 17:00:${
+        String(uploadSequence).padStart(2, "0")
+      }`;
+      const file: CannedAttachment = {
+        name: `FILE-UPLOAD-${sequence}`,
+        file_name: fileName,
+        file_url: `${isPrivate ? "/private" : ""}/files/${fileName}`,
+        file_size: approximateBase64Bytes(blob),
+        is_private: isPrivate,
+        attached_to_field: typeof args.attached_to_field === "string"
+          ? args.attached_to_field.trim()
+          : null,
+        creation: timestamp,
+        modified: timestamp,
+        owner: "dev-host@casys.ai",
+        mimeType: mimeTypeForFileName(fileName),
+        blob,
+      };
+      documentFiles.unshift(file);
+      return {
+        data: {
+          ...fileListRow(file),
+          is_private: file.is_private ? 1 : 0,
+          attached_to_doctype: DEV_DOCUMENT_DOCTYPE,
+          attached_to_name: DEV_DOCUMENT_NAME,
+        },
+        message:
+          `${fileName} attached to ${DEV_DOCUMENT_DOCTYPE} ${DEV_DOCUMENT_NAME}`,
+      };
+    }
+    case "erpnext_file_download": {
+      if (viewer !== "doc" || !targetsDevDocument(args)) return null;
+      const file = documentFiles.find((candidate) =>
+        candidate.name === args.file_id
+      );
+      if (!file) return null;
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Prepared ${file.file_name} for download (${file.file_size} bytes).`,
+          },
+          {
+            type: "resource",
+            resource: {
+              uri: `file:///${encodeURIComponent(file.file_name)}`,
+              mimeType: file.mimeType,
+              blob: file.blob,
+            },
+          },
+        ],
+      } satisfies CannedDownloadToolResult;
+    }
     case "erpnext_doc_list": {
       const doctype = String(args.doctype ?? "");
       if (doctype === "Payment Entry") return list(doctype, PAYMENTS);

--- a/src/ui/dev-host/src/canned_test.ts
+++ b/src/ui/dev-host/src/canned_test.ts
@@ -1,0 +1,206 @@
+import { assert, assertEquals } from "@std/assert";
+import {
+  approximateBase64Bytes,
+  cannedResult,
+  DEV_DOCUMENT_DOCTYPE,
+  DEV_DOCUMENT_NAME,
+  INITIAL_TOOL,
+  initialResult,
+  isCannedDownloadToolResult,
+  resetCannedState,
+  summarizeDownloadContents,
+  toolArgumentsForLog,
+  withDevViewerTools,
+} from "./canned.ts";
+
+function object(value: unknown): Record<string, unknown> {
+  assert(value !== null && typeof value === "object" && !Array.isArray(value));
+  return value as Record<string, unknown>;
+}
+
+const documentArgs = {
+  attached_to_doctype: DEV_DOCUMENT_DOCTYPE,
+  attached_to_name: DEV_DOCUMENT_NAME,
+};
+
+Deno.test("dev-host canned - keeps eight viewers and exposes exact generic document tools", () => {
+  assertEquals(Object.keys(INITIAL_TOOL), [
+    "invoice",
+    "doclist",
+    "doc",
+    "kanban",
+    "stock",
+    "funnel",
+    "kpi",
+    "chart",
+  ]);
+
+  const payload = object(withDevViewerTools("doc", initialResult("doc")));
+  const data = object(payload.data);
+  assertEquals(data.doctype, "BOM");
+  assertEquals(data.name, DEV_DOCUMENT_NAME);
+  assertEquals((data.items as unknown[]).length, 3);
+  assertEquals((data.operations as unknown[]).length, 2);
+  assertEquals(payload.refreshRequest, {
+    toolName: "erpnext_doc_get",
+    arguments: { doctype: DEV_DOCUMENT_DOCTYPE, name: DEV_DOCUMENT_NAME },
+  });
+  assertEquals(payload._availableTools, [
+    "erpnext_doc_cancel",
+    "erpnext_doc_get",
+    "erpnext_doc_submit",
+    "erpnext_file_download",
+    "erpnext_file_list",
+    "erpnext_file_upload",
+  ]);
+});
+
+Deno.test("dev-host canned - file list is attached to the exact document", () => {
+  resetCannedState();
+  const result = object(cannedResult("doc", "erpnext_file_list", {
+    ...documentArgs,
+    limit: 50,
+  }));
+  assertEquals(result.count, 2);
+  const files = result.data as Array<Record<string, unknown>>;
+  assertEquals(files.map((file) => file.name), [
+    "FILE-BOM-001",
+    "FILE-BOM-002",
+  ]);
+  assertEquals(files[0].is_private, true);
+  assertEquals(files[1].is_private, false);
+
+  assertEquals(
+    cannedResult("doc", "erpnext_file_list", {
+      ...documentArgs,
+      attached_to_name: "BOM-OTHER",
+    }),
+    null,
+  );
+  assertEquals(
+    cannedResult("invoice", "erpnext_file_list", documentArgs),
+    null,
+  );
+});
+
+Deno.test("dev-host canned - upload is relisted and can be downloaded", () => {
+  resetCannedState();
+  const blob = "SGVsbG8=";
+  const upload = object(cannedResult("doc", "erpnext_file_upload", {
+    ...documentArgs,
+    file_name: "inspection note.txt",
+    content_base64: blob,
+    is_private: false,
+  }));
+  assertEquals(
+    upload.message,
+    `inspection note.txt attached to ${DEV_DOCUMENT_DOCTYPE} ${DEV_DOCUMENT_NAME}`,
+  );
+
+  const listed = object(cannedResult("doc", "erpnext_file_list", documentArgs));
+  assertEquals(listed.count, 3);
+  const first = (listed.data as Array<Record<string, unknown>>)[0];
+  assertEquals(first, {
+    name: "FILE-UPLOAD-001",
+    file_name: "inspection note.txt",
+    file_url: "/files/inspection note.txt",
+    file_size: 5,
+    is_private: false,
+    attached_to_field: null,
+    creation: "2026-08-24 17:00:01",
+    modified: "2026-08-24 17:00:01",
+    owner: "dev-host@casys.ai",
+  });
+
+  const download = cannedResult("doc", "erpnext_file_download", {
+    ...documentArgs,
+    file_id: "FILE-UPLOAD-001",
+  });
+  assert(isCannedDownloadToolResult(download));
+  assertEquals(download.content, [
+    {
+      type: "text",
+      text: "Prepared inspection note.txt for download (5 bytes).",
+    },
+    {
+      type: "resource",
+      resource: {
+        uri: "file:///inspection%20note.txt",
+        mimeType: "text/plain",
+        blob,
+      },
+    },
+  ]);
+});
+
+Deno.test("dev-host canned - download matches the single embedded-resource contract", () => {
+  resetCannedState();
+  const result = cannedResult("doc", "erpnext_file_download", {
+    ...documentArgs,
+    file_id: "FILE-BOM-001",
+  });
+  assert(isCannedDownloadToolResult(result));
+  assertEquals(result.content.length, 2);
+  assertEquals(result.content[0], {
+    type: "text",
+    text: "Prepared control-cabinet-drawing.pdf for download (16 bytes).",
+  });
+  assertEquals(result.content[1].resource, {
+    uri: "file:///control-cabinet-drawing.pdf",
+    mimeType: "application/pdf",
+    blob: "JVBERi0xLjQKJcTl8uXrCg==",
+  });
+  assertEquals(
+    JSON.stringify(result).split("JVBERi0xLjQKJcTl8uXrCg==").length - 1,
+    1,
+  );
+
+  const summary = summarizeDownloadContents([result.content[1]]);
+  assertEquals(summary, [{
+    name: "control-cabinet-drawing.pdf",
+    mimeType: "application/pdf",
+    approximateBytes: 16,
+  }]);
+  assertEquals(JSON.stringify(summary).includes("JVBER"), false);
+});
+
+Deno.test("dev-host canned - download and upload fail closed on identity", () => {
+  resetCannedState();
+  assertEquals(
+    cannedResult("doc", "erpnext_file_download", {
+      ...documentArgs,
+      file_id: "FILE-UNKNOWN",
+    }),
+    null,
+  );
+  assertEquals(
+    cannedResult("doc", "erpnext_file_download", {
+      ...documentArgs,
+      attached_to_doctype: "Task",
+      file_id: "FILE-BOM-001",
+    }),
+    null,
+  );
+  assertEquals(
+    cannedResult("doc", "erpnext_file_upload", {
+      ...documentArgs,
+      file_name: "../escape.txt",
+      content_base64: "eA==",
+    }),
+    null,
+  );
+});
+
+Deno.test("dev-host canned - journal metadata omits uploaded and downloaded blobs", () => {
+  assertEquals(approximateBase64Bytes("SGVsbG8="), 5);
+  assertEquals(approximateBase64Bytes(" AP8=\n"), 2);
+  const logged = toolArgumentsForLog({
+    file_name: "hello.txt",
+    content_base64: "SGVsbG8=",
+  });
+  assertEquals(logged, {
+    file_name: "hello.txt",
+    content_base64: "[base64 omitted; approximately 5 bytes]",
+  });
+  assertEquals(JSON.stringify(logged).includes("SGVsbG8="), false);
+});

--- a/src/ui/dev-host/src/capabilities.ts
+++ b/src/ui/dev-host/src/capabilities.ts
@@ -5,10 +5,15 @@ export type CapabilityProfile =
   | "message-only"
   | "none";
 
-export type HostChannel = "serverTools" | "updateModelContext" | "message";
+export type HostChannel =
+  | "serverTools"
+  | "downloadFile"
+  | "updateModelContext"
+  | "message";
 
 export interface DevHostCapabilities {
   serverTools?: Record<string, never>;
+  downloadFile?: Record<string, never>;
   updateModelContext?: { text: Record<string, never> };
   message?: { text: Record<string, never> };
 }
@@ -39,6 +44,7 @@ export function capabilitiesForProfile(
     case "full":
       return {
         serverTools: {},
+        downloadFile: {},
         updateModelContext: { text: {} },
         message: { text: {} },
       };

--- a/src/ui/dev-host/src/capabilities_test.ts
+++ b/src/ui/dev-host/src/capabilities_test.ts
@@ -8,6 +8,7 @@ import {
 Deno.test("dev-host capabilities - maps the five profiles exactly", () => {
   assertEquals(capabilitiesForProfile("full"), {
     serverTools: {},
+    downloadFile: {},
     updateModelContext: { text: {} },
     message: { text: {} },
   });
@@ -34,6 +35,7 @@ Deno.test("dev-host capabilities - preserves legacy URL aliases", () => {
 Deno.test("dev-host capabilities - exposes journal channel names", () => {
   assertEquals(channelsForProfile("full"), [
     "serverTools",
+    "downloadFile",
     "updateModelContext",
     "message",
   ]);
@@ -41,4 +43,17 @@ Deno.test("dev-host capabilities - exposes journal channel names", () => {
   assertEquals(channelsForProfile("context-only"), ["updateModelContext"]);
   assertEquals(channelsForProfile("message-only"), ["message"]);
   assertEquals(channelsForProfile("none"), []);
+});
+
+Deno.test("dev-host capabilities - keeps download fail-closed outside full", () => {
+  for (
+    const profile of [
+      "serverTools-only",
+      "context-only",
+      "message-only",
+      "none",
+    ] as const
+  ) {
+    assertEquals("downloadFile" in capabilitiesForProfile(profile), false);
+  }
 });

--- a/src/ui/dev-host/src/main.ts
+++ b/src/ui/dev-host/src/main.ts
@@ -16,6 +16,10 @@ import {
 import {
   cannedResult,
   initialResult,
+  isCannedDownloadToolResult,
+  resetCannedState,
+  summarizeDownloadContents,
+  toolArgumentsForLog,
   type ViewerKey,
   withDevViewerTools,
 } from "./canned.ts";
@@ -64,6 +68,7 @@ async function mount() {
   const profile = selectedProfile();
   const hostCapabilities = capabilitiesForProfile(profile);
   const channels = channelsForProfile(profile);
+  resetCannedState();
   log.innerHTML = "<h2>journal hôte</h2>";
   status.textContent = "chargement…";
   note(
@@ -108,7 +113,11 @@ async function mount() {
   bridge.oncalltool = async (params) => {
     const args = (params.arguments ?? {}) as Record<string, unknown>;
     const payload = cannedResult(viewer, params.name, args);
-    note("tool", `canal serverTools · tools/call ${params.name}`, args);
+    note(
+      "tool",
+      `canal serverTools · tools/call ${params.name}`,
+      toolArgumentsForLog(args),
+    );
     if (payload === null) {
       note("info", `${params.name} : non simulé → isError`);
       return {
@@ -120,7 +129,27 @@ async function mount() {
         }],
       };
     }
+    // Le backend renvoie déjà ce résultat au format MCP : le retransformer en
+    // texte dupliquerait le blob et empêcherait le viewer de l'extraire.
+    if (isCannedDownloadToolResult(payload)) return payload;
     return textResult(withDevViewerTools(viewer, payload));
+  };
+  bridge.ondownloadfile = async (params) => {
+    const files = summarizeDownloadContents(params.contents);
+    if (!("downloadFile" in hostCapabilities)) {
+      note(
+        "info",
+        "canal downloadFile refusé · capacité non annoncée",
+        { fichiers: files },
+      );
+      return { isError: true };
+    }
+    note(
+      "info",
+      "canal downloadFile · ui/download-file",
+      { fichiers: files },
+    );
+    return {};
   };
   bridge.onupdatemodelcontext = async (params) => {
     note(

--- a/src/ui/doc-viewer/index.html
+++ b/src/ui/doc-viewer/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document Viewer - mcp-erpnext</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./src/main.tsx"></script>
+  </body>
+</html>

--- a/src/ui/doc-viewer/src/DocViewer.tsx
+++ b/src/ui/doc-viewer/src/DocViewer.tsx
@@ -1,0 +1,595 @@
+/** @jsxImportSource preact */
+
+import { App } from "@modelcontextprotocol/ext-apps";
+import { useEffect, useLayoutEffect, useRef, useState } from "preact/hooks";
+import { ConfirmSheet, useConfirm } from "~/shared/confirm.tsx";
+import type { DocumentChangeEvent } from "~/shared/document-events.ts";
+import { AttachmentsSection } from "~/shared/document/AttachmentsSection.tsx";
+import { documentCapabilities } from "~/shared/document/capabilities.ts";
+import { DocumentSurface } from "~/shared/document/DocumentSurface.tsx";
+import {
+  documentEnvelopeOf,
+  documentModelOf,
+} from "~/shared/document/model.ts";
+import type { DocumentEnvelope } from "~/shared/document/types.ts";
+import { useAttachments } from "~/shared/document/useAttachments.ts";
+import { bindHostContext } from "~/shared/host-context-hook.ts";
+import { useT } from "~/shared/i18n-hook.ts";
+import { jumpFromHint } from "~/shared/jumps.ts";
+import { JumpList } from "~/shared/levels/JumpList.tsx";
+import { LevelBody } from "~/shared/levels/LevelBody.tsx";
+import { viewerRootKey } from "~/shared/nav-stack.ts";
+import { PathBar } from "~/shared/PathBar.tsx";
+import {
+  beginUiRefresh,
+  canRequestUiRefresh,
+  completeUiRefresh,
+  createUiRefreshSequence,
+  extractToolResultText,
+  invalidateUiRefresh,
+  normalizeUiRefreshFailureMessage,
+  type ToolResultPayload,
+} from "~/shared/refresh.ts";
+import {
+  Button,
+  CasysCredit,
+  StateMessage,
+  ToolButton,
+  ViewerShell,
+} from "~/shared/ui.tsx";
+import { useViewerLayout } from "~/shared/useViewerLayout.ts";
+import { useViewerNav } from "~/shared/useViewerNav.ts";
+import { hasAvailableTool } from "~/shared/viewer-tools.ts";
+import { canonicalReadbackSupersedesMutation } from "./canonical-readback.ts";
+import { DOC_FIXTURE, DOC_FIXTURE_FILES, isFixtureMode } from "./fixture.ts";
+
+const app = new App({
+  name: "ERPNext Document Viewer",
+  version: "3.1.0-beta.2",
+});
+const REFRESH_INTERVAL_MS = 15_000;
+const TOOL_CALL_TIMEOUT_MS = 10_000;
+const CANONICAL_READBACK_DELAY_MS = 1_500;
+
+export function DocViewer() {
+  const t = useT();
+  const fixture = isFixtureMode();
+  const fixtureEnvelope = fixture ? documentEnvelopeOf(DOC_FIXTURE) : null;
+  const [envelope, setEnvelope] = useState<DocumentEnvelope | null>(
+    fixtureEnvelope,
+  );
+  const [loading, setLoading] = useState(!fixture);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [rootFreshEvent, setRootFreshEvent] = useState(fixture ? 1 : 0);
+  const envelopeRef = useRef(envelope);
+  const refreshSequenceRef = useRef(createUiRefreshSequence());
+  const refreshPromiseRef = useRef<Promise<boolean> | null>(null);
+  const lastRefreshStartedAtRef = useRef(0);
+  const rootFreshEventRef = useRef(fixture ? 1 : 0);
+
+  function consumeToolResult(result: ToolResultPayload): boolean {
+    if (result.isError) {
+      setError(extractToolResultText(result) ?? t("common.error.tool_failed"));
+      setLoading(false);
+      return false;
+    }
+    const text = extractToolResultText(result);
+    if (!text) return false;
+    try {
+      const next = documentEnvelopeOf(JSON.parse(text));
+      if (!next) throw new Error("missing canonical document identity");
+      envelopeRef.current = next;
+      setEnvelope(next);
+      const fresh = ++rootFreshEventRef.current;
+      setRootFreshEvent(fresh);
+      setError(null);
+      setLoading(false);
+      return true;
+    } catch {
+      setError(t("common.error.parse_failed"));
+      setLoading(false);
+      return false;
+    }
+  }
+
+  async function requestRefresh(
+    options: { ignoreInterval?: boolean; force?: boolean } = {},
+  ): Promise<boolean> {
+    if (fixture) return false;
+    const current = refreshSequenceRef.current;
+    if (options.force) {
+      if (current.inFlight !== null) {
+        refreshSequenceRef.current =
+          beginUiRefresh(current, { force: true }).state;
+        return refreshPromiseRef.current ?? false;
+      }
+      refreshSequenceRef.current = {
+        ...invalidateUiRefresh(current),
+        pendingForced: true,
+      };
+    } else if (current.inFlight !== null) {
+      return false;
+    }
+
+    const operation = (async (): Promise<boolean> => {
+      try {
+        while (true) {
+          const sequence = refreshSequenceRef.current;
+          const currentEnvelope = envelopeRef.current;
+          const request = currentEnvelope?.refreshRequest;
+          const capabilities = currentEnvelope
+            ? documentCapabilities(
+              app.getHostCapabilities(),
+              currentEnvelope.availableTools,
+              request,
+            )
+            : null;
+          const forced = sequence.pendingForced;
+          if (
+            !request || !capabilities?.canRefresh ||
+            !canRequestUiRefresh({
+              request,
+              visibilityState: typeof document === "undefined"
+                ? "visible"
+                : document.visibilityState,
+              refreshInFlight: false,
+              now: Date.now(),
+              lastRefreshStartedAt: lastRefreshStartedAtRef.current,
+              minIntervalMs: REFRESH_INTERVAL_MS,
+            }, { ignoreInterval: options.ignoreInterval || forced })
+          ) return false;
+
+          const started = beginUiRefresh(sequence, { force: forced });
+          if (started.generation === null) return false;
+          refreshSequenceRef.current = started.state;
+          lastRefreshStartedAtRef.current = Date.now();
+          setRefreshing(true);
+
+          let result: ToolResultPayload | null = null;
+          let failure: unknown = null;
+          try {
+            result = await app.callServerTool({
+              name: request.toolName,
+              arguments: request.arguments,
+            }, { timeout: TOOL_CALL_TIMEOUT_MS });
+          } catch (cause) {
+            failure = cause;
+          }
+
+          const completed = completeUiRefresh(
+            refreshSequenceRef.current,
+            started.generation,
+          );
+          refreshSequenceRef.current = completed.state;
+          let succeeded = false;
+          if (completed.accept) {
+            if (failure) setError(normalizeUiRefreshFailureMessage(failure));
+            else if (result?.isError) {
+              setError(t("common.error.refresh_failed"));
+            } else if (result) succeeded = consumeToolResult(result);
+          }
+          if (!completed.runPending) return succeeded;
+        }
+      } finally {
+        setRefreshing(false);
+      }
+    })();
+    refreshPromiseRef.current = operation;
+    void operation.finally(() => {
+      if (refreshPromiseRef.current === operation) {
+        refreshPromiseRef.current = null;
+      }
+    });
+    return operation;
+  }
+
+  function invalidateRefresh() {
+    refreshSequenceRef.current = invalidateUiRefresh(
+      refreshSequenceRef.current,
+    );
+  }
+
+  useEffect(() => {
+    if (fixture) return;
+    app.ontoolresult = (result: ToolResultPayload) => {
+      invalidateRefresh();
+      consumeToolResult(result);
+    };
+    app.ontoolinputpartial = () => {
+      if (!envelopeRef.current) setLoading(true);
+    };
+    app.connect().then(() => bindHostContext(app)).catch(() => {});
+  }, [fixture]);
+
+  useEffect(() => {
+    if (fixture) return;
+    const refresh = () => void requestRefresh({ ignoreInterval: true });
+    const visible = () => {
+      if (document.visibilityState === "visible") refresh();
+    };
+    window.addEventListener("focus", refresh);
+    document.addEventListener("visibilitychange", visible);
+    return () => {
+      window.removeEventListener("focus", refresh);
+      document.removeEventListener("visibilitychange", visible);
+    };
+  }, [fixture]);
+
+  if (loading || !envelope) {
+    return (
+      <ViewerShell class="h-screen">
+        <StateMessage>
+          {loading ? t("common.loading") : t("common.no_data")}
+        </StateMessage>
+      </ViewerShell>
+    );
+  }
+
+  return (
+    <DocumentContent
+      key={`${envelope.doctype}:${envelope.name}`}
+      envelope={envelope}
+      fixture={fixture}
+      error={error}
+      refreshing={refreshing}
+      rootFreshEvent={rootFreshEvent}
+      onError={setError}
+      onInvalidateRefresh={invalidateRefresh}
+      onRefresh={(force = false) =>
+        requestRefresh({ ignoreInterval: true, force })}
+    />
+  );
+}
+
+function DocumentContent({
+  envelope,
+  fixture,
+  error,
+  refreshing,
+  rootFreshEvent,
+  onError,
+  onInvalidateRefresh,
+  onRefresh,
+}: {
+  envelope: DocumentEnvelope;
+  fixture: boolean;
+  error: string | null;
+  refreshing: boolean;
+  rootFreshEvent: number;
+  onError: (message: string | null) => void;
+  onInvalidateRefresh: () => void;
+  onRefresh: (force?: boolean) => Promise<boolean>;
+}) {
+  const t = useT();
+  const { ref, layout } = useViewerLayout<HTMLDivElement>();
+  const confirm = useConfirm();
+  const [showJson, setShowJson] = useState(false);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+  const [mutationCommitted, setMutationCommitted] = useState(false);
+  const [mutationBaseline, setMutationBaseline] = useState<number | null>(null);
+  const delayedRefreshRef = useRef<number | null>(null);
+  const model = documentModelOf(envelope);
+  const capabilities = documentCapabilities(
+    fixture ? undefined : app.getHostCapabilities(),
+    envelope.availableTools,
+    envelope.refreshRequest,
+  );
+  const viewerNav = useViewerNav(app, {
+    title: envelope.name,
+    kind: "root",
+    origin: "record",
+    body: envelope,
+    key: viewerRootKey("document", envelope.refreshRequest, {
+      doctype: envelope.doctype,
+      name: envelope.name,
+    }),
+  }, { fixture });
+  const nav = viewerNav.nav;
+  const rootId = nav.stack.levels[0].id;
+
+  useLayoutEffect(() => {
+    if (
+      canonicalReadbackSupersedesMutation(mutationBaseline, rootFreshEvent)
+    ) {
+      nav.clearStale(rootId);
+      setMutationBaseline(null);
+      setMutationCommitted(false);
+    }
+  }, [mutationBaseline, rootFreshEvent, rootId]);
+  useEffect(() => () => {
+    if (delayedRefreshRef.current !== null) {
+      clearTimeout(delayedRefreshRef.current);
+    }
+  }, []);
+
+  const beginCanonicalReadback = () => {
+    setMutationBaseline(rootFreshEvent);
+    onInvalidateRefresh();
+  };
+
+  const scheduleCanonicalRefresh = () => {
+    if (delayedRefreshRef.current !== null) {
+      clearTimeout(delayedRefreshRef.current);
+    }
+    delayedRefreshRef.current = window.setTimeout(() => {
+      delayedRefreshRef.current = null;
+      void onRefresh(true).then((refreshed) => {
+        if (!refreshed) onError(t("common.error.refresh_failed"));
+      }, () => onError(t("common.error.refresh_failed")));
+    }, CANONICAL_READBACK_DELAY_MS);
+  };
+
+  const reportChange = (event: DocumentChangeEvent) => {
+    nav.reportDocumentChange(event);
+    beginCanonicalReadback();
+  };
+  const attachments = useAttachments({
+    app,
+    envelope,
+    capabilities,
+    fixtureFiles: fixture ? DOC_FIXTURE_FILES : undefined,
+    onDocumentChanged: (event) => {
+      reportChange(event);
+      scheduleCanonicalRefresh();
+    },
+  });
+
+  if (!model) {
+    return (
+      <ViewerShell class="h-screen" containerRef={ref}>
+        <StateMessage tone="bad">{t("common.error.parse_failed")}</StateMessage>
+      </ViewerShell>
+    );
+  }
+
+  const hints = envelope.sendMessageHints ?? [];
+  const jumps = viewerNav.jumpsEnabled
+    ? hints.flatMap((hint) => {
+      if (!hint.tool || !hasAvailableTool(envelope.availableTools, hint.tool)) {
+        return [];
+      }
+      const jump = jumpFromHint(
+        hint,
+        { id: envelope.name, doctype: envelope.doctype },
+        t("nav.linked_to", { id: envelope.name }),
+      );
+      return jump ? [jump] : [];
+    })
+    : [];
+  const asks = !viewerNav.jumpsEnabled && viewerNav.ask
+    ? hints.flatMap((hint) =>
+      hint.message
+        ? [{
+          label: hint.label,
+          message: hint.message
+            .replace(/\{id\}/g, envelope.name)
+            .replace(/\{doctype\}/g, envelope.doctype),
+        }]
+        : []
+    )
+    : [];
+
+  async function mutate(mutation: "submit" | "cancel") {
+    if (fixture || actionLoading) return;
+    const toolName = mutation === "submit"
+      ? "erpnext_doc_submit"
+      : "erpnext_doc_cancel";
+    if (!hasAvailableTool(envelope.availableTools, toolName)) return;
+    setActionLoading(mutation);
+    setActionMessage(null);
+    onError(null);
+    try {
+      const result = await app.callServerTool({
+        name: toolName,
+        arguments: { doctype: envelope.doctype, name: envelope.name },
+      }, { timeout: TOOL_CALL_TIMEOUT_MS });
+      if (result.isError) {
+        throw new Error(
+          extractToolResultText(result) ?? t("doclist.detail.action_failed"),
+        );
+      }
+      reportChange({
+        doctype: envelope.doctype,
+        name: envelope.name,
+        mutation,
+        committedAt: new Date().toISOString(),
+        source: "doc-viewer",
+      });
+      setMutationCommitted(true);
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, CANONICAL_READBACK_DELAY_MS)
+      );
+      const refreshed = await onRefresh(true);
+      setActionMessage(
+        refreshed
+          ? t(
+            mutation === "submit"
+              ? "doclist.detail.action.submit_ok"
+              : "doclist.detail.action.cancel_ok",
+          )
+          : t("document.action.refresh_pending"),
+      );
+    } catch (cause) {
+      const message = cause instanceof Error && cause.message
+        ? cause.message
+        : t("doclist.detail.action_failed");
+      onError(message);
+    } finally {
+      setActionLoading(null);
+    }
+  }
+
+  const isDraft = model.docstatus === 0 || model.status === "Draft";
+  const isSubmitted = model.docstatus === 1;
+  const rootStale = nav.stack.levels[0].stale;
+  const canSubmit = isDraft && capabilities.canRefresh &&
+    capabilities.canSubmit && !mutationCommitted;
+  const canCancel = isSubmitted && capabilities.canRefresh &&
+    capabilities.canCancel && !mutationCommitted;
+  const navigationActions = (jumps.length > 0 || asks.length > 0) && (
+    <div class="flex flex-col gap-2 border-b border-line-soft pb-3">
+      <span class="font-mono text-micro uppercase tracking-label text-ink-faint">
+        {t("nav.goto")}
+      </span>
+      <JumpList
+        jumps={jumps}
+        asks={asks}
+        onJump={viewerNav.jumpsEnabled ? nav.jump : undefined}
+        onAsk={viewerNav.ask}
+        narrow={layout !== "wide"}
+      />
+    </div>
+  );
+  const mutationActions = (navigationActions || canSubmit || canCancel)
+    ? (
+      <div class="flex flex-col gap-2">
+        {navigationActions}
+        {canSubmit && (
+          <Button
+            variant="accent"
+            disabled={actionLoading !== null}
+            onClick={() =>
+              confirm.request({
+                subject: envelope.name,
+                title: t("doclist.confirm.submit"),
+                detail: t("doclist.confirm.submit.detail"),
+                actionLabel: t("doclist.confirm.submit.action"),
+                onConfirm: () => void mutate("submit"),
+              })}
+          >
+            {actionLoading === "submit" ? "…" : t("common.submit")}
+          </Button>
+        )}
+        {canCancel && (
+          <Button
+            variant="danger"
+            disabled={actionLoading !== null}
+            onClick={() =>
+              confirm.request({
+                subject: envelope.name,
+                title: t("doclist.confirm.cancel"),
+                detail: t("doclist.confirm.cancel.detail"),
+                actionLabel: t("doclist.confirm.cancel.action"),
+                onConfirm: () => void mutate("cancel"),
+              })}
+          >
+            {actionLoading === "cancel" ? "…" : t("common.cancel")}
+          </Button>
+        )}
+      </div>
+    )
+    : undefined;
+  const attachmentSurface = fixture || capabilities.canListAttachments
+    ? (
+      <AttachmentsSection
+        controller={attachments}
+        capabilities={capabilities}
+        layout={layout}
+      />
+    )
+    : undefined;
+  const headerActions = (
+    <>
+      {rootStale && (
+        <span
+          role="status"
+          title={t("nav.stale_title")}
+          class="inline-flex items-center gap-1.5 font-mono text-nano text-warn"
+        >
+          <span aria-hidden="true" class="size-1.5 rounded-full bg-warn" />
+          {layout === "wide" && t("nav.stale_values", { at: rootStale.at })}
+        </span>
+      )}
+      {capabilities.canRefresh && (
+        <ToolButton
+          aria-label={t("common.refresh")}
+          title={t("common.refresh")}
+          disabled={refreshing || actionLoading !== null}
+          onClick={() => void onRefresh()}
+        >
+          {refreshing ? "…" : "↻"}
+        </ToolButton>
+      )}
+      <ToolButton
+        aria-pressed={showJson}
+        title={t("document.json")}
+        onClick={() => setShowJson((visible) => !visible)}
+      >
+        {"{ }"}
+      </ToolButton>
+    </>
+  );
+  const footer = (
+    <div class="flex min-h-9 items-center gap-3 px-3.5 py-2">
+      <div class="min-w-0 flex-1">
+        {error
+          ? <StateMessage tone="bad">{error}</StateMessage>
+          : actionMessage
+          ? <span class="font-mono text-chip text-ok">{actionMessage}</span>
+          : null}
+      </div>
+      <CasysCredit />
+    </div>
+  );
+
+  return (
+    <ViewerShell class="h-screen" containerRef={ref}>
+      <PathBar
+        layout={layout}
+        stack={nav.stack}
+        onBack={nav.pop}
+        onJump={nav.popTo}
+        loading={nav.current.loading}
+      />
+      {nav.isRoot
+        ? (
+          <div class="relative flex min-h-0 flex-1">
+            <DocumentSurface
+              model={model}
+              layout={layout}
+              live={capabilities.canRefresh && !error}
+              headerActions={headerActions}
+              attachments={attachmentSurface}
+              actions={mutationActions}
+              footer={footer}
+            />
+            {showJson && (
+              <div class="absolute inset-0 z-20 flex min-h-0 flex-col bg-surface/98">
+                <div class="flex min-h-11 items-center justify-between border-b border-line px-3.5">
+                  <span class="font-mono text-micro uppercase tracking-label text-ink-muted">
+                    {t("document.json")}
+                  </span>
+                  <ToolButton onClick={() => setShowJson(false)}>
+                    {t("common.close")}
+                  </ToolButton>
+                </div>
+                <pre class="scroll-slim min-h-0 flex-1 overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-chip leading-relaxed text-ink-2">
+                  {JSON.stringify(envelope.document, null, 2)}
+                </pre>
+              </div>
+            )}
+          </div>
+        )
+        : (
+          <LevelBody
+            level={nav.current}
+            app={app}
+            list={viewerNav.list}
+            layout={layout}
+            fixture={fixture}
+            onJump={viewerNav.jumpsEnabled ? nav.jump : undefined}
+            onAsk={viewerNav.ask}
+            onError={onError}
+            onMutated={nav.markStale}
+            onDocumentChanged={nav.reportDocumentChange}
+            onMutationInvalidate={beginCanonicalReadback}
+            onMutationRefresh={scheduleCanonicalRefresh}
+            onRefresh={() => void nav.refreshLevel()}
+          />
+        )}
+      <ConfirmSheet confirm={confirm} />
+    </ViewerShell>
+  );
+}

--- a/src/ui/doc-viewer/src/canonical-readback.ts
+++ b/src/ui/doc-viewer/src/canonical-readback.ts
@@ -1,0 +1,11 @@
+/**
+ * A root snapshot may only clear its stale marker when it was accepted after
+ * the mutation that invalidated it. Failed and pre-mutation reads do not
+ * advance the fresh-event clock.
+ */
+export function canonicalReadbackSupersedesMutation(
+  mutationBaseline: number | null,
+  rootFreshEvent: number,
+): boolean {
+  return mutationBaseline !== null && rootFreshEvent > mutationBaseline;
+}

--- a/src/ui/doc-viewer/src/canonical-readback_test.ts
+++ b/src/ui/doc-viewer/src/canonical-readback_test.ts
@@ -1,0 +1,96 @@
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import type { DocumentChangeEvent } from "../../shared/document-events.ts";
+import {
+  clearStale,
+  createStack,
+  pushLevel,
+  reportDocumentChange,
+} from "../../shared/nav-stack.ts";
+import {
+  beginUiRefresh,
+  completeUiRefresh,
+  createUiRefreshSequence,
+  invalidateUiRefresh,
+} from "../../shared/refresh.ts";
+import { canonicalReadbackSupersedesMutation } from "./canonical-readback.ts";
+
+Deno.test("child mutation clears root stale only after its canonical readback succeeds", () => {
+  let stack = createStack({ title: "Task", kind: "root" });
+  stack = pushLevel(stack, { title: "Orders", kind: "list" });
+
+  let rootFreshEvent = 4;
+  const preMutationRead = beginUiRefresh(createUiRefreshSequence());
+  assert(preMutationRead.generation !== null);
+
+  const mutation: DocumentChangeEvent = {
+    doctype: "Sales Order",
+    name: "SO-00042",
+    mutation: "submit",
+    committedAt: "2026-08-24T12:00:00.000Z",
+    source: "doclist.inline-detail",
+  };
+  stack = reportDocumentChange(stack, "20:00", mutation);
+  const mutationBaseline = rootFreshEvent;
+  let sequence = invalidateUiRefresh(preMutationRead.state);
+
+  const rejectedOldRead = completeUiRefresh(
+    sequence,
+    preMutationRead.generation,
+  );
+  assertEquals(rejectedOldRead.accept, false);
+  assertEquals(
+    canonicalReadbackSupersedesMutation(mutationBaseline, rootFreshEvent),
+    false,
+  );
+  assert(stack.levels[0].stale);
+
+  const failedRead = beginUiRefresh(rejectedOldRead.state, { force: true });
+  assert(failedRead.generation !== null);
+  sequence = completeUiRefresh(failedRead.state, failedRead.generation).state;
+  // A tool error or invalid payload is not a fresh canonical document.
+  assertEquals(
+    canonicalReadbackSupersedesMutation(mutationBaseline, rootFreshEvent),
+    false,
+  );
+  assert(stack.levels[0].stale);
+
+  const successfulRead = beginUiRefresh(sequence, { force: true });
+  assert(successfulRead.generation !== null);
+  const accepted = completeUiRefresh(
+    successfulRead.state,
+    successfulRead.generation,
+  );
+  assertEquals(accepted.accept, true);
+  rootFreshEvent += 1;
+  if (
+    canonicalReadbackSupersedesMutation(mutationBaseline, rootFreshEvent)
+  ) {
+    stack = clearStale(stack, stack.levels[0].id);
+  }
+
+  assertEquals(stack.levels[0].stale, undefined);
+  assertEquals(stack.levels[1].stale?.documentChange, mutation);
+});
+
+Deno.test("DocViewer wires child mutations into root invalidation and reread", async () => {
+  const source = await Deno.readTextFile(
+    new URL("./DocViewer.tsx", import.meta.url),
+  );
+  assertStringIncludes(
+    source,
+    "onDocumentChanged={nav.reportDocumentChange}",
+  );
+  assertStringIncludes(
+    source,
+    "onMutationInvalidate={beginCanonicalReadback}",
+  );
+  assertStringIncludes(
+    source,
+    "onMutationRefresh={scheduleCanonicalRefresh}",
+  );
+  assertStringIncludes(source, "onRefresh(true)");
+  assertStringIncludes(
+    source,
+    "canonicalReadbackSupersedesMutation(mutationBaseline, rootFreshEvent)",
+  );
+});

--- a/src/ui/doc-viewer/src/fixture.ts
+++ b/src/ui/doc-viewer/src/fixture.ts
@@ -1,0 +1,97 @@
+import type { DocumentAttachment } from "~/shared/document/attachment-results.ts";
+
+export const DOC_FIXTURE = {
+  data: {
+    doctype: "Task",
+    name: "TASK-2026-0142",
+    subject: "Commission the Taichung packaging line",
+    status: "Open",
+    docstatus: 0,
+    project: "PLANT-TAICHUNG",
+    company: "Casys Taiwan",
+    priority: "High",
+    progress: 62,
+    exp_start_date: "2026-08-18",
+    exp_end_date: "2026-09-04",
+    description:
+      "Coordinate controls validation, safety sign-off and operator handover before production ramp-up.",
+    depends_on: [
+      {
+        task: "TASK-2026-0128",
+        subject: "Validate PLC interlocks",
+        status: "Completed",
+      },
+      {
+        task: "TASK-2026-0134",
+        subject: "Complete guarding inspection",
+        status: "Working",
+      },
+    ],
+    time_logs: [
+      {
+        activity_type: "Engineering",
+        hours: 4.5,
+        from_time: "2026-08-22 09:00:00",
+        to_time: "2026-08-22 13:30:00",
+      },
+      {
+        activity_type: "Commissioning",
+        hours: 3,
+        from_time: "2026-08-23 14:00:00",
+        to_time: "2026-08-23 17:00:00",
+      },
+    ],
+    owner: "erwan@casys.ai",
+    modified: "2026-08-24 16:42:00",
+  },
+  refreshRequest: {
+    toolName: "erpnext_task_get",
+    arguments: { name: "TASK-2026-0142" },
+  },
+  _availableTools: [
+    "erpnext_task_get",
+    "erpnext_file_list",
+    "erpnext_file_upload",
+    "erpnext_file_download",
+    "erpnext_doc_submit",
+    "erpnext_doc_cancel",
+    "erpnext_doc_list",
+    "erpnext_timesheet_list",
+  ],
+  _sendMessageHints: [{
+    key: "timesheets",
+    label: "Timesheets",
+    message: "Show timesheets for task {id}",
+    tool: "erpnext_doc_list",
+    args: {
+      doctype: "Timesheet",
+      filters: [["Timesheet Detail", "task", "=", "{id}"]],
+      limit: 20,
+    },
+    kind: "list",
+  }],
+};
+
+export const DOC_FIXTURE_FILES: readonly DocumentAttachment[] = [
+  {
+    id: "FILE-001",
+    fileName: "commissioning-checklist.pdf",
+    fileSize: 482_304,
+    isPrivate: true,
+    owner: "erwan@casys.ai",
+    createdAt: "2026-08-24 15:10:00",
+  },
+  {
+    id: "FILE-002",
+    fileName: "line-layout-rev-c.png",
+    fileSize: 1_842_176,
+    isPrivate: false,
+    owner: "engineer@casys.ai",
+    createdAt: "2026-08-23 11:20:00",
+  },
+];
+
+export function isFixtureMode(): boolean {
+  if (typeof window === "undefined") return false;
+  return new URLSearchParams(globalThis.location.search).has("fixture");
+}

--- a/src/ui/doc-viewer/src/main.tsx
+++ b/src/ui/doc-viewer/src/main.tsx
@@ -1,0 +1,8 @@
+/** @jsxImportSource preact */
+import { render } from "preact";
+import "~/global.css";
+import { applyCasysTheme, themeFromSearch } from "~/shared/casys-theme";
+import { DocViewer } from "./DocViewer.tsx";
+
+applyCasysTheme(themeFromSearch());
+render(<DocViewer />, document.getElementById("app")!);

--- a/src/ui/doclist-viewer/src/DoclistViewer.tsx
+++ b/src/ui/doclist-viewer/src/DoclistViewer.tsx
@@ -368,6 +368,7 @@ function DoclistContent({
         onAsk={ask}
         onError={onError}
         onMutated={nav.markStale}
+        onDocumentChanged={nav.reportDocumentChange}
         onMutationInvalidate={refreshAvailable
           ? onMutationInvalidate
           : undefined}
@@ -388,6 +389,7 @@ function DoclistContent({
             : undefined}
           onMutationRefresh={refreshAvailable ? onMutationRefresh : undefined}
           onMutated={nav.markStale}
+          onDocumentChanged={nav.reportDocumentChange}
           onError={onError}
           onJump={jumpsEnabled ? nav.jump : undefined}
           onAsk={ask}

--- a/src/ui/doclist-viewer/src/fixture.ts
+++ b/src/ui/doclist-viewer/src/fixture.ts
@@ -1,4 +1,4 @@
-import type { DoclistData } from "~/shared/doclist/types";
+import type { DoclistData } from "../../shared/doclist/types.ts";
 
 const STATUSES = [
   { status: "Draft", docstatus: 0 },

--- a/src/ui/funnel-viewer/src/FunnelViewer.tsx
+++ b/src/ui/funnel-viewer/src/FunnelViewer.tsx
@@ -9,7 +9,7 @@
  * la vue (DoclistBody) plutôt que d'envoyer un message au chat.
  * Sans serverTools, le comportement reste strictement identique à avant.
  */
-import { useEffect, useRef, useState } from "preact/hooks";
+import { useEffect, useLayoutEffect, useRef, useState } from "preact/hooks";
 import { App } from "@modelcontextprotocol/ext-apps";
 import { bindHostContext } from "~/shared/host-context-hook";
 import { CasysCredit, cx, StateMessage, ViewerShell } from "~/shared/ui";
@@ -613,16 +613,28 @@ function FunnelContent(
   {
     data,
     error,
-    refreshing: _refreshing,
+    refreshing,
     fixture,
-    onRefresh: _onRefresh,
+    rootRefreshRequest,
+    rootFreshEvent,
+    rootMutationEvent,
+    canRefreshRoot,
+    onRefresh,
+    onMutationInvalidate,
+    onMutationRefresh,
     onError,
   }: {
     data: FunnelData;
     error: string | null;
     refreshing: boolean;
-    onRefresh: () => void;
     fixture: boolean;
+    rootRefreshRequest: UiRefreshRequestData | null;
+    rootFreshEvent: number;
+    rootMutationEvent: number;
+    canRefreshRoot: boolean;
+    onRefresh: () => void;
+    onMutationInvalidate: () => void;
+    onMutationRefresh?: () => void;
     onError: (msg: string | null) => void;
   },
 ) {
@@ -630,7 +642,7 @@ function FunnelContent(
   const { ref: containerRef, layout } = useViewerLayout<HTMLDivElement>();
 
   // ── Navigation (pile de niveaux) ──────────────────────────────────────
-  const rootKey = viewerRootKey("funnel", data.refreshRequest, {
+  const rootKey = viewerRootKey("funnel", rootRefreshRequest ?? undefined, {
     title: data.title,
   });
   const viewerNav = useViewerNav(app, {
@@ -641,6 +653,12 @@ function FunnelContent(
   }, { fixture });
   const nav = viewerNav.nav;
   const { current: navCurrent, isRoot } = nav;
+  useLayoutEffect(() => {
+    const root = nav.stack.levels[0];
+    if (rootFreshEvent > rootMutationEvent && root?.stale) {
+      nav.clearStale(root.id);
+    }
+  }, [rootFreshEvent, rootMutationEvent]);
 
   // jumpsEnabled = false en fixture (pas d'outils) ou si l'hôte ne relaie pas.
   const { jumpsEnabled } = viewerNav;
@@ -790,6 +808,35 @@ function FunnelContent(
                 )}
               </div>
               <div class="flex min-w-0 shrink-0 items-center gap-2">
+                {navCurrent.stale && (
+                  <div
+                    role="status"
+                    title={t("nav.stale_title")}
+                    class="flex items-center gap-1.5 font-mono text-[9.5px] text-warn"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="size-[5px] rounded-full bg-warn"
+                    />
+                    {isWide && (
+                      <span>
+                        {t("nav.stale_values", { at: navCurrent.stale.at })}
+                      </span>
+                    )}
+                    {canRefreshRoot && (
+                      <button
+                        type="button"
+                        disabled={refreshing}
+                        onClick={onRefresh}
+                        aria-label={t("nav.refresh")}
+                        title={t("nav.refresh")}
+                        class="rounded-[3px] px-1 text-[12px] leading-none text-warn hover:bg-warn/10 disabled:opacity-50"
+                      >
+                        {refreshing ? "…" : "↻"}
+                      </button>
+                    )}
+                  </div>
+                )}
                 <ActiveContextChip
                   compact={!isWide}
                   selections={activeContext.selections}
@@ -873,6 +920,9 @@ function FunnelContent(
         onAsk={ask}
         onError={onError}
         onMutated={nav.markStale}
+        onDocumentChanged={nav.reportDocumentChange}
+        onMutationInvalidate={onMutationInvalidate}
+        onMutationRefresh={onMutationRefresh}
         onRefresh={() => void nav.refreshLevel()}
       >
         {/* Contenu racine — funnel chart */}
@@ -928,10 +978,13 @@ export function FunnelViewer() {
   );
   const [loading, setLoading] = useState(!fixture);
   const [refreshing, setRefreshing] = useState(false);
+  const [rootFreshEvent, setRootFreshEvent] = useState(0);
+  const [rootMutationEvent, setRootMutationEvent] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const dataRef = useRef<FunnelData | null>(fixture ? FUNNEL_FIXTURE : null);
   const refreshRequestRef = useRef<UiRefreshRequestData | null>(null);
   const refreshSequenceRef = useRef(createUiRefreshSequence());
+  const rootEventRef = useRef(0);
   const lastRefreshStartedAtRef = useRef(0);
 
   function hydrateData(nextData: FunnelData) {
@@ -941,6 +994,7 @@ export function FunnelViewer() {
       refreshRequestRef.current,
     );
     setData(nextData);
+    setRootFreshEvent(++rootEventRef.current);
   }
 
   function consumeToolResult(result: ToolResultPayload): boolean {
@@ -960,28 +1014,14 @@ export function FunnelViewer() {
     }
   }
 
-  async function requestRefresh(options: { ignoreInterval?: boolean } = {}) {
+  async function requestRefresh(
+    options: { ignoreInterval?: boolean; force?: boolean } = {},
+  ) {
     if (fixture) return false;
     const request = resolveUiRefreshRequest(
       dataRef.current,
       refreshRequestRef.current,
     );
-    const sequence = refreshSequenceRef.current;
-    if (
-      !canRequestUiRefresh({
-        request,
-        visibilityState: typeof document === "undefined"
-          ? "visible"
-          : document.visibilityState,
-        refreshInFlight: sequence.inFlight !== null,
-        now: Date.now(),
-        lastRefreshStartedAt: lastRefreshStartedAtRef.current,
-        minIntervalMs: FUNNEL_REFRESH_INTERVAL_MS,
-      }, options)
-    ) {
-      return false;
-    }
-
     if (
       !request ||
       !canCallViewerTool(
@@ -993,7 +1033,32 @@ export function FunnelViewer() {
       return false;
     }
 
-    const started = beginUiRefresh(sequence);
+    const sequence = refreshSequenceRef.current;
+    if (sequence.inFlight !== null) {
+      if (options.force) {
+        refreshSequenceRef.current = beginUiRefresh(sequence, {
+          force: true,
+        }).state;
+      }
+      return false;
+    }
+    const forced = Boolean(options.force || sequence.pendingForced);
+    if (
+      !canRequestUiRefresh({
+        request,
+        visibilityState: typeof document === "undefined"
+          ? "visible"
+          : document.visibilityState,
+        refreshInFlight: false,
+        now: Date.now(),
+        lastRefreshStartedAt: lastRefreshStartedAtRef.current,
+        minIntervalMs: FUNNEL_REFRESH_INTERVAL_MS,
+      }, { ignoreInterval: options.ignoreInterval || forced })
+    ) {
+      return false;
+    }
+
+    const started = beginUiRefresh(sequence, { force: forced });
     if (started.generation === null) return false;
     refreshSequenceRef.current = started.state;
     lastRefreshStartedAtRef.current = Date.now();
@@ -1028,6 +1093,9 @@ export function FunnelViewer() {
       }
     }
     setRefreshing(false);
+    if (completed.runPending) {
+      void requestRefresh({ ignoreInterval: true, force: true });
+    }
     return succeeded;
   }
 
@@ -1086,13 +1154,38 @@ export function FunnelViewer() {
     );
   }
 
+  const rootRefreshRequest = resolveUiRefreshRequest(
+    data,
+    refreshRequestRef.current,
+  );
+  const canRefreshRoot = Boolean(
+    !fixture &&
+      rootRefreshRequest &&
+      app.getHostCapabilities()?.serverTools &&
+      readAvailableTools(data)?.includes(rootRefreshRequest.toolName),
+  );
+
   return (
     <FunnelContent
       data={data}
       error={error}
       refreshing={refreshing}
       fixture={fixture}
-      onRefresh={() => void requestRefresh({ ignoreInterval: true })}
+      rootRefreshRequest={rootRefreshRequest}
+      rootFreshEvent={rootFreshEvent}
+      rootMutationEvent={rootMutationEvent}
+      canRefreshRoot={canRefreshRoot}
+      onRefresh={() =>
+        void requestRefresh({ ignoreInterval: true, force: true })}
+      onMutationInvalidate={() => {
+        setRootMutationEvent(++rootEventRef.current);
+        refreshSequenceRef.current = invalidateUiRefresh(
+          refreshSequenceRef.current,
+        );
+      }}
+      onMutationRefresh={canRefreshRoot
+        ? () => void requestRefresh({ ignoreInterval: true, force: true })
+        : undefined}
       onError={setError}
     />
   );

--- a/src/ui/funnel-viewer/src/types.ts
+++ b/src/ui/funnel-viewer/src/types.ts
@@ -1,5 +1,5 @@
-import type { UiRefreshRequestData } from "~/shared/refresh";
-import type { NavHint } from "~/shared/jumps";
+import type { UiRefreshRequestData } from "../../shared/refresh.ts";
+import type { NavHint } from "../../shared/jumps.ts";
 
 export interface FunnelStage {
   label: string;
@@ -17,6 +17,8 @@ export interface FunnelData {
   stages: FunnelStage[];
   currency?: string;
   refreshRequest?: UiRefreshRequestData;
+  /** Outils exacts autorisés par le registre serveur pour ce viewer. */
+  _availableTools?: string[];
   /**
    * Sauts serveur par libellé d'étape.
    * Injecté par withUiRefreshRequest → FUNNEL_STAGE_JUMPS.

--- a/src/ui/invoice-viewer/src/InvoiceViewer.tsx
+++ b/src/ui/invoice-viewer/src/InvoiceViewer.tsx
@@ -11,9 +11,13 @@
  *  - InvoiceViewer : état, connexion, refresh, actions — sans hooks d'UI.
  *  - InvoiceContent : rendu, pile de navigation, boutons — data toujours dispo.
  */
-import { useEffect, useRef, useState } from "preact/hooks";
+import { useEffect, useLayoutEffect, useRef, useState } from "preact/hooks";
 import { App } from "@modelcontextprotocol/ext-apps";
 import { bindHostContext } from "~/shared/host-context-hook";
+import type { DocumentChangeEvent } from "~/shared/document-events";
+import { AttachmentsSection } from "~/shared/document/AttachmentsSection";
+import { documentCapabilities } from "~/shared/document/capabilities";
+import { useAttachments } from "~/shared/document/useAttachments";
 import {
   Button,
   CasysCredit,
@@ -37,25 +41,31 @@ import {
 } from "~/shared/refresh";
 import { useT } from "~/shared/i18n-hook";
 import { ConfirmSheet, type ConfirmState, useConfirm } from "~/shared/confirm";
-import { type NavHint } from "~/shared/jumps";
 import { useViewerNav } from "~/shared/useViewerNav";
 import { viewerRootKey } from "~/shared/nav-stack";
 import { PathBar } from "~/shared/PathBar";
 import { LevelBody } from "~/shared/levels/LevelBody";
 import { canSendTextMessage, sendTextMessage } from "~/shared/host-message";
-import { hasAvailableTool, readAvailableTools } from "~/shared/viewer-tools";
+import { hasAvailableTool } from "~/shared/viewer-tools";
 import { StatusBadge } from "./components/StatusBadge";
 import { ItemDetailPanel } from "./components/ItemDetailPanel";
-import { INVOICE_FIXTURE, isFixtureMode } from "./fixture.ts";
+import {
+  INVOICE_ATTACHMENT_FIXTURES,
+  INVOICE_FIXTURE,
+  isFixtureMode,
+} from "./fixture.ts";
 import {
   canOfferNavigation,
   invoiceJumps,
   invoiceMutationActions,
+  invoiceRootDocumentChange,
+  type InvoiceRootMutation,
   nextInvoiceMutationCommitted,
 } from "./nav.ts";
 import {
   type InvoiceData,
-  invoiceDataFromPayload,
+  type InvoiceDocumentEnvelope,
+  invoiceDocumentEnvelope,
   type InvoiceItem,
   type InvoicePayload,
 } from "./types.ts";
@@ -63,6 +73,8 @@ import {
 const app = new App({ name: "Invoice Viewer", version: "3.0.0" });
 const REFRESH_INTERVAL_MS = 15_000;
 const TOOL_CALL_TIMEOUT_MS = 10_000;
+const CANONICAL_READBACK_DELAY_MS = 1_500;
+const ATTACHMENT_SIDEBAR_MIN_WIDTH = 960;
 
 type LineRow = InvoiceItem & { idx: number };
 
@@ -70,9 +82,7 @@ type LineRow = InvoiceItem & { idx: number };
 
 interface InvoiceContentProps {
   data: InvoiceData;
-  /** Hints du serveur ; null = pas de sauts disponibles. */
-  hints: NavHint[] | null;
-  availableTools: readonly string[] | undefined;
+  envelope: InvoiceDocumentEnvelope;
   mutationCommitted: boolean;
   error: string | null;
   refreshing: boolean;
@@ -81,12 +91,18 @@ interface InvoiceContentProps {
   actionLoading: string | null;
   actionMessage: string | null;
   actionIsError: boolean;
+  rootFreshEvent: number;
+  rootMutationEvent: number;
   callAction: (
-    key: string,
+    mutation: InvoiceRootMutation,
     toolName: string,
     args: Record<string, unknown>,
     successMsg: string,
+    target: { doctype: string; name: string },
+    onDocumentChanged: (event: DocumentChangeEvent) => void,
   ) => Promise<void>;
+  onBeginCanonicalReadback: () => void;
+  onCanonicalRefresh: () => Promise<boolean>;
   onNavigate: (key: string, message: string) => Promise<boolean>;
   setError: (msg: string | null) => void;
 }
@@ -98,17 +114,14 @@ interface InvoiceContentProps {
 export function InvoiceViewer() {
   const t = useT();
   const fixture = isFixtureMode();
+  const initialEnvelope = fixture
+    ? invoiceDocumentEnvelope(INVOICE_FIXTURE)
+    : null;
 
   /* ── État ─────────────────────────────────────────────────────────────── */
 
-  const [data, setData] = useState<InvoiceData | null>(
-    fixture ? (INVOICE_FIXTURE.data ?? null) : null,
-  );
-  const [hints, setHints] = useState<NavHint[] | null>(
-    fixture ? (INVOICE_FIXTURE._sendMessageHints as NavHint[] ?? null) : null,
-  );
-  const [availableTools, setAvailableTools] = useState<string[] | undefined>(
-    fixture ? readAvailableTools(INVOICE_FIXTURE) : undefined,
+  const [envelope, setEnvelope] = useState<InvoiceDocumentEnvelope | null>(
+    initialEnvelope,
   );
   const [loading, setLoading] = useState(!fixture);
   const [refreshing, setRefreshing] = useState(false);
@@ -117,35 +130,39 @@ export function InvoiceViewer() {
   const [actionMessage, setActionMessage] = useState<string | null>(null);
   const [actionIsError, setActionIsError] = useState(false);
   const [mutationCommitted, setMutationCommitted] = useState(false);
+  const [rootFreshEvent, setRootFreshEvent] = useState(0);
+  const [rootMutationEvent, setRootMutationEvent] = useState(0);
   const confirm = useConfirm();
 
   /* ── Refs ─────────────────────────────────────────────────────────────── */
 
   const loadingRef = useRef<HTMLDivElement>(null);
-  const dataRef = useRef<InvoiceData | null>(
-    fixture ? (INVOICE_FIXTURE.data ?? null) : null,
-  );
+  const envelopeRef = useRef<InvoiceDocumentEnvelope | null>(initialEnvelope);
   const refreshRequestRef = useRef<UiRefreshRequestData | null>(
-    fixture ? resolveUiRefreshRequest(INVOICE_FIXTURE, null) : null,
+    initialEnvelope?.refreshRequest ?? null,
   );
   const refreshSequenceRef = useRef(createUiRefreshSequence());
   const refreshPromiseRef = useRef<Promise<boolean> | null>(null);
   const lastRefreshStartedAtRef = useRef(0);
-  const availableToolsRef = useRef<string[] | undefined>(
-    fixture ? readAvailableTools(INVOICE_FIXTURE) : undefined,
+  const availableToolsRef = useRef<readonly string[] | undefined>(
+    initialEnvelope?.availableTools,
   );
   const actionInFlightRef = useRef(false);
   const mutationCommittedRef = useRef(false);
+  const canonicalRefreshBlockedRef = useRef(false);
+  const rootEventRef = useRef(0);
 
   /* ── Hydratation ──────────────────────────────────────────────────────── */
 
-  function hydrateData(nextData: InvoiceData) {
-    dataRef.current = nextData;
-    setData(nextData);
+  function hydrateData(nextEnvelope: InvoiceDocumentEnvelope) {
+    envelopeRef.current = nextEnvelope;
+    setEnvelope(nextEnvelope);
+    canonicalRefreshBlockedRef.current = false;
     mutationCommittedRef.current = false;
     setMutationCommitted((current) =>
       nextInvoiceMutationCommitted(current, "canonical-hydrated")
     );
+    setRootFreshEvent(++rootEventRef.current);
   }
 
   function consumeToolResult(result: ToolResultPayload): boolean {
@@ -159,19 +176,20 @@ export function InvoiceViewer() {
     if (!text) return false;
     try {
       const parsed = JSON.parse(text) as InvoicePayload;
-      const nextData = invoiceDataFromPayload(parsed);
-      if (!nextData) throw new Error("Missing explicit document identity");
-      const nextAvailableTools = readAvailableTools(parsed);
-      availableToolsRef.current = nextAvailableTools;
-      setAvailableTools(nextAvailableTools);
-      refreshRequestRef.current = resolveUiRefreshRequest(
+      const parsedEnvelope = invoiceDocumentEnvelope(parsed);
+      if (!parsedEnvelope) {
+        throw new Error("Missing explicit document identity");
+      }
+      availableToolsRef.current = parsedEnvelope.availableTools;
+      const refreshRequest = resolveUiRefreshRequest(
         parsed,
         refreshRequestRef.current,
       );
-      // Extraire les hints de navigation du payload serveur.
-      const nextHints = parsed._sendMessageHints;
-      setHints(Array.isArray(nextHints) ? nextHints as NavHint[] : null);
-      hydrateData(nextData);
+      refreshRequestRef.current = refreshRequest;
+      hydrateData({
+        ...parsedEnvelope,
+        ...(refreshRequest ? { refreshRequest } : {}),
+      });
       setError(null);
       setLoading(false);
       return true;
@@ -187,7 +205,7 @@ export function InvoiceViewer() {
   async function requestRefresh(
     options: { ignoreInterval?: boolean; force?: boolean } = {},
   ): Promise<boolean> {
-    if (fixture) return false;
+    if (fixture || canonicalRefreshBlockedRef.current) return false;
 
     const current = refreshSequenceRef.current;
     if (options.force) {
@@ -285,11 +303,30 @@ export function InvoiceViewer() {
 
   /* ── Actions ──────────────────────────────────────────────────────────── */
 
+  function invalidateRefresh() {
+    refreshSequenceRef.current = invalidateUiRefresh(
+      refreshSequenceRef.current,
+    );
+  }
+
+  function beginCanonicalReadback() {
+    canonicalRefreshBlockedRef.current = true;
+    invalidateRefresh();
+    setRootMutationEvent(++rootEventRef.current);
+  }
+
+  function requestCanonicalRefresh(): Promise<boolean> {
+    canonicalRefreshBlockedRef.current = false;
+    return requestRefresh({ ignoreInterval: true, force: true });
+  }
+
   async function callAction(
-    key: string,
+    mutation: InvoiceRootMutation,
     toolName: string,
     args: Record<string, unknown>,
     successMsg: string,
+    target: { doctype: string; name: string },
+    onDocumentChanged: (event: DocumentChangeEvent) => void,
   ) {
     if (
       fixture ||
@@ -298,14 +335,20 @@ export function InvoiceViewer() {
       !hasAvailableTool(availableToolsRef.current, toolName)
     ) return;
     actionInFlightRef.current = true;
-    setActionLoading(key);
+    setActionLoading(mutation);
     setActionMessage(null);
     setActionIsError(false);
+    const targetIsCurrent = () => {
+      const current = envelopeRef.current;
+      return current?.doctype === target.doctype &&
+        current.name === target.name;
+    };
     try {
       const result = await app.callServerTool({
         name: toolName,
         arguments: args,
       }, { timeout: TOOL_CALL_TIMEOUT_MS });
+      if (!targetIsCurrent()) return;
       if (result.isError) {
         const text = extractToolResultText(result);
         setActionIsError(true);
@@ -315,21 +358,30 @@ export function InvoiceViewer() {
         setMutationCommitted((current) =>
           nextInvoiceMutationCommitted(current, "mutation-committed")
         );
-        const refreshPromise = requestRefresh({
-          ignoreInterval: true,
-          force: true,
-        });
+        onDocumentChanged(invoiceRootDocumentChange(
+          target.doctype,
+          target.name,
+          mutation,
+          new Date().toISOString(),
+        ));
+        beginCanonicalReadback();
         setActionIsError(false);
         setActionMessage(successMsg);
-        const refreshed = await refreshPromise;
+        await new Promise<void>((resolve) =>
+          setTimeout(resolve, CANONICAL_READBACK_DELAY_MS)
+        );
+        if (!targetIsCurrent()) return;
+        const refreshed = await requestCanonicalRefresh();
         if (!refreshed && mutationCommittedRef.current) {
           setActionIsError(true);
           setActionMessage(t("invoice.error.refresh_failed"));
         }
       }
     } catch {
-      setActionIsError(true);
-      setActionMessage(t("invoice.error.action_failed"));
+      if (targetIsCurrent()) {
+        setActionIsError(true);
+        setActionMessage(t("invoice.error.action_failed"));
+      }
     } finally {
       actionInFlightRef.current = false;
       setActionLoading(null);
@@ -359,13 +411,11 @@ export function InvoiceViewer() {
   useEffect(() => {
     if (fixture) return;
     app.ontoolresult = (result: ToolResultPayload) => {
-      refreshSequenceRef.current = invalidateUiRefresh(
-        refreshSequenceRef.current,
-      );
+      invalidateRefresh();
       consumeToolResult(result);
     };
     app.ontoolinputpartial = () => {
-      if (!dataRef.current) setLoading(true);
+      if (!envelopeRef.current) setLoading(true);
     };
     app.connect().then(() => bindHostContext(app)).catch(() => {});
   }, [fixture]);
@@ -388,7 +438,7 @@ export function InvoiceViewer() {
 
   /* ── Early returns ────────────────────────────────────────────────────── */
 
-  if (loading || !data) {
+  if (loading || !envelope) {
     return (
       <ViewerShell containerRef={loadingRef}>
         <StateMessage>
@@ -401,12 +451,13 @@ export function InvoiceViewer() {
 
   /* ── Rendu ────────────────────────────────────────────────────────────── */
 
+  const data = envelope.document;
+
   return (
     <InvoiceContent
       key={`${data.doctype}:${data.name}`}
       data={data}
-      hints={hints}
-      availableTools={availableTools}
+      envelope={envelope}
       mutationCommitted={mutationCommitted}
       error={error}
       refreshing={refreshing}
@@ -415,7 +466,11 @@ export function InvoiceViewer() {
       actionLoading={actionLoading}
       actionMessage={actionMessage}
       actionIsError={actionIsError}
+      rootFreshEvent={rootFreshEvent}
+      rootMutationEvent={rootMutationEvent}
       callAction={callAction}
+      onBeginCanonicalReadback={beginCanonicalReadback}
+      onCanonicalRefresh={requestCanonicalRefresh}
       onNavigate={navigate}
       setError={setError}
     />
@@ -430,8 +485,7 @@ export function InvoiceViewer() {
 
 function InvoiceContent({
   data,
-  hints,
-  availableTools,
+  envelope,
   mutationCommitted,
   error,
   refreshing,
@@ -440,13 +494,17 @@ function InvoiceContent({
   actionLoading,
   actionMessage,
   actionIsError,
+  rootFreshEvent,
+  rootMutationEvent,
   callAction,
+  onBeginCanonicalReadback,
+  onCanonicalRefresh,
   onNavigate,
   setError,
 }: InvoiceContentProps) {
   /* ── Hooks d'UI (inconditionnels) ────────────────────────────────────── */
 
-  const { ref, layout } = useViewerLayout<HTMLDivElement>();
+  const { ref, width, layout } = useViewerLayout<HTMLDivElement>();
   const t = useT();
 
   // Pile de navigation : titre racine = nom de la pièce.
@@ -461,10 +519,79 @@ function InvoiceContent({
   }, { fixture });
   const nav = viewerNav.nav;
 
+  const rootLevelId = nav.stack.levels[0].id;
+  useLayoutEffect(() => {
+    if (rootFreshEvent > rootMutationEvent) nav.clearStale(rootLevelId);
+  }, [rootFreshEvent, rootMutationEvent, rootLevelId]);
+
   // useDoclist doit être appelé inconditionnellement avant tout return.
   const { list } = viewerNav;
 
   const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
+  const [canonicalRefreshPending, setCanonicalRefreshPending] = useState(false);
+  const delayedRefreshRef = useRef<number | null>(null);
+  const delayedRefreshGenerationRef = useRef(0);
+
+  useEffect(() => () => {
+    delayedRefreshGenerationRef.current += 1;
+    if (delayedRefreshRef.current !== null) {
+      clearTimeout(delayedRefreshRef.current);
+    }
+  }, []);
+
+  const hostCapabilities = fixture ? undefined : app.getHostCapabilities();
+  const availableTools = envelope.availableTools;
+  const hints = envelope.sendMessageHints
+    ? [...envelope.sendMessageHints]
+    : null;
+  const baseDocumentCapabilities = documentCapabilities(
+    hostCapabilities,
+    availableTools,
+    envelope.refreshRequest,
+  );
+  const attachmentCapabilities = {
+    ...baseDocumentCapabilities,
+    canUploadAttachment: baseDocumentCapabilities.canUploadAttachment &&
+      actionLoading === null && !mutationCommitted &&
+      !canonicalRefreshPending,
+  };
+
+  function scheduleCanonicalRefresh(invalidate = true) {
+    if (invalidate) onBeginCanonicalReadback();
+    setCanonicalRefreshPending(true);
+    const generation = ++delayedRefreshGenerationRef.current;
+    if (delayedRefreshRef.current !== null) {
+      clearTimeout(delayedRefreshRef.current);
+    }
+    delayedRefreshRef.current = window.setTimeout(() => {
+      delayedRefreshRef.current = null;
+      const finish = () => {
+        if (delayedRefreshGenerationRef.current !== generation) return false;
+        setCanonicalRefreshPending(false);
+        return true;
+      };
+      void onCanonicalRefresh().then((refreshed) => {
+        if (finish() && !refreshed) {
+          setError(t("invoice.error.refresh_failed"));
+        }
+      }, () => {
+        if (finish()) setError(t("invoice.error.refresh_failed"));
+      });
+    }, CANONICAL_READBACK_DELAY_MS);
+  }
+
+  const attachments = useAttachments({
+    app,
+    envelope,
+    capabilities: attachmentCapabilities,
+    fixtureFiles: fixture ? INVOICE_ATTACHMENT_FIXTURES : undefined,
+    onDocumentChanged: (event) => {
+      nav.reportDocumentChange(event);
+      scheduleCanonicalRefresh();
+    },
+  });
+  const attachmentMutationBusy = attachments.state.upload !== "idle" &&
+    attachments.state.upload !== "error";
 
   /* ── Valeurs dérivées ─────────────────────────────────────────────────── */
 
@@ -483,7 +610,7 @@ function InvoiceContent({
     ((data.grand_total ?? 0) - netTotal);
   const isDraft = data.status === "Draft" || data.docstatus === 0;
   const isSubmitted = data.docstatus === 1;
-  const hasServerTools = Boolean(app.getHostCapabilities()?.serverTools);
+  const hasServerTools = Boolean(hostCapabilities?.serverTools);
   const canInspectItem = hasServerTools && (
     hasAvailableTool(availableTools, "erpnext_item_get") ||
     hasAvailableTool(availableTools, "erpnext_stock_balance")
@@ -495,9 +622,37 @@ function InvoiceContent({
   const canExpand = canInspectItem || messagesEnabled || fixture;
   const rows: LineRow[] = items.map((item, idx) => ({ ...item, idx }));
   const previewTitle = fixture ? t("invoice.preview.title") : undefined;
-
   const isWide = layout === "wide";
   const isMobile = layout === "mobile";
+  const rootStale = nav.stack.levels[0].stale;
+  const rootStaleIndicator = nav.isRoot && rootStale
+    ? (
+      <span
+        role="status"
+        aria-label={t("nav.stale_values", { at: rootStale.at })}
+        title={t("nav.stale_title")}
+        class="inline-flex items-center gap-1.5 font-mono text-nano text-warn"
+      >
+        <span aria-hidden="true" class="size-[5px] rounded-full bg-warn" />
+        {!isMobile && <span>{t("nav.stale_values", { at: rootStale.at })}
+        </span>}
+      </span>
+    )
+    : null;
+
+  const showAttachments = fixture ||
+    baseDocumentCapabilities.canListAttachments;
+  const showAttachmentSidebar = showAttachments && isWide &&
+    width !== null && width >= ATTACHMENT_SIDEBAR_MIN_WIDTH;
+  const attachmentSection = showAttachments
+    ? (
+      <AttachmentsSection
+        controller={attachments}
+        capabilities={attachmentCapabilities}
+        layout={layout}
+      />
+    )
+    : null;
 
   /* ── Sauts de navigation ─────────────────────────────────────────────── */
 
@@ -655,7 +810,9 @@ function InvoiceContent({
     <Button
       variant="accent"
       class={isMobile ? "min-h-[44px] rounded-touch text-body" : "text-cell"}
-      disabled={fixture || actionLoading === "submit"}
+      disabled={fixture || actionLoading === "submit" ||
+        canonicalRefreshPending ||
+        attachmentMutationBusy}
       title={fixture ? previewTitle : t("invoice.btn.submit.title")}
       onClick={() =>
         confirm.request({
@@ -670,6 +827,8 @@ function InvoiceContent({
               mutations.submit.toolName,
               mutations.submit.args,
               t("invoice.action.submitted"),
+              { doctype, name: data.name },
+              nav.reportDocumentChange,
             );
           },
         })}
@@ -687,7 +846,9 @@ function InvoiceContent({
           ? "w-full min-h-[44px] rounded-touch text-body"
           : "ml-auto text-cell",
       )}
-      disabled={fixture || actionLoading === "cancel"}
+      disabled={fixture || actionLoading === "cancel" ||
+        canonicalRefreshPending ||
+        attachmentMutationBusy}
       title={fixture ? previewTitle : t("invoice.btn.cancel.title")}
       onClick={() =>
         confirm.request({
@@ -702,6 +863,8 @@ function InvoiceContent({
               mutations.cancel.toolName,
               mutations.cancel.args,
               t("invoice.action.cancelled"),
+              { doctype, name: data.name },
+              nav.reportDocumentChange,
             );
           },
         })}
@@ -776,6 +939,7 @@ function InvoiceContent({
                   {t("common.refreshing")}
                 </span>
               )}
+              {rootStaleIndicator}
               {nav.isRoot && (
                 <span class="text-data text-ink-muted">
                   {partyName}
@@ -828,115 +992,139 @@ function InvoiceContent({
           onAsk={ask}
           onError={setError}
           onMutated={nav.markStale}
+          onDocumentChanged={nav.reportDocumentChange}
+          onMutationInvalidate={onBeginCanonicalReadback}
+          onMutationRefresh={() => scheduleCanonicalRefresh(false)}
           onRefresh={() => void nav.refreshLevel()}
         >
           {/* ── Contenu racine (niveau 1 seulement) ── */}
           {messages}
 
-          {/* En-tête de tableau */}
           <div
-            class="grid border-b border-line bg-sunken"
-            style={{
-              gridTemplateColumns: "2.6fr 0.5fr 0.9fr 1fr",
-              padding: "8px 16px",
-            }}
+            class={showAttachmentSidebar ? "grid min-w-0" : "min-w-0"}
+            style={showAttachmentSidebar
+              ? { gridTemplateColumns: "minmax(0, 1fr) 268px" }
+              : undefined}
           >
-            <span class="font-mono text-micro uppercase tracking-label text-ink-faint">
-              {t("invoice.table.col.item")}
-            </span>
-            <span class="font-mono text-micro uppercase tracking-label text-ink-faint text-right">
-              {t("invoice.table.col.qty")}
-            </span>
-            <span class="font-mono text-micro uppercase tracking-label text-ink-faint text-right">
-              {t("invoice.table.col.rate")}
-            </span>
-            <span class="font-mono text-micro uppercase tracking-label text-ink-faint text-right">
-              {t("invoice.table.col.amount")}
-            </span>
-          </div>
-
-          {/* Lignes article */}
-          {rows.map((row) => {
-            const isSelected = canExpand && expandedIdx === row.idx;
-            return (
-              <div key={`${row.idx}-${row.item_code}`}>
-                <div
-                  class={cx(
-                    "grid items-center border-b border-line-soft focus-visible:outline-2 focus-visible:outline-accent",
-                    canExpand ? "cursor-pointer" : "",
-                    isSelected ? "bg-row-selected" : "hover:bg-row-hover",
-                  )}
-                  style={{
-                    gridTemplateColumns: "2.6fr 0.5fr 0.9fr 1fr",
-                    padding: "10px 16px",
-                    borderLeft: `2px solid ${
-                      isSelected ? "var(--color-accent)" : "transparent"
-                    }`,
-                  }}
-                  role={canExpand ? "button" : undefined}
-                  tabIndex={canExpand ? 0 : undefined}
-                  aria-expanded={canExpand ? isSelected : undefined}
-                  onClick={canExpand
-                    ? () =>
-                      setExpandedIdx(expandedIdx === row.idx ? null : row.idx)
-                    : undefined}
-                  onKeyDown={canExpand
-                    ? (e: KeyboardEvent) => {
-                      if (e.key !== "Enter" && e.key !== " ") return;
-                      e.preventDefault();
-                      setExpandedIdx(expandedIdx === row.idx ? null : row.idx);
-                    }
-                    : undefined}
-                >
-                  <div class="flex flex-col gap-0.5">
-                    <span class="text-body text-ink">
-                      {row.item_name ?? row.item_code}
-                    </span>
-                    <span class="font-mono text-chip text-ink-faint">
-                      {row.item_code}
-                    </span>
-                  </div>
-                  <span class="font-mono text-cell tabular-nums text-ink-2 text-right">
-                    {formatNumber(row.qty)}
-                  </span>
-                  <span class="font-mono text-cell tabular-nums text-ink-muted text-right">
-                    {formatNumber(row.rate)}
-                  </span>
-                  <span class="font-mono text-cell font-medium tabular-nums text-ink text-right">
-                    {formatNumber(row.amount)}
-                  </span>
-                </div>
-
-                {isSelected && (
-                  <ItemDetailPanel
-                    app={app}
-                    itemCode={row.item_code}
-                    fixture={fixture}
-                    availableTools={availableTools}
-                    hints={hints ?? undefined}
-                    onJump={jumpsEnabled ? nav.jump : undefined}
-                    onClose={() => setExpandedIdx(null)}
-                    lineIndex={row.idx}
-                    lineCount={rows.length}
-                    lineQty={row.qty}
-                  />
-                )}
+            <div class="min-w-0">
+              {/* En-tête de tableau */}
+              <div
+                class="grid border-b border-line bg-sunken"
+                style={{
+                  gridTemplateColumns: "2.6fr 0.5fr 0.9fr 1fr",
+                  padding: "8px 16px",
+                }}
+              >
+                <span class="font-mono text-micro uppercase tracking-label text-ink-faint">
+                  {t("invoice.table.col.item")}
+                </span>
+                <span class="font-mono text-micro uppercase tracking-label text-ink-faint text-right">
+                  {t("invoice.table.col.qty")}
+                </span>
+                <span class="font-mono text-micro uppercase tracking-label text-ink-faint text-right">
+                  {t("invoice.table.col.rate")}
+                </span>
+                <span class="font-mono text-micro uppercase tracking-label text-ink-faint text-right">
+                  {t("invoice.table.col.amount")}
+                </span>
               </div>
-            );
-          })}
 
-          {/* Footer : boutons gauche | totaux droite */}
-          <div
-            class="grid border-t border-line"
-            style={{ gridTemplateColumns: "1fr 300px" }}
-          >
-            <div class="flex items-center gap-2 px-4 py-3.5">
-              {btnSubmit}
-              {btnPayments}
-              {btnParty}
-              {btnCancel}
+              {/* Lignes article */}
+              {rows.map((row) => {
+                const isSelected = canExpand && expandedIdx === row.idx;
+                return (
+                  <div key={`${row.idx}-${row.item_code}`}>
+                    <div
+                      class={cx(
+                        "grid items-center border-b border-line-soft focus-visible:outline-2 focus-visible:outline-accent",
+                        canExpand ? "cursor-pointer" : "",
+                        isSelected ? "bg-row-selected" : "hover:bg-row-hover",
+                      )}
+                      style={{
+                        gridTemplateColumns: "2.6fr 0.5fr 0.9fr 1fr",
+                        padding: "10px 16px",
+                        borderLeft: `2px solid ${
+                          isSelected ? "var(--color-accent)" : "transparent"
+                        }`,
+                      }}
+                      role={canExpand ? "button" : undefined}
+                      tabIndex={canExpand ? 0 : undefined}
+                      aria-expanded={canExpand ? isSelected : undefined}
+                      onClick={canExpand
+                        ? () =>
+                          setExpandedIdx(
+                            expandedIdx === row.idx ? null : row.idx,
+                          )
+                        : undefined}
+                      onKeyDown={canExpand
+                        ? (e: KeyboardEvent) => {
+                          if (e.key !== "Enter" && e.key !== " ") return;
+                          e.preventDefault();
+                          setExpandedIdx(
+                            expandedIdx === row.idx ? null : row.idx,
+                          );
+                        }
+                        : undefined}
+                    >
+                      <div class="flex flex-col gap-0.5">
+                        <span class="text-body text-ink">
+                          {row.item_name ?? row.item_code}
+                        </span>
+                        <span class="font-mono text-chip text-ink-faint">
+                          {row.item_code}
+                        </span>
+                      </div>
+                      <span class="font-mono text-cell tabular-nums text-ink-2 text-right">
+                        {formatNumber(row.qty)}
+                      </span>
+                      <span class="font-mono text-cell tabular-nums text-ink-muted text-right">
+                        {formatNumber(row.rate)}
+                      </span>
+                      <span class="font-mono text-cell font-medium tabular-nums text-ink text-right">
+                        {formatNumber(row.amount)}
+                      </span>
+                    </div>
+
+                    {isSelected && (
+                      <ItemDetailPanel
+                        app={app}
+                        itemCode={row.item_code}
+                        fixture={fixture}
+                        availableTools={availableTools}
+                        hints={hints ?? undefined}
+                        onJump={jumpsEnabled ? nav.jump : undefined}
+                        onClose={() => setExpandedIdx(null)}
+                        lineIndex={row.idx}
+                        lineCount={rows.length}
+                        lineQty={row.qty}
+                      />
+                    )}
+                  </div>
+                );
+              })}
+
+              {/* Footer : boutons gauche | totaux droite */}
+              <div
+                class="grid border-t border-line"
+                style={{ gridTemplateColumns: "1fr 300px" }}
+              >
+                <div class="flex items-center gap-2 px-4 py-3.5">
+                  {btnSubmit}
+                  {btnPayments}
+                  {btnParty}
+                  {btnCancel}
+                </div>
+                {totalsPanel}
+              </div>
+              {!showAttachmentSidebar && attachmentSection && (
+                <div class="border-t border-line">{attachmentSection}</div>
+              )}
             </div>
-            {totalsPanel}
+            {showAttachmentSidebar && (
+              <aside class="min-w-0 border-l border-line bg-sunken/35">
+                {attachmentSection}
+              </aside>
+            )}
           </div>
         </LevelBody>
 
@@ -986,6 +1174,7 @@ function InvoiceContent({
             </div>
             <div class="flex flex-col items-end gap-[5px]">
               <StatusBadge status={data.status} />
+              {rootStaleIndicator}
               {data.due_date && (
                 <span class="font-mono text-chip text-ink-muted">
                   {t("invoice.header.due", { date: data.due_date.slice(5) })}
@@ -1016,6 +1205,9 @@ function InvoiceContent({
         onAsk={ask}
         onError={setError}
         onMutated={nav.markStale}
+        onDocumentChanged={nav.reportDocumentChange}
+        onMutationInvalidate={onBeginCanonicalReadback}
+        onMutationRefresh={() => scheduleCanonicalRefresh(false)}
         onRefresh={() => void nav.refreshLevel()}
       >
         {/* ── Contenu racine (niveau 1 seulement) ── */}
@@ -1074,6 +1266,10 @@ function InvoiceContent({
             {formatCurrency(data.grand_total, ccy)}
           </span>
         </div>
+
+        {attachmentSection && (
+          <div class="border-b border-line">{attachmentSection}</div>
+        )}
 
         {/* CTA section */}
         {hasActionButtons && (

--- a/src/ui/invoice-viewer/src/fixture.ts
+++ b/src/ui/invoice-viewer/src/fixture.ts
@@ -1,13 +1,10 @@
 import type { InvoicePayload, ItemRecord, StockRow } from "./types.ts";
+import type { DocumentAttachment } from "../../shared/document/attachment-results.ts";
 
 /** Mock payload so the bundled HTML can be opened without a host. */
 export const INVOICE_FIXTURE: InvoicePayload = {
-  _availableTools: [
-    "erpnext_doc_submit",
-    "erpnext_doc_cancel",
-    "erpnext_item_get",
-    "erpnext_stock_balance",
-  ],
+  // Le mode fixture documente le rendu, mais ne simule aucune action hôte.
+  _availableTools: [],
   data: {
     doctype: "Sales Invoice",
     name: "ACC-SINV-2026-00042",
@@ -97,6 +94,21 @@ export const INVOICE_FIXTURE: InvoicePayload = {
     },
   ],
 };
+
+export const INVOICE_ATTACHMENT_FIXTURES: readonly DocumentAttachment[] = [
+  {
+    id: "FILE-SINV-00042-PDF",
+    fileName: "ACC-SINV-2026-00042.pdf",
+    fileSize: 184_320,
+    isPrivate: true,
+  },
+  {
+    id: "FILE-SINV-00042-DELIVERY",
+    fileName: "signed-delivery-note.png",
+    fileSize: 426_812,
+    isPrivate: false,
+  },
+];
 
 export const ITEM_FIXTURES: Record<string, {
   item: ItemRecord;

--- a/src/ui/invoice-viewer/src/nav.ts
+++ b/src/ui/invoice-viewer/src/nav.ts
@@ -9,6 +9,7 @@
  */
 import type { Jump, NavHint } from "../../shared/jumps.ts";
 import { jumpFromHint } from "../../shared/jumps.ts";
+import type { DocumentChangeEvent } from "../../shared/document-events.ts";
 import { hasAvailableTool } from "../../shared/viewer-tools.ts";
 
 export interface InvoiceJumps {
@@ -29,6 +30,23 @@ export interface InvoiceMutationActions {
 export type InvoiceMutationLifecycleEvent =
   | "mutation-committed"
   | "canonical-hydrated";
+
+export type InvoiceRootMutation = "submit" | "cancel";
+
+export function invoiceRootDocumentChange(
+  doctype: string,
+  name: string,
+  mutation: InvoiceRootMutation,
+  committedAt: string,
+): DocumentChangeEvent {
+  return {
+    doctype,
+    name,
+    mutation,
+    committedAt,
+    source: "invoice-viewer",
+  };
+}
 
 /**
  * Une mutation réussie verrouille l'ancien docstatus. Seule l'hydratation

--- a/src/ui/invoice-viewer/src/nav_test.ts
+++ b/src/ui/invoice-viewer/src/nav_test.ts
@@ -9,9 +9,15 @@ import {
   canOfferNavigation,
   invoiceJumps,
   invoiceMutationActions,
+  invoiceRootDocumentChange,
   nextInvoiceMutationCommitted,
 } from "./nav.ts";
-import { invoiceDataFromPayload } from "./types.ts";
+import { INVOICE_ATTACHMENT_FIXTURES, INVOICE_FIXTURE } from "./fixture.ts";
+import {
+  invoiceDataFromPayload,
+  invoiceDocumentEnvelope,
+  type InvoicePayload,
+} from "./types.ts";
 
 // Langue stable pour les libellés traduits ("Paiements" en fr)
 setLangSource(() => "en-US");
@@ -245,6 +251,92 @@ Deno.test("invoice payload : préfère le DocType explicite et tolère le payloa
       },
     })?.doctype,
     "Quotation",
+  );
+});
+
+Deno.test("invoice envelope : conserve document canonique, refresh et manifeste exact", () => {
+  const envelope = invoiceDocumentEnvelope({
+    data: {
+      doctype: "Sales Invoice",
+      name: "SINV-1",
+      status: "Draft",
+      grand_total: 42,
+    },
+    _availableTools: ["erpnext_file_list", "erpnext_file_list", ""],
+    refreshRequest: {
+      toolName: "erpnext_sales_invoice_get",
+      arguments: { name: "SINV-1" },
+    },
+  });
+
+  assertEquals(envelope?.doctype, "Sales Invoice");
+  assertEquals(envelope?.name, "SINV-1");
+  assertEquals(envelope?.document.name, "SINV-1");
+  assertEquals(envelope?.availableTools, ["erpnext_file_list"]);
+  assertEquals(envelope?.refreshRequest?.toolName, "erpnext_sales_invoice_get");
+});
+
+Deno.test("invoice envelope : manifeste absent reste legacy, manifeste malformé fail-close", () => {
+  const document = {
+    doctype: "Sales Invoice",
+    name: "SINV-1",
+    status: "Draft",
+    grand_total: 42,
+  };
+  assertEquals(
+    invoiceDocumentEnvelope({ data: document })?.availableTools,
+    undefined,
+  );
+  assertEquals(
+    invoiceDocumentEnvelope({
+      data: document,
+      _availableTools: "erpnext_file_upload",
+    } as unknown as InvoicePayload)?.availableTools,
+    [],
+  );
+});
+
+Deno.test("invoice mutations : événements typés indépendants des outils dédiés", () => {
+  assertEquals(
+    invoiceRootDocumentChange(
+      "Sales Invoice",
+      "SINV-1",
+      "submit",
+      "2026-08-24T10:00:00.000Z",
+    ),
+    {
+      doctype: "Sales Invoice",
+      name: "SINV-1",
+      mutation: "submit",
+      committedAt: "2026-08-24T10:00:00.000Z",
+      source: "invoice-viewer",
+    },
+  );
+  assertEquals(
+    invoiceRootDocumentChange(
+      "Sales Order",
+      "SO-1",
+      "cancel",
+      "2026-08-24T10:01:00.000Z",
+    ),
+    {
+      doctype: "Sales Order",
+      name: "SO-1",
+      mutation: "cancel",
+      committedAt: "2026-08-24T10:01:00.000Z",
+      source: "invoice-viewer",
+    },
+  );
+});
+
+Deno.test("invoice fixture : pièces jointes visuelles sans action hôte", () => {
+  assertEquals(INVOICE_FIXTURE._availableTools, []);
+  assertEquals(
+    INVOICE_ATTACHMENT_FIXTURES.map((file) => [file.fileName, file.isPrivate]),
+    [
+      ["ACC-SINV-2026-00042.pdf", true],
+      ["signed-delivery-note.png", false],
+    ],
   );
 });
 

--- a/src/ui/invoice-viewer/src/types.ts
+++ b/src/ui/invoice-viewer/src/types.ts
@@ -1,5 +1,8 @@
 import type { NavHint } from "../../shared/jumps.ts";
+import { documentEnvelopeOf } from "../../shared/document/model.ts";
+import type { DocumentEnvelope } from "../../shared/document/types.ts";
 import type { UiRefreshRequestData } from "../../shared/refresh.ts";
+import { readAvailableTools } from "../../shared/viewer-tools.ts";
 
 export interface InvoiceItem {
   item_code: string;
@@ -35,6 +38,11 @@ export interface InvoiceData {
   items?: InvoiceItem[];
   contact_email?: string;
   address_display?: string;
+  [key: string]: unknown;
+}
+
+export interface InvoiceDocumentEnvelope extends DocumentEnvelope {
+  document: InvoiceData;
 }
 
 export interface InvoicePayload {
@@ -80,6 +88,22 @@ export function invoiceDataFromPayload(
     ...record,
     doctype: legacyDoctype(payload),
   } as unknown as InvoiceData;
+}
+
+/** Normalise aussi les payloads 3.0.x avant de construire l'enveloppe partagée. */
+export function invoiceDocumentEnvelope(
+  payload: InvoicePayload,
+): InvoiceDocumentEnvelope | null {
+  const document = invoiceDataFromPayload(payload);
+  if (!document) return null;
+  const envelope = documentEnvelopeOf({ ...payload, data: document });
+  if (!envelope) return null;
+  const availableTools = readAvailableTools(payload);
+  return {
+    ...envelope,
+    document: envelope.document as unknown as InvoiceData,
+    ...(availableTools !== undefined ? { availableTools } : {}),
+  };
 }
 
 export interface ItemRecord {

--- a/src/ui/kanban-viewer/src/KanbanViewer.tsx
+++ b/src/ui/kanban-viewer/src/KanbanViewer.tsx
@@ -8,7 +8,13 @@
  * Aucun import de @casys/mcp-view.
  */
 import type { ComponentChildren, JSX, Ref } from "preact";
-import { useCallback, useEffect, useRef, useState } from "preact/hooks";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "preact/hooks";
 import { App } from "@modelcontextprotocol/ext-apps";
 import { bindHostContext } from "~/shared/host-context-hook";
 import {
@@ -779,7 +785,16 @@ function MobileColumnNavWrapper({
 /** Extension runtime de KanbanBoardData : le serveur injecte ce champ via withUiRefreshRequest. */
 type BoardWithHints = KanbanBoardData & {
   _sendMessageHints?: NavHint[];
+  refreshRequest?: KanbanRefreshRequestData;
 };
+
+function resolvedBoardRefreshRequest(
+  board: KanbanBoardData | null,
+  fallback: KanbanRefreshRequestData | null,
+): KanbanRefreshRequestData | null {
+  return (board as BoardWithHints | null)?.refreshRequest ??
+    resolveKanbanRefreshRequest(board, fallback);
+}
 
 /* ────────────────────────────── KanbanBoardWithNav ─────────────────────── */
 
@@ -803,6 +818,14 @@ function KanbanBoardWithNav({
   liveMessage,
   inlineError,
   activeDropColumn,
+  refreshing,
+  rootRefreshRequest,
+  rootFreshEvent,
+  rootMutationEvent,
+  canRefreshRoot,
+  onRefreshRoot,
+  onMutationInvalidate,
+  onMutationRefresh,
   onMove,
   onDropCard,
   onDragStart,
@@ -825,6 +848,14 @@ function KanbanBoardWithNav({
   liveMessage: string;
   inlineError: string | null;
   activeDropColumn: string | null;
+  refreshing: boolean;
+  rootRefreshRequest: KanbanRefreshRequestData | null;
+  rootFreshEvent: number;
+  rootMutationEvent: number;
+  canRefreshRoot: boolean;
+  onRefreshRoot: () => void;
+  onMutationInvalidate: () => void;
+  onMutationRefresh?: () => void;
   onMove: (card: KanbanCardData, toColumn: string, label: string) => void;
   onDropCard: (toColumn: string, event: KanbanDragEvent) => void;
   onDragStart: (card: KanbanCardData, event: KanbanDragEvent) => void;
@@ -859,14 +890,17 @@ function KanbanBoardWithNav({
     origin: "list",
     key: viewerRootKey(
       "kanban",
-      {
-        toolName: "erpnext_kanban_get_board",
-        arguments: board.refreshArguments,
-      },
+      rootRefreshRequest ?? undefined,
       { boardId: board.boardId, doctype: board.doctype },
     ),
   }, { fixture });
   const nav = viewerNav.nav;
+  useLayoutEffect(() => {
+    const root = nav.stack.levels[0];
+    if (rootFreshEvent > rootMutationEvent && root?.stale) {
+      nav.clearStale(root.id);
+    }
+  }, [rootFreshEvent, rootMutationEvent]);
   // Liste du niveau courant (racine → vide ; niveau empilé liste → payload de l'outil).
   const { list } = viewerNav;
 
@@ -946,9 +980,62 @@ function KanbanBoardWithNav({
             )}
           </div>
           {!narrow && nav.isRoot && (
-            <span class="font-mono text-chip text-ink-faint shrink-0">
-              {actionCapabilities.canMove ? board.moveToolName : null}
-            </span>
+            <div class="flex shrink-0 items-center gap-2">
+              {nav.current.stale && (
+                <div
+                  role="status"
+                  title={t("nav.stale_title")}
+                  class="flex items-center gap-1.5 font-mono text-[9.5px] text-warn"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="size-[5px] rounded-full bg-warn"
+                  />
+                  <span>
+                    {t("nav.stale_values", { at: nav.current.stale.at })}
+                  </span>
+                  {canRefreshRoot && (
+                    <button
+                      type="button"
+                      disabled={refreshing}
+                      onClick={onRefreshRoot}
+                      aria-label={t("nav.refresh")}
+                      title={t("nav.refresh")}
+                      class="rounded-[3px] px-1 text-[12px] leading-none text-warn hover:bg-warn/10 disabled:opacity-50"
+                    >
+                      {refreshing ? "…" : "↻"}
+                    </button>
+                  )}
+                </div>
+              )}
+              <span class="font-mono text-chip text-ink-faint">
+                {actionCapabilities.canMove ? board.moveToolName : null}
+              </span>
+            </div>
+          )}
+          {narrow && nav.isRoot && nav.current.stale && (
+            <div
+              role="status"
+              title={t("nav.stale_title")}
+              class="ml-auto flex shrink-0 items-center gap-1 font-mono text-warn"
+            >
+              <span
+                aria-hidden="true"
+                class="size-[5px] rounded-full bg-warn"
+              />
+              {canRefreshRoot && (
+                <button
+                  type="button"
+                  disabled={refreshing}
+                  onClick={onRefreshRoot}
+                  aria-label={t("nav.refresh")}
+                  title={t("nav.refresh")}
+                  class="rounded-[3px] px-1 text-[12px] leading-none text-warn hover:bg-warn/10 disabled:opacity-50"
+                >
+                  {refreshing ? "…" : "↻"}
+                </button>
+              )}
+            </div>
           )}
         </header>
 
@@ -974,6 +1061,9 @@ function KanbanBoardWithNav({
             if (msg !== null) onError(msg);
           }}
           onMutated={nav.markStale}
+          onDocumentChanged={nav.reportDocumentChange}
+          onMutationInvalidate={onMutationInvalidate}
+          onMutationRefresh={onMutationRefresh}
           onRefresh={() => void nav.refreshLevel()}
         >
           {/* Contenu racine : le tableau kanban lui-même */}
@@ -1089,6 +1179,8 @@ export function KanbanViewer() {
   const [liveMessage, setLiveMessage] = useState("");
   const [activeDropColumn, setActiveDropColumn] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
+  const [rootFreshEvent, setRootFreshEvent] = useState(0);
+  const [rootMutationEvent, setRootMutationEvent] = useState(0);
   const queueRef = useRef<QueuedKanbanMove[]>([]);
   const snapshotsRef = useRef<Record<string, KanbanBoardData>>({});
   const processingRef = useRef(false);
@@ -1099,6 +1191,7 @@ export function KanbanViewer() {
   const draggingRef = useRef(false);
   const refreshRequestRef = useRef<KanbanRefreshRequestData | null>(null);
   const refreshSequenceRef = useRef(createUiRefreshSequence());
+  const rootEventRef = useRef(0);
   const refreshAfterMutationRef = useRef(false);
   const lastRefreshStartedAtRef = useRef(0);
   const detailFetchCardIdRef = useRef<string | null>(null);
@@ -1110,6 +1203,15 @@ export function KanbanViewer() {
   function updateBoard(board: KanbanBoardData) {
     boardRef.current = board;
     hydrateBoard(board);
+  }
+
+  function acceptCanonicalBoard(board: KanbanBoardData) {
+    refreshRequestRef.current = resolvedBoardRefreshRequest(
+      board,
+      refreshRequestRef.current,
+    );
+    updateBoard(board);
+    setRootFreshEvent(++rootEventRef.current);
   }
 
   function parseToolCallResult(
@@ -1138,7 +1240,7 @@ export function KanbanViewer() {
   ) {
     if (fixture) return false;
     const board = boardRef.current;
-    const request = resolveKanbanRefreshRequest(
+    const request = resolvedBoardRefreshRequest(
       board,
       refreshRequestRef.current,
     );
@@ -1214,7 +1316,7 @@ export function KanbanViewer() {
       const text = extractTextContent(result);
       if (text) {
         try {
-          updateBoard(parseBoard(text));
+          acceptCanonicalBoard(parseBoard(text));
           refreshed = true;
         } catch {
           // Keep the current board when a passive refresh payload is invalid.
@@ -1433,7 +1535,7 @@ export function KanbanViewer() {
       }
 
       try {
-        updateBoard(parseBoard(text));
+        acceptCanonicalBoard(parseBoard(text));
       } catch (error) {
         setError(
           error instanceof Error
@@ -1911,6 +2013,17 @@ export function KanbanViewer() {
     );
   }
 
+  const rootRefreshRequest = resolvedBoardRefreshRequest(
+    state.board,
+    refreshRequestRef.current,
+  );
+  const canRefreshRoot = Boolean(
+    !fixture &&
+      rootRefreshRequest &&
+      app.getHostCapabilities()?.serverTools &&
+      state.board._availableTools?.includes(rootRefreshRequest.toolName),
+  );
+
   return (
     <KanbanBoardWithNav
       board={state.board}
@@ -1921,6 +2034,22 @@ export function KanbanViewer() {
       liveMessage={liveMessage}
       inlineError={errorPresentation.inlineError}
       activeDropColumn={activeDropColumn}
+      refreshing={refreshing}
+      rootRefreshRequest={rootRefreshRequest}
+      rootFreshEvent={rootFreshEvent}
+      rootMutationEvent={rootMutationEvent}
+      canRefreshRoot={canRefreshRoot}
+      onRefreshRoot={() =>
+        void requestBoardRefresh({ ignoreInterval: true, force: true })}
+      onMutationInvalidate={() => {
+        setRootMutationEvent(++rootEventRef.current);
+        refreshSequenceRef.current = invalidateUiRefresh(
+          refreshSequenceRef.current,
+        );
+      }}
+      onMutationRefresh={canRefreshRoot
+        ? () => void requestBoardRefresh({ ignoreInterval: true, force: true })
+        : undefined}
       onMove={requestMove}
       onDropCard={handleDropCard}
       onDragStart={handleDragStart}

--- a/src/ui/kpi-viewer/src/KpiViewer.tsx
+++ b/src/ui/kpi-viewer/src/KpiViewer.tsx
@@ -4,7 +4,7 @@
  * Pile de navigation câblée : sauts « › » quand l'hôte relaie les outils,
  * comportement drillDown inchangé sinon.
  */
-import { useEffect, useRef, useState } from "preact/hooks";
+import { useEffect, useLayoutEffect, useRef, useState } from "preact/hooks";
 import { App } from "@modelcontextprotocol/ext-apps";
 import { bindHostContext } from "~/shared/host-context-hook";
 import {
@@ -809,18 +809,32 @@ function KpiViewerContent({
   data,
   error,
   fixture,
+  refreshing,
+  rootRefreshRequest,
+  rootFreshEvent,
+  rootMutationEvent,
+  canRefreshRoot,
   onError,
   onRefresh,
+  onMutationInvalidate,
+  onMutationRefresh,
 }: {
   data: KpiData;
   error: string | null;
   fixture: boolean;
+  refreshing: boolean;
+  rootRefreshRequest: UiRefreshRequestData | null;
+  rootFreshEvent: number;
+  rootMutationEvent: number;
+  canRefreshRoot: boolean;
   onError: (msg: string | null) => void;
   onRefresh: () => void;
+  onMutationInvalidate: () => void;
+  onMutationRefresh?: () => void;
 }) {
   const { ref: shellRef, layout } = useViewerLayout<HTMLDivElement>();
   const t = useT();
-  const rootKey = viewerRootKey("kpi", data.refreshRequest, {
+  const rootKey = viewerRootKey("kpi", rootRefreshRequest ?? undefined, {
     label: data.label,
   });
   const activeContext = useActiveContext(app, rootKey);
@@ -835,6 +849,12 @@ function KpiViewerContent({
   }, { fixture });
   const nav = viewerNav.nav;
   const { current, isRoot } = nav;
+  useLayoutEffect(() => {
+    const root = nav.stack.levels[0];
+    if (rootFreshEvent > rootMutationEvent && root?.stale) {
+      nav.clearStale(root.id);
+    }
+  }, [rootFreshEvent, rootMutationEvent]);
   // jumpsEnabled : les sauts sont désactivés en mode fixture (pas d'outils).
   const { jumpsEnabled } = viewerNav;
   // useDoclist tenu inconditionnellement : il retournera EMPTY_LIST à la racine.
@@ -891,17 +911,47 @@ function KpiViewerContent({
         onAsk={ask}
         onError={onError}
         onMutated={nav.markStale}
+        onDocumentChanged={nav.reportDocumentChange}
+        onMutationInvalidate={onMutationInvalidate}
+        onMutationRefresh={onMutationRefresh}
         onRefresh={() => void nav.refreshLevel()}
       >
-        <KpiCard
-          data={data}
-          error={error}
-          layout={layout}
-          jumpsEnabled={jumpsEnabled}
-          activeContext={activeContext}
-          onJump={jumpsEnabled ? nav.jump : undefined}
-          onRefresh={onRefresh}
-        />
+        <>
+          {isRoot && current.stale && (
+            <div
+              role="status"
+              title={t("nav.stale_title")}
+              class="flex shrink-0 items-center justify-end gap-1.5 px-3 pt-1 font-mono text-[9.5px] text-warn"
+            >
+              <span
+                aria-hidden="true"
+                class="size-[5px] rounded-full bg-warn"
+              />
+              <span>{t("nav.stale_values", { at: current.stale.at })}</span>
+              {canRefreshRoot && (
+                <button
+                  type="button"
+                  disabled={refreshing}
+                  onClick={onRefresh}
+                  aria-label={t("nav.refresh")}
+                  title={t("nav.refresh")}
+                  class="rounded-[3px] px-1 text-[12px] leading-none text-warn hover:bg-warn/10 disabled:opacity-50"
+                >
+                  {refreshing ? "…" : "↻"}
+                </button>
+              )}
+            </div>
+          )}
+          <KpiCard
+            data={data}
+            error={error}
+            layout={layout}
+            jumpsEnabled={jumpsEnabled}
+            activeContext={activeContext}
+            onJump={jumpsEnabled ? nav.jump : undefined}
+            onRefresh={onRefresh}
+          />
+        </>
       </LevelBody>
     </ViewerShell>
   );
@@ -916,10 +966,14 @@ export function KpiViewer() {
     fixture ? KPI_FIXTURE : null,
   );
   const [loading, setLoading] = useState(!fixture);
+  const [refreshing, setRefreshing] = useState(false);
+  const [rootFreshEvent, setRootFreshEvent] = useState(0);
+  const [rootMutationEvent, setRootMutationEvent] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const dataRef = useRef<KpiData | null>(fixture ? KPI_FIXTURE : null);
   const refreshRequestRef = useRef<UiRefreshRequestData | null>(null);
   const refreshSequenceRef = useRef(createUiRefreshSequence());
+  const rootEventRef = useRef(0);
   const lastRefreshStartedAtRef = useRef(0);
 
   function hydrateData(nextData: KpiData) {
@@ -929,6 +983,7 @@ export function KpiViewer() {
       refreshRequestRef.current,
     );
     setData(nextData);
+    setRootFreshEvent(++rootEventRef.current);
   }
 
   function consumeToolResult(result: ToolResultPayload): boolean {
@@ -947,27 +1002,14 @@ export function KpiViewer() {
     }
   }
 
-  async function requestRefresh(options: { ignoreInterval?: boolean } = {}) {
+  async function requestRefresh(
+    options: { ignoreInterval?: boolean; force?: boolean } = {},
+  ) {
     if (fixture) return false;
     const request = resolveUiRefreshRequest(
       dataRef.current,
       refreshRequestRef.current,
     );
-    const sequence = refreshSequenceRef.current;
-    if (
-      !canRequestUiRefresh({
-        request,
-        visibilityState: typeof document === "undefined"
-          ? "visible"
-          : document.visibilityState,
-        refreshInFlight: sequence.inFlight !== null,
-        now: Date.now(),
-        lastRefreshStartedAt: lastRefreshStartedAtRef.current,
-        minIntervalMs: KPI_REFRESH_INTERVAL_MS,
-      }, options)
-    ) {
-      return false;
-    }
     if (
       !request ||
       !canCallViewerTool(
@@ -979,10 +1021,36 @@ export function KpiViewer() {
       return false;
     }
 
-    const started = beginUiRefresh(sequence);
+    const sequence = refreshSequenceRef.current;
+    if (sequence.inFlight !== null) {
+      if (options.force) {
+        refreshSequenceRef.current = beginUiRefresh(sequence, {
+          force: true,
+        }).state;
+      }
+      return false;
+    }
+    const forced = Boolean(options.force || sequence.pendingForced);
+    if (
+      !canRequestUiRefresh({
+        request,
+        visibilityState: typeof document === "undefined"
+          ? "visible"
+          : document.visibilityState,
+        refreshInFlight: false,
+        now: Date.now(),
+        lastRefreshStartedAt: lastRefreshStartedAtRef.current,
+        minIntervalMs: KPI_REFRESH_INTERVAL_MS,
+      }, { ignoreInterval: options.ignoreInterval || forced })
+    ) {
+      return false;
+    }
+
+    const started = beginUiRefresh(sequence, { force: forced });
     if (started.generation === null) return false;
     refreshSequenceRef.current = started.state;
     lastRefreshStartedAtRef.current = Date.now();
+    setRefreshing(true);
 
     let result: ToolResultPayload | null = null;
     let failure: { cause: unknown } | null = null;
@@ -1000,18 +1068,23 @@ export function KpiViewer() {
       started.generation,
     );
     refreshSequenceRef.current = completed.state;
+    let succeeded = false;
     if (completed.accept) {
       if (failure) {
         setError(normalizeUiRefreshFailureMessage(failure.cause));
       } else if (result?.isError) {
         setError(t("common.error.refresh_failed"));
       } else if (result && consumeToolResult(result)) {
-        return true;
+        succeeded = true;
       } else {
         setError(t("common.error.refresh_no_data"));
       }
     }
-    return false;
+    setRefreshing(false);
+    if (completed.runPending) {
+      void requestRefresh({ ignoreInterval: true, force: true });
+    }
+    return succeeded;
   }
 
   useEffect(() => {
@@ -1064,13 +1137,39 @@ export function KpiViewer() {
     );
   }
 
+  const rootRefreshRequest = resolveUiRefreshRequest(
+    data,
+    refreshRequestRef.current,
+  );
+  const canRefreshRoot = Boolean(
+    !fixture &&
+      rootRefreshRequest &&
+      app.getHostCapabilities()?.serverTools &&
+      readAvailableTools(data)?.includes(rootRefreshRequest.toolName),
+  );
+
   return (
     <KpiViewerContent
       data={data}
       error={error}
       fixture={fixture}
+      refreshing={refreshing}
+      rootRefreshRequest={rootRefreshRequest}
+      rootFreshEvent={rootFreshEvent}
+      rootMutationEvent={rootMutationEvent}
+      canRefreshRoot={canRefreshRoot}
       onError={setError}
-      onRefresh={() => void requestRefresh({ ignoreInterval: true })}
+      onRefresh={() =>
+        void requestRefresh({ ignoreInterval: true, force: true })}
+      onMutationInvalidate={() => {
+        setRootMutationEvent(++rootEventRef.current);
+        refreshSequenceRef.current = invalidateUiRefresh(
+          refreshSequenceRef.current,
+        );
+      }}
+      onMutationRefresh={canRefreshRoot
+        ? () => void requestRefresh({ ignoreInterval: true, force: true })
+        : undefined}
     />
   );
 }

--- a/src/ui/kpi-viewer/src/types.ts
+++ b/src/ui/kpi-viewer/src/types.ts
@@ -1,5 +1,5 @@
-import type { UiRefreshRequestData } from "~/shared/refresh";
-import type { NavHint } from "~/shared/jumps";
+import type { UiRefreshRequestData } from "../../shared/refresh.ts";
+import type { NavHint } from "../../shared/jumps.ts";
 
 export interface KpiData {
   label: string;
@@ -17,6 +17,8 @@ export interface KpiData {
   color?: string;
   icon?: string;
   refreshRequest?: UiRefreshRequestData;
+  /** Outils exacts autorisés par le registre serveur pour ce viewer. */
+  _availableTools?: string[];
   _drillDown?: string;
   _trendDrillDown?: string;
   /** Sauts de pile : le nombre ouvre une liste, la courbe un graphique. */

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -8,6 +8,7 @@
     "dev:invoice": "UI_NAME=invoice-viewer vite --config vite.single.config.mjs",
     "dev:stock": "UI_NAME=stock-viewer vite --config vite.single.config.mjs",
     "dev:doclist": "UI_NAME=doclist-viewer vite --config vite.single.config.mjs",
+    "dev:doc": "UI_NAME=doc-viewer vite --config vite.single.config.mjs",
     "dev:kanban": "UI_NAME=kanban-viewer vite --config vite.single.config.mjs",
     "dev:chart": "UI_NAME=chart-viewer vite --config vite.single.config.mjs",
     "dev:kpi": "UI_NAME=kpi-viewer vite --config vite.single.config.mjs",
@@ -16,6 +17,7 @@
     "dev:invoice:fixture": "UI_NAME=invoice-viewer vite --config vite.single.config.mjs --open /?fixture=1",
     "dev:stock:fixture": "UI_NAME=stock-viewer vite --config vite.single.config.mjs --open /?fixture=1",
     "dev:doclist:fixture": "UI_NAME=doclist-viewer vite --config vite.single.config.mjs --open /?fixture=1",
+    "dev:doc:fixture": "UI_NAME=doc-viewer vite --config vite.single.config.mjs --open /?fixture=1",
     "dev:kanban:fixture": "UI_NAME=kanban-viewer vite --config vite.single.config.mjs --open /?fixture=1",
     "dev:chart:fixture": "UI_NAME=chart-viewer vite --config vite.single.config.mjs --open /?fixture=1",
     "dev:funnel:fixture": "UI_NAME=funnel-viewer vite --config vite.single.config.mjs --open /?fixture=1"

--- a/src/ui/shared/doclist/DoclistBody.tsx
+++ b/src/ui/shared/doclist/DoclistBody.tsx
@@ -6,8 +6,11 @@
 
 import type { App } from "@modelcontextprotocol/ext-apps";
 import { useEffect, useRef, useState } from "preact/hooks";
+import type { DocumentChangeEvent } from "../document-events.ts";
+import type { DocumentEnvelope } from "../document/types.ts";
 import { useT } from "../i18n-hook";
 import type { Jump } from "../jumps";
+import { documentChangeForTool, recordOf } from "../levels/bodies.ts";
 import { extractToolResultText } from "../refresh";
 import { StateMessage, ToolButton, TotalRow } from "../ui";
 import type { ViewerLayout } from "../useViewerLayout";
@@ -51,6 +54,7 @@ export function DoclistBody(
     onMutationInvalidate,
     onMutationRefresh,
     onMutated,
+    onDocumentChanged,
   }: {
     app: App;
     data: DoclistData;
@@ -73,6 +77,8 @@ export function DoclistBody(
     onMutationRefresh?: () => void;
     /** Une action d'ici (valider, annuler) vient de changer `subject`. */
     onMutated?: (subject: string) => void;
+    /** Changement canonique structuré, indépendant de son transport futur. */
+    onDocumentChanged?: (event: DocumentChangeEvent) => void;
   },
 ) {
   const t = useT();
@@ -86,7 +92,11 @@ export function DoclistBody(
     )
     ? payloadRowAction
     : undefined;
-  type Expanded = { id: string | null; data: Row | null; loading: boolean };
+  type Expanded = {
+    id: string | null;
+    data: DocumentEnvelope | null;
+    loading: boolean;
+  };
   const [expanded, setExpandedState] = useState<Expanded>({
     id: null,
     data: null,
@@ -118,9 +128,18 @@ export function DoclistBody(
     );
     if (!row) return;
     if (fixture || (!rowAction && row._detail)) {
+      const envelope = recordOf(
+        (row._detail as Row | undefined) ?? row,
+        { doctype: data.doctype, name: expandedId },
+      );
+      if (!envelope) {
+        onError(t("doclist.error.load_details"));
+        list.setExpandedId(null);
+        return;
+      }
       setExpanded({
         id: expandedId,
-        data: (row._detail as Row | undefined) ?? row,
+        data: envelope,
         loading: false,
       });
       return;
@@ -145,9 +164,14 @@ export function DoclistBody(
           const text = extractToolResultText(result);
           if (text) {
             const parsed = JSON.parse(text);
+            const envelope = recordOf(parsed, {
+              doctype: data.doctype,
+              name: expandedId,
+            });
+            if (!envelope) throw new Error("document envelope is invalid");
             setExpanded({
               id: expandedId,
-              data: parsed.data ?? parsed,
+              data: envelope,
               loading: false,
             });
             onError(null);
@@ -174,7 +198,7 @@ export function DoclistBody(
         }
       }
     })();
-  }, [expandedId, rows, rowAction, fixture]);
+  }, [expandedId, rows, rowAction, fixture, data.doctype]);
 
   function onRowClick(row: Row) {
     const rowId = resolveRowId(row, rowAction, "");
@@ -182,13 +206,26 @@ export function DoclistBody(
     list.setExpandedId(expandedId === rowId ? null : rowId);
   }
 
+  function notifyDocumentChanged(event: DocumentChangeEvent) {
+    onMutated?.(event.name);
+    onDocumentChanged?.(event);
+  }
+
+  function handleAttachmentDocumentChanged(event: DocumentChangeEvent) {
+    notifyDocumentChanged(event);
+    onMutationInvalidate?.();
+    onMutationRefresh?.();
+  }
+
   async function handleDetailAction(
     toolName: string,
     args: Record<string, unknown>,
   ): Promise<boolean> {
+    const actionEnvelope = expandedRef.current.data;
     if (
       fixture ||
-      !canCallViewerTool(serverTools, data._availableTools, toolName)
+      !serverTools ||
+      !actionEnvelope?.availableTools?.includes(toolName)
     ) return false;
     try {
       const result = await app.callServerTool({
@@ -197,7 +234,17 @@ export function DoclistBody(
       }, { timeout: TOOL_CALL_TIMEOUT_MS });
       if (result.isError) return false;
       const currentId = expandedId;
-      if (currentId) onMutated?.(currentId);
+      const currentEnvelope = actionEnvelope;
+      const event = currentEnvelope
+        ? documentChangeForTool(
+          currentEnvelope,
+          toolName,
+          new Date().toISOString(),
+          "doclist.inline-detail",
+        )
+        : null;
+      if (event) notifyDocumentChanged(event);
+      else if (currentId) onMutated?.(currentId);
       onMutationInvalidate?.();
 
       // Le bouton reste busy pendant la fenêtre de cohérence ERPNext. Il ne
@@ -223,9 +270,16 @@ export function DoclistBody(
         const text = extractToolResultText(readBack);
         if (!text) throw new Error("canonical read-back is empty");
         const parsed = JSON.parse(text);
+        const envelope = recordOf(parsed, {
+          doctype: currentEnvelope?.doctype ?? data.doctype,
+          name: currentEnvelope?.name ?? currentId,
+        });
+        if (!envelope) {
+          throw new Error("canonical document envelope is invalid");
+        }
         setExpanded({
           id: currentId,
-          data: parsed.data ?? parsed,
+          data: envelope,
           loading: false,
         });
         onError(null);
@@ -357,17 +411,15 @@ export function DoclistBody(
         {inspecting && (
           <InlineDetailPanel
             app={app}
-            data={expanded.data}
+            envelope={expanded.data}
             loading={expanded.loading}
-            doctype={data.doctype}
-            sendMessageHints={data._sendMessageHints}
             fixture={fixture}
-            availableTools={serverTools ? data._availableTools : []}
             layout={layout}
             onClose={() => list.setExpandedId(null)}
             onAction={handleDetailAction}
             onJump={onJump}
             onAsk={onAsk}
+            onDocumentChanged={handleAttachmentDocumentChanged}
           />
         )}
       </div>

--- a/src/ui/shared/doclist/InlineDetailPanel.tsx
+++ b/src/ui/shared/doclist/InlineDetailPanel.tsx
@@ -8,79 +8,90 @@
  * plus quand on ouvre une pièce.
  */
 
+import type { App } from "@modelcontextprotocol/ext-apps";
 import type { ComponentChildren } from "preact";
 import { useState } from "preact/hooks";
-import type { App } from "@modelcontextprotocol/ext-apps";
-import { Button, InfoRow, Label, Skeleton } from "~/shared/ui";
-import { useT } from "~/shared/i18n-hook";
 import { ConfirmSheet, useConfirm } from "~/shared/confirm";
-import { TONE_AMOUNT, toneForStatus } from "~/shared/status";
-import { StatusBadge, StatusCell } from "./StatusCell";
-import type { SendMessageHint } from "./types";
-import { formatCell } from "./helpers";
-import type { ViewerLayout } from "~/shared/useViewerLayout";
-import { type Jump, jumpFromHint } from "~/shared/jumps";
+import { AttachmentsSection } from "~/shared/document/AttachmentsSection.tsx";
+import { documentCapabilities } from "~/shared/document/capabilities.ts";
+import {
+  documentEnvelopeOf,
+  documentModelOf,
+} from "~/shared/document/model.ts";
+import { DocumentSurface } from "~/shared/document/DocumentSurface.tsx";
+import type { DocumentEnvelope } from "~/shared/document/types.ts";
+import { useAttachments } from "~/shared/document/useAttachments.ts";
+import type { DocumentChangeEvent } from "~/shared/document-events.ts";
+import { useT } from "~/shared/i18n-hook";
+import {
+  fillTemplate,
+  hintLabel,
+  type Jump,
+  jumpFromHint,
+} from "~/shared/jumps";
 import { JumpList } from "~/shared/levels/JumpList";
-import { hasAvailableTool } from "~/shared/viewer-tools";
+import { Button, Label, Skeleton } from "~/shared/ui";
+import type { ViewerLayout } from "~/shared/useViewerLayout";
+import type { SendMessageHint } from "./types";
 
-/** Champs mis en avant sous le titre, dans cet ordre, avant le reste. */
-const LEAD_FIELDS = ["grand_total", "outstanding_amount", "total"];
+interface InlineDetailPanelProps {
+  app: App;
+  /** Enveloppe canonique de la fiche enfant, seule source de capacités. */
+  envelope?: DocumentEnvelope | null;
+  loading: boolean;
+  fixture?: boolean;
+  /** Mise en page courante — détermine le header de l'inspecteur et les tailles. */
+  layout?: ViewerLayout;
+  onClose: () => void;
+  /** Présent quand l'hôte relaie les outils : les hints deviennent des sauts « › ». */
+  onJump?: (jump: Jump) => void;
+  onAsk?: (message: string) => void;
+  onAction: (
+    toolName: string,
+    args: Record<string, unknown>,
+  ) => Promise<boolean>;
+  onDocumentChanged?: (event: DocumentChangeEvent) => void;
+  /** @deprecated Utiliser `envelope`; conservé pour les anciens appelants. */
+  data?: Record<string, unknown> | null;
+  /** @deprecated Complète uniquement l'identité de l'ancien `data`. */
+  doctype?: string;
+  /** @deprecated Une capacité parent ne peut pas autoriser la fiche enfant. */
+  availableTools?: readonly string[];
+  /** @deprecated Les hints doivent appartenir à l'enveloppe enfant. */
+  sendMessageHints?: SendMessageHint[];
+}
+
+function legacyEnvelopeOf(
+  data: Record<string, unknown> | null | undefined,
+  doctype: string | undefined,
+): DocumentEnvelope | null {
+  if (!data) return null;
+  const exact = documentEnvelopeOf(data);
+  if (exact) return exact;
+  const name = typeof data.name === "string" ? data.name.trim() : "";
+  if (!doctype?.trim() || !name) return null;
+  return documentEnvelopeOf({
+    data: { ...data, doctype: doctype.trim(), name },
+  });
+}
 
 export function InlineDetailPanel(
   {
+    app,
+    envelope,
     data,
-    loading,
     doctype,
-    sendMessageHints,
+    loading,
     fixture,
-    availableTools,
     layout,
     onClose,
     onJump,
     onAsk,
     onAction,
-  }: {
-    app: App;
-    data: Record<string, unknown> | null;
-    loading: boolean;
-    doctype?: string;
-    sendMessageHints?: SendMessageHint[];
-    fixture?: boolean;
-    /** Contrat serveur borné : seules ces mutations peuvent être proposées. */
-    availableTools?: readonly string[];
-    /** Mise en page courante — détermine le header de l'inspecteur et les tailles. */
-    layout?: ViewerLayout;
-    onClose: () => void;
-    /** Présent quand l'hôte relaie les outils : les hints deviennent des sauts « › ». */
-    onJump?: (jump: Jump) => void;
-    onAsk?: (message: string) => void;
-    onAction: (
-      toolName: string,
-      args: Record<string, unknown>,
-    ) => Promise<boolean>;
-  },
+    onDocumentChanged,
+  }: InlineDetailPanelProps,
 ) {
-  const t = useT();
   const narrow = layout !== "wide";
-  const [actLoading, setActLoading] = useState<string | null>(null);
-  const confirm = useConfirm();
-  const [actMsg, setActMsg] = useState<string | null>(null);
-  const [actOk, setActOk] = useState(true);
-
-  async function act(
-    key: string,
-    tool: string,
-    args: Record<string, unknown>,
-    msg: string,
-  ) {
-    if (fixture || !hasAvailableTool(availableTools, tool)) return;
-    setActLoading(key);
-    setActMsg(null);
-    const ok = await onAction(tool, args);
-    setActOk(ok);
-    setActMsg(ok ? msg : t("doclist.detail.action_failed"));
-    setActLoading(null);
-  }
 
   if (loading) {
     return (
@@ -96,294 +107,257 @@ export function InlineDetailPanel(
       </InspectorFrame>
     );
   }
-  if (!data) return null;
+  const documentEnvelope = envelope ?? legacyEnvelopeOf(data, doctype);
+  if (!documentEnvelope) return null;
+  return (
+    <InlineDocument
+      key={`${documentEnvelope.doctype}\u0000${documentEnvelope.name}`}
+      app={app}
+      envelope={documentEnvelope}
+      fixture={fixture}
+      outerLayout={layout ?? "panel"}
+      onClose={onClose}
+      onJump={onJump}
+      onAsk={onAsk}
+      onAction={onAction}
+      onDocumentChanged={onDocumentChanged}
+    />
+  );
+}
 
-  const entries: { id: string; label: string; value: string }[] = [];
-  for (const [key, value] of Object.entries(data)) {
-    if (key.startsWith("_") || key === "refreshRequest" || key === "doctype") {
-      continue;
-    }
-    if (value == null) continue;
-    const label = key.replace(/_/g, " ").replace(/\./g, " > ");
-    if (Array.isArray(value)) {
-      entries.push({
-        id: key,
-        label,
-        value: t("doclist.detail.array_count", {
-          n: value.length,
-          s: value.length > 1 ? "s" : "",
-        }),
-      });
-    } else if (typeof value === "object") {
-      for (
-        const [sub, subValue] of Object.entries(
-          value as Record<string, unknown>,
-        )
-      ) {
-        if (subValue != null && typeof subValue !== "object") {
-          entries.push({
-            id: `${key}.${sub}`,
-            label: `${label} > ${sub.replace(/_/g, " ")}`,
-            value: String(subValue),
-          });
-        }
-      }
-    } else {
-      entries.push({ id: key, label, value: formatCell(value) });
-    }
-  }
+function InlineDocument({
+  app,
+  envelope,
+  fixture,
+  outerLayout,
+  onClose,
+  onJump,
+  onAsk,
+  onAction,
+  onDocumentChanged,
+}: {
+  app: App;
+  envelope: DocumentEnvelope;
+  fixture?: boolean;
+  outerLayout: ViewerLayout;
+  onClose: () => void;
+  onJump?: (jump: Jump) => void;
+  onAsk?: (message: string) => void;
+  onAction: (
+    toolName: string,
+    args: Record<string, unknown>,
+  ) => Promise<boolean>;
+  onDocumentChanged?: (event: DocumentChangeEvent) => void;
+}) {
+  const t = useT();
+  const confirm = useConfirm();
+  const [actLoading, setActLoading] = useState<string | null>(null);
+  const [actMsg, setActMsg] = useState<string | null>(null);
+  const [actOk, setActOk] = useState(true);
+  const surfaceLayout: ViewerLayout = outerLayout === "mobile"
+    ? "mobile"
+    : "panel";
+  const outerNarrow = outerLayout !== "wide";
+  const model = documentModelOf(envelope);
+  const capabilities = documentCapabilities(
+    app.getHostCapabilities(),
+    envelope.availableTools,
+    envelope.refreshRequest,
+  );
+  const attachments = useAttachments({
+    app,
+    envelope,
+    capabilities,
+    onDocumentChanged,
+  });
 
-  const docName = String(data.name ?? "");
-  const status = String(data.status ?? "");
-  const tone = toneForStatus(status);
-  const isDraft = status === "Draft" || data.docstatus === 0;
-  const isSubmitted = data.docstatus === 1;
-  const canSubmit = hasAvailableTool(availableTools, "erpnext_doc_submit");
-  const canCancel = hasAvailableTool(availableTools, "erpnext_doc_cancel");
-
-  const lead = entries.filter((entry) => LEAD_FIELDS.includes(entry.id));
-  const rest = entries.filter((entry) => !LEAD_FIELDS.includes(entry.id));
-
-  /* Le libellé vient du catalogue quand le serveur donne une clé, sinon du
-     serveur lui-même (anglais). */
-  const hintLabel = (hint: SendMessageHint) => {
-    const key = hint.key ? `doclist.hint.${hint.key}` : null;
-    const translated = key ? t(key) : null;
-    return translated && translated !== key ? translated : hint.label;
+  const vars = {
+    id: envelope.name,
+    name: envelope.name,
+    doctype: envelope.doctype,
   };
-  /* Quand l'hôte relaie les outils, chaque hint qui porte un outil devient
-     un saut dans la vue ; les autres restent des questions au modèle. */
-  const jumps = onJump
-    ? (sendMessageHints ?? [])
-      .filter((hint) =>
-        typeof hint.tool === "string" &&
-        hasAvailableTool(availableTools, hint.tool)
+  const hints = envelope.sendMessageHints ?? [];
+  const exactTools = envelope.availableTools;
+  const canRouteHint = (toolName: string) =>
+    Boolean(
+      onJump && app.getHostCapabilities()?.serverTools && exactTools &&
+        exactTools.includes(toolName),
+    );
+  const jumps = hints
+    .filter((hint) => hint.tool && canRouteHint(hint.tool))
+    .map((hint) =>
+      jumpFromHint(
+        hint,
+        vars,
+        t("nav.linked_to", { id: envelope.name }),
       )
-      .map((hint) =>
-        jumpFromHint(
-          hint,
-          { id: docName, doctype: doctype ?? "" },
-          t("nav.linked_to", { id: docName }),
-        )
-      )
-      .filter((jump): jump is Jump => jump !== null)
-    : [];
-  const hints = sendMessageHints?.map((hint) => ({
-    ...hint,
-    label: hintLabel(hint),
-    message: hint.message
-      .replace(/\{id\}/g, docName)
-      .replace(/\{doctype\}/g, doctype ?? ""),
-  })) ?? [];
+    )
+    .filter((jump): jump is Jump => jump !== null);
   const asks = onAsk
-    ? hints.filter((hint) => !hint.tool).map((hint) => ({
-      label: hint.label,
-      message: hint.message,
-    }))
+    ? hints.flatMap((hint) => {
+      if (!hint.message || (onJump && hint.tool)) return [];
+      return [{
+        label: hintLabel(hint),
+        message: fillTemplate(hint.message, vars),
+      }];
+    })
     : [];
-  if (
-    onAsk && asks.length === 0 && jumps.length === 0 && docName && doctype
-  ) {
+  if (onAsk && asks.length === 0 && jumps.length === 0) {
     asks.push({
       label: t("doclist.detail.full_detail"),
       message: t("doclist.detail.full_detail_message", {
-        doctype,
-        id: docName,
+        doctype: envelope.doctype,
+        id: envelope.name,
       }),
     });
   }
 
-  return (
-    <InspectorFrame narrow={narrow} onClose={onClose}>
-      <div class="flex flex-col gap-3.5 p-3.5">
-        <div class="flex flex-col gap-1.5">
-          <span class="break-all font-display text-[15px] font-semibold text-ink">
-            {docName || t("doclist.detail.document_fallback")}
-          </span>
-          <div class="flex items-center gap-[7px]">
-            {/* En narrow le badge adopte la forme pill (radius-pill 13px) pour la maquette mobile. */}
-            {status && narrow
-              ? (
-                <StatusBadge tone={toneForStatus(status)} pill>
-                  {status}
-                </StatusBadge>
-              )
-              : status
-              ? <StatusCell value={status} />
-              : null}
-            {data.docstatus != null && (
-              <span class="font-mono text-chip text-ink-faint">
-                docstatus {String(data.docstatus)}
-              </span>
-            )}
-          </div>
-        </div>
+  const isDraft = model.status === "Draft" || model.docstatus === 0;
+  const isSubmitted = model.docstatus === 1;
+  const showSubmit = isDraft && (fixture || capabilities.canSubmit);
+  const showCancel = isSubmitted && (fixture || capabilities.canCancel);
 
-        {rest.length > 0 && (
-          <div class="flex flex-col gap-[9px] border-t border-line-soft pt-3">
-            {rest.slice(0, 10).map((entry) => (
-              <InfoRow key={entry.id} label={entry.label}>
-                {entry.value}
-              </InfoRow>
-            ))}
-          </div>
+  async function act(
+    key: string,
+    tool: string,
+    args: Record<string, unknown>,
+    msg: string,
+  ) {
+    if (fixture) return;
+    const allowed = key === "submit"
+      ? capabilities.canSubmit
+      : key === "cancel"
+      ? capabilities.canCancel
+      : false;
+    if (!allowed) return;
+    setActLoading(key);
+    setActMsg(null);
+    const ok = await onAction(tool, args);
+    setActOk(ok);
+    setActMsg(ok ? msg : t("doclist.detail.action_failed"));
+    setActLoading(null);
+  }
+
+  const hasActions = jumps.length > 0 || asks.length > 0 || showSubmit ||
+    showCancel || actMsg !== null;
+  const actions = hasActions
+    ? (
+      <div class="flex flex-col gap-2">
+        {jumps.length > 0 && <Label>{t("nav.goto")}</Label>}
+        {(jumps.length > 0 || asks.length > 0) && (
+          <JumpList
+            narrow
+            jumps={jumps}
+            asks={asks}
+            onJump={onJump}
+            onAsk={onAsk}
+          />
         )}
-
-        {lead.length > 0 && (
-          <div class="flex flex-col gap-1.5 border-t border-line-soft pt-3">
-            {lead.map((entry, index) => (
-              <div
-                key={entry.id}
-                class="flex items-baseline justify-between gap-2.5"
-              >
-                <span class="font-mono text-chip text-ink-faint">
-                  {entry.label}
-                </span>
-                <span
-                  class={[
-                    "font-mono tabular-nums",
-                    // Le dernier montant de la pile est le chiffre qui compte.
-                    // En narrow il monte à 20 px (text-metric-unit) pour la lisibilité mobile.
-                    index === lead.length - 1
-                      ? `${
-                        narrow
-                          ? "text-metric-unit tracking-tight"
-                          : "text-total"
-                      } font-semibold ${TONE_AMOUNT[tone]}`
-                      : "text-body text-ink-2",
-                  ].join(" ")}
-                >
-                  {entry.value}
-                </span>
-              </div>
-            ))}
-          </div>
-        )}
-
         {actMsg && (
-          <p
-            class={`font-mono text-chip ${actOk ? "text-ok" : "text-bad"}`}
-          >
+          <p class={`font-mono text-chip ${actOk ? "text-ok" : "text-bad"}`}>
             {actMsg}
           </p>
         )}
-
-        {/* En narrow les boutons ont une cible tactile min-h-[44px] (maquette mobile). */}
-        <div
-          class={`flex flex-col border-t border-line-soft pt-3 ${
-            narrow ? "gap-2" : "gap-1.5"
-          }`}
-        >
-          {onJump
-            ? (
-              <>
-                {jumps.length > 0 && <Label>{t("nav.goto")}</Label>}
-                <JumpList
-                  narrow={layout !== "wide"}
-                  jumps={jumps}
-                  asks={asks}
-                  onJump={onJump}
-                  onAsk={onAsk}
-                />
-              </>
-            )
-            : (
-              <>
-                {onAsk && hints.map((hint, index) => (
-                  <Button
-                    key={index}
-                    variant={index === 0 ? "accent" : "secondary"}
-                    disabled={fixture}
-                    title={fixture ? t("doclist.preview.no_host") : hint.label}
-                    class={narrow
-                      ? "min-h-[44px] rounded-control text-body"
-                      : undefined}
-                    onClick={() => onAsk(hint.message)}
-                  >
-                    {hint.label}
-                  </Button>
-                ))}
-                {onAsk && docName && doctype && hints.length === 0 && (
-                  <Button
-                    variant="accent"
-                    disabled={fixture}
-                    title={fixture
-                      ? t("doclist.preview.no_host")
-                      : t("doclist.detail.full_detail")}
-                    class={narrow
-                      ? "min-h-[44px] rounded-control text-body"
-                      : undefined}
-                    onClick={() =>
-                      onAsk(
-                        t("doclist.detail.full_detail_message", {
-                          doctype: doctype ?? "",
-                          id: docName,
-                        }),
-                      )}
-                  >
-                    {t("doclist.detail.full_detail")}
-                  </Button>
-                )}
-              </>
-            )}
-          {isDraft && docName && (fixture || canSubmit) && (
-            <Button
-              variant="secondary"
-              disabled={actLoading === "submit" || fixture}
-              title={fixture
-                ? t("doclist.preview.no_host")
-                : t("doclist.detail.action.submit_title")}
-              class={narrow
-                ? "min-h-[44px] rounded-control text-body"
-                : undefined}
-              onClick={() =>
-                confirm.request({
-                  subject: `${doctype ?? ""} ${docName}`.trim(),
-                  title: t("doclist.confirm.submit"),
-                  detail: t("doclist.confirm.submit.detail"),
-                  actionLabel: t("doclist.confirm.submit.action"),
-                  onConfirm: () =>
-                    void act("submit", "erpnext_doc_submit", {
-                      doctype: doctype ?? "",
-                      name: docName,
-                    }, t("doclist.detail.action.submit_ok")),
-                })}
-            >
-              {actLoading === "submit" ? "…" : t("common.submit")}
-            </Button>
-          )}
-          {isSubmitted && docName && (fixture || canCancel) && (
-            <Button
-              variant="danger"
-              disabled={actLoading === "cancel" || fixture}
-              title={fixture
-                ? t("doclist.preview.no_host")
-                : t("doclist.detail.action.cancel_label")}
-              class={narrow
-                ? "min-h-[44px] rounded-control text-body"
-                : undefined}
-              onClick={() =>
-                confirm.request({
-                  subject: `${doctype ?? ""} ${docName}`.trim(),
-                  title: t("doclist.confirm.cancel"),
-                  detail: t("doclist.confirm.cancel.detail"),
-                  actionLabel: t("doclist.confirm.cancel.action"),
-                  onConfirm: () =>
-                    void act("cancel", "erpnext_doc_cancel", {
-                      doctype: doctype ?? "",
-                      name: docName,
-                    }, t("doclist.detail.action.cancel_ok")),
-                })}
-            >
-              {actLoading === "cancel"
-                ? "…"
-                : t("doclist.detail.action.cancel_label")}
-            </Button>
-          )}
-        </div>
+        {showSubmit && (
+          <Button
+            variant="secondary"
+            disabled={actLoading === "submit" || fixture}
+            title={fixture
+              ? t("doclist.preview.no_host")
+              : t("doclist.detail.action.submit_title")}
+            class="min-h-[44px] rounded-control text-body"
+            onClick={() =>
+              confirm.request({
+                subject: `${envelope.doctype} ${envelope.name}`,
+                title: t("doclist.confirm.submit"),
+                detail: t("doclist.confirm.submit.detail"),
+                actionLabel: t("doclist.confirm.submit.action"),
+                onConfirm: () =>
+                  void act("submit", "erpnext_doc_submit", {
+                    doctype: envelope.doctype,
+                    name: envelope.name,
+                  }, t("doclist.detail.action.submit_ok")),
+              })}
+          >
+            {actLoading === "submit" ? "…" : t("common.submit")}
+          </Button>
+        )}
+        {showCancel && (
+          <Button
+            variant="danger"
+            disabled={actLoading === "cancel" || fixture}
+            title={fixture
+              ? t("doclist.preview.no_host")
+              : t("doclist.detail.action.cancel_label")}
+            class="min-h-[44px] rounded-control text-body"
+            onClick={() =>
+              confirm.request({
+                subject: `${envelope.doctype} ${envelope.name}`,
+                title: t("doclist.confirm.cancel"),
+                detail: t("doclist.confirm.cancel.detail"),
+                actionLabel: t("doclist.confirm.cancel.action"),
+                onConfirm: () =>
+                  void act("cancel", "erpnext_doc_cancel", {
+                    doctype: envelope.doctype,
+                    name: envelope.name,
+                  }, t("doclist.detail.action.cancel_ok")),
+              })}
+          >
+            {actLoading === "cancel"
+              ? "…"
+              : t("doclist.detail.action.cancel_label")}
+          </Button>
+        )}
       </div>
+    )
+    : undefined;
+
+  const navigation = outerNarrow
+    ? (
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label={t("doclist.detail.back_to_list")}
+        class="font-mono text-chip text-accent-text transition-colors hover:text-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+      >
+        {t("doclist.detail.back_list_label")}
+      </button>
+    )
+    : undefined;
+  const headerActions = !outerNarrow
+    ? (
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label={t("doclist.detail.close_inspector")}
+        class="grid size-7 place-items-center rounded-control text-lede text-ink-faint transition-colors hover:bg-control hover:text-ink focus-visible:outline-2 focus-visible:outline-accent"
+      >
+        ×
+      </button>
+    )
+    : undefined;
+
+  return (
+    <>
+      <DocumentSurface
+        model={model}
+        layout={surfaceLayout}
+        navigation={navigation}
+        headerActions={headerActions}
+        attachments={capabilities.canListAttachments
+          ? (
+            <AttachmentsSection
+              controller={attachments}
+              capabilities={capabilities}
+              layout={surfaceLayout}
+            />
+          )
+          : undefined}
+        actions={actions}
+        class="h-full"
+      />
       <ConfirmSheet confirm={confirm} />
-    </InspectorFrame>
+    </>
   );
 }
 

--- a/src/ui/shared/doclist/types.ts
+++ b/src/ui/shared/doclist/types.ts
@@ -1,6 +1,6 @@
 /** Doclist Viewer types */
 
-import type { UiRefreshRequestData } from "~/shared/refresh";
+import type { UiRefreshRequestData } from "../refresh.ts";
 
 /** Server-driven row action — injected in tool payload to make rows clickable */
 export interface RowAction {

--- a/src/ui/shared/document-events.ts
+++ b/src/ui/shared/document-events.ts
@@ -1,0 +1,55 @@
+/**
+ * Changement canonique d'un document ERPNext.
+ *
+ * Le nom routable reste séparé de la payload : celle-ci peut circuler par un
+ * appel local, un bus en mémoire ou, plus tard, comme `data` d'un événement
+ * Compose sans dépendre d'aucun de ces transports.
+ */
+
+export const DOCUMENT_CHANGE_EVENT_NAME = "erpnext.document.changed" as const;
+
+export const DOCUMENT_MUTATION_KINDS = [
+  "update",
+  "submit",
+  "cancel",
+  "attachment.added",
+] as const;
+
+export type DocumentMutationKind = typeof DOCUMENT_MUTATION_KINDS[number];
+
+export interface DocumentChangeEvent {
+  readonly doctype: string;
+  readonly name: string;
+  readonly mutation: DocumentMutationKind;
+  /** Instant où le serveur a confirmé la mutation, au format ISO 8601. */
+  readonly committedAt: string;
+  /** Identifiant libre de l'émetteur, utile au diagnostic et non au routage. */
+  readonly source?: string;
+}
+
+const DOCUMENT_MUTATIONS = new Set<string>(DOCUMENT_MUTATION_KINDS);
+const ISO_DATE_TIME =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/** Garde d'entrée pour une payload reçue d'un transport éventuel. */
+export function isDocumentChangeEvent(
+  value: unknown,
+): value is DocumentChangeEvent {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return isNonEmptyString(candidate.doctype) &&
+    isNonEmptyString(candidate.name) &&
+    typeof candidate.mutation === "string" &&
+    DOCUMENT_MUTATIONS.has(candidate.mutation) &&
+    typeof candidate.committedAt === "string" &&
+    ISO_DATE_TIME.test(candidate.committedAt) &&
+    Number.isFinite(Date.parse(candidate.committedAt)) &&
+    (candidate.source === undefined || isNonEmptyString(candidate.source));
+}

--- a/src/ui/shared/document-events_test.ts
+++ b/src/ui/shared/document-events_test.ts
@@ -1,0 +1,57 @@
+import { assertEquals } from "@std/assert";
+import {
+  DOCUMENT_CHANGE_EVENT_NAME,
+  DOCUMENT_MUTATION_KINDS,
+  type DocumentChangeEvent,
+  isDocumentChangeEvent,
+} from "./document-events.ts";
+
+const validEvent: DocumentChangeEvent = {
+  doctype: "Sales Invoice",
+  name: "SINV-00046",
+  mutation: "attachment.added",
+  committedAt: "2026-08-24T06:02:03.456Z",
+  source: "document-viewer",
+};
+
+Deno.test("document change - contrat routable et payload valide", () => {
+  assertEquals(DOCUMENT_CHANGE_EVENT_NAME, "erpnext.document.changed");
+  assertEquals(DOCUMENT_MUTATION_KINDS, [
+    "update",
+    "submit",
+    "cancel",
+    "attachment.added",
+  ]);
+  assertEquals(
+    DOCUMENT_MUTATION_KINDS.map((mutation) =>
+      isDocumentChangeEvent({ ...validEvent, mutation })
+    ),
+    [true, true, true, true],
+  );
+  assertEquals(isDocumentChangeEvent(validEvent), true);
+  assertEquals(
+    isDocumentChangeEvent({
+      ...validEvent,
+      committedAt: "2026-08-24T14:02:03+08:00",
+    }),
+    true,
+  );
+  assertEquals(
+    isDocumentChangeEvent({ ...validEvent, source: undefined }),
+    true,
+  );
+});
+
+Deno.test("document change - rejette les références, mutations et dates invalides", () => {
+  const invalid = [
+    null,
+    { ...validEvent, doctype: " " },
+    { ...validEvent, name: "" },
+    { ...validEvent, mutation: "delete" },
+    { ...validEvent, committedAt: "24/08/2026 14:02" },
+    { ...validEvent, committedAt: "not-a-date" },
+    { ...validEvent, source: " " },
+  ];
+
+  assertEquals(invalid.map(isDocumentChangeEvent), invalid.map(() => false));
+});

--- a/src/ui/shared/document/AttachmentsSection.tsx
+++ b/src/ui/shared/document/AttachmentsSection.tsx
@@ -1,0 +1,272 @@
+/** @jsxImportSource preact */
+
+import type { JSX } from "preact";
+import { useRef, useState } from "preact/hooks";
+import { useT } from "../i18n-hook.ts";
+import type { ViewerLayout } from "../useViewerLayout.ts";
+import { cx } from "../ui.tsx";
+import type { DocumentCapabilities } from "./capabilities.ts";
+import type { AttachmentsController } from "./useAttachments.ts";
+
+function PaperclipIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true" class="size-3.5" fill="none">
+      <path
+        d="m5.25 8.9 4.2-4.2a2.05 2.05 0 0 1 2.9 2.9l-5.3 5.3a3.15 3.15 0 0 1-4.45-4.45l5-5"
+        stroke="currentColor"
+        stroke-width="1.25"
+        stroke-linecap="round"
+      />
+    </svg>
+  );
+}
+
+function DownloadIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true" class="size-3.5" fill="none">
+      <path
+        d="M8 2.5v7m0 0 2.5-2.5M8 9.5 5.5 7M3 12.5h10"
+        stroke="currentColor"
+        stroke-width="1.25"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  );
+}
+
+function formatBytes(bytes: number | null): string {
+  if (bytes === null) return "—";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function AttachmentsSection({
+  controller,
+  capabilities,
+  layout,
+}: {
+  controller: AttachmentsController;
+  capabilities: DocumentCapabilities;
+  layout: ViewerLayout;
+}) {
+  const t = useT();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isPrivate, setIsPrivate] = useState(true);
+  const { state, files, readProgress } = controller;
+  const narrow = layout !== "wide";
+  const uploadBusy = state.upload !== "idle" && state.upload !== "error";
+
+  const chooseFile = () => {
+    if (!uploadBusy) inputRef.current?.click();
+  };
+  const selectedFile = (event: JSX.TargetedEvent<HTMLInputElement>) => {
+    const file = event.currentTarget.files?.[0];
+    event.currentTarget.value = "";
+    if (file) void controller.upload(file, isPrivate);
+  };
+
+  const uploadLabel = state.upload === "reading"
+    ? readProgress === null
+      ? t("document.attachments.reading")
+      : t("document.attachments.reading_progress", {
+        value: Math.round(readProgress * 100),
+      })
+    : state.upload === "uploading"
+    ? t("document.attachments.uploading")
+    : state.upload === "relisting"
+    ? t("document.attachments.relisting")
+    : t("document.attachments.add");
+
+  return (
+    <section aria-labelledby="document-attachments-title" class="min-w-0">
+      <div class="flex min-h-10 items-center gap-2 border-b border-line-soft px-3.5 py-2">
+        <h3
+          id="document-attachments-title"
+          class="m-0 font-mono text-micro uppercase tracking-label text-ink-muted"
+        >
+          {t("document.attachments")}
+          <span class="ml-1.5 text-ink-faint">{files.length}</span>
+        </h3>
+        <div class="flex-1" />
+        {capabilities.canListAttachments && (
+          <button
+            type="button"
+            aria-label={t("document.attachments.refresh")}
+            title={t("document.attachments.refresh")}
+            disabled={state.load === "loading" || uploadBusy}
+            onClick={() => void controller.refresh()}
+            class={cx(
+              "grid size-7 place-items-center rounded-control text-ink-faint transition-colors",
+              "hover:bg-control hover:text-ink focus-visible:outline-2 focus-visible:outline-accent",
+              "disabled:cursor-not-allowed disabled:opacity-40",
+            )}
+          >
+            <span
+              aria-hidden="true"
+              class={state.load === "loading" ? "animate-spin" : ""}
+            >
+              ↻
+            </span>
+          </button>
+        )}
+      </div>
+
+      {state.error && (
+        <div
+          role="alert"
+          class="mx-3.5 mt-3 flex items-start gap-2 rounded-control border border-bad/25 bg-bad/8 px-2.5 py-2 font-mono text-chip text-bad"
+        >
+          <span class="min-w-0 flex-1 break-words">{state.error.message}</span>
+          <button
+            type="button"
+            aria-label={t("document.attachments.dismiss_error")}
+            onClick={controller.dismissError}
+            class="grid size-5 shrink-0 place-items-center rounded-sm hover:bg-bad/10 focus-visible:outline-2 focus-visible:outline-bad"
+          >
+            ×
+          </button>
+        </div>
+      )}
+
+      <div class={cx("flex flex-col", narrow ? "px-3 py-2.5" : "px-3.5 py-3")}>
+        {state.load === "loading" && files.length === 0
+          ? (
+            <div
+              role="status"
+              class="py-6 text-center font-mono text-chip text-ink-faint"
+            >
+              {t("document.attachments.loading")}
+            </div>
+          )
+          : files.length === 0
+          ? (
+            <div class="rounded-control border border-dashed border-line px-3 py-5 text-center">
+              <PaperclipIcon />
+              <p class="mt-2 font-mono text-chip text-ink-faint">
+                {capabilities.canListAttachments
+                  ? t("document.attachments.empty")
+                  : t("document.attachments.unavailable")}
+              </p>
+            </div>
+          )
+          : (
+            <div class="overflow-hidden rounded-control border border-line-soft">
+              {files.map((file) => {
+                const downloading = state.downloadingFile === file.id;
+                return (
+                  <div
+                    key={file.id}
+                    class="group flex min-h-11 items-center gap-2.5 border-b border-line-soft px-2.5 py-2 last:border-b-0 hover:bg-row-hover"
+                  >
+                    <span class="shrink-0 text-ink-faint">
+                      <PaperclipIcon />
+                    </span>
+                    <div class="min-w-0 flex-1">
+                      <div
+                        class="truncate text-data text-ink"
+                        title={file.fileName}
+                      >
+                        {file.fileName}
+                      </div>
+                      <div class="mt-0.5 flex items-center gap-1.5 font-mono text-nano text-ink-faint">
+                        <span>{formatBytes(file.fileSize)}</span>
+                        <span aria-hidden="true">·</span>
+                        <span>
+                          {file.isPrivate
+                            ? t("document.attachments.private")
+                            : t("document.attachments.public")}
+                        </span>
+                      </div>
+                    </div>
+                    {capabilities.canDownloadAttachment && (
+                      <button
+                        type="button"
+                        aria-label={t("document.attachments.download", {
+                          name: file.fileName,
+                        })}
+                        title={t("document.attachments.download", {
+                          name: file.fileName,
+                        })}
+                        disabled={state.downloadingFile !== null}
+                        onClick={() => void controller.download(file)}
+                        class={cx(
+                          "grid size-8 shrink-0 place-items-center rounded-control text-ink-faint transition-colors",
+                          "hover:bg-control hover:text-accent focus-visible:outline-2 focus-visible:outline-accent",
+                          "disabled:cursor-not-allowed disabled:opacity-45",
+                          !narrow && !downloading &&
+                            "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100",
+                        )}
+                      >
+                        {downloading
+                          ? (
+                            <span aria-hidden="true" class="animate-pulse">
+                              …
+                            </span>
+                          )
+                          : <DownloadIcon />}
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+        {capabilities.canUploadAttachment && (
+          <div class="mt-3 flex flex-wrap items-center gap-2">
+            <input
+              ref={inputRef}
+              class="sr-only"
+              type="file"
+              tabIndex={-1}
+              onChange={selectedFile}
+            />
+            <button
+              type="button"
+              disabled={uploadBusy}
+              onClick={chooseFile}
+              class={cx(
+                "inline-flex min-h-8 items-center gap-1.5 rounded-control border border-line bg-control px-2.5",
+                "font-mono text-chip text-ink-muted transition-colors hover:border-line-hover hover:text-ink",
+                "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
+                "disabled:cursor-wait disabled:opacity-55",
+                narrow && "min-h-10",
+              )}
+            >
+              <span aria-hidden="true">＋</span>
+              {uploadLabel}
+            </button>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={isPrivate}
+              aria-label={t("document.attachments.privacy")}
+              title={t(
+                isPrivate
+                  ? "document.attachments.private_hint"
+                  : "document.attachments.public_hint",
+              )}
+              disabled={uploadBusy}
+              onClick={() => setIsPrivate((value) => !value)}
+              class={cx(
+                "min-h-8 rounded-pill border px-2.5 font-mono text-nano uppercase tracking-chip transition-colors",
+                isPrivate
+                  ? "border-line bg-sunken text-ink-muted"
+                  : "border-accent/45 bg-accent/10 text-accent-text",
+                "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
+                "disabled:cursor-not-allowed disabled:opacity-50",
+                narrow && "min-h-10",
+              )}
+            >
+              {isPrivate
+                ? `⌁ ${t("document.attachments.private")}`
+                : `◌ ${t("document.attachments.public")}`}
+            </button>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/ui/shared/document/ChildTableSection.tsx
+++ b/src/ui/shared/document/ChildTableSection.tsx
@@ -1,0 +1,303 @@
+/** @jsxImportSource preact */
+
+import type { ComponentChildren } from "preact";
+import { useState } from "preact/hooks";
+import { formatNumber } from "../format";
+import { type TFunction, useT } from "../i18n-hook";
+import type { ViewerLayout } from "../useViewerLayout";
+import { CountBadge, cx, Label, TotalRow } from "../ui";
+import {
+  childTableColumnsForLayout,
+  childTableHiddenEntries,
+} from "./child-table-model.ts";
+import type {
+  ChildTableColumn,
+  ChildTableModel,
+  ChildTableRow,
+  DocumentDisplayValue,
+  DocumentFieldModel,
+} from "./types.ts";
+import { DocumentFieldValue } from "./ScalarFields";
+
+export interface ChildTableSectionProps {
+  table: ChildTableModel;
+  layout: ViewerLayout;
+  idPrefix?: string;
+  class?: string;
+}
+
+function valueText(value: DocumentDisplayValue | undefined, t: TFunction) {
+  if (value === undefined || value === null || value === "") {
+    return t("document.empty_value");
+  }
+  if (typeof value === "boolean") {
+    return t(value ? "document.boolean.true" : "document.boolean.false");
+  }
+  if (typeof value === "number") {
+    return formatNumber(value, Number.isInteger(value) ? 0 : 2);
+  }
+  return value;
+}
+
+function gridClass(layout: ViewerLayout, count: number): string {
+  if (layout === "mobile") {
+    if (count >= 3) return "grid-cols-[minmax(0,1fr)_52px_82px]";
+    if (count === 2) return "grid-cols-[minmax(0,1fr)_82px]";
+    return "grid-cols-1";
+  }
+  if (count >= 4) {
+    return "grid-cols-[minmax(0,1.8fr)_minmax(0,1.2fr)_minmax(52px,0.7fr)_minmax(72px,0.8fr)]";
+  }
+  if (count === 3) {
+    return "grid-cols-[minmax(0,1.7fr)_minmax(0,1.15fr)_minmax(72px,0.8fr)]";
+  }
+  if (count === 2) return "grid-cols-[minmax(0,1fr)_minmax(72px,0.6fr)]";
+  return "grid-cols-1";
+}
+
+function cells(
+  row: ChildTableRow,
+  columns: readonly ChildTableColumn[],
+  t: TFunction,
+): ComponentChildren {
+  return columns.map((column) => (
+    <span
+      key={column.key}
+      class={cx(
+        "min-w-0 truncate text-cell text-ink-2",
+        column.numeric && "text-right font-mono tabular-nums",
+      )}
+      title={String(row[column.key] ?? "")}
+    >
+      {valueText(row[column.key], t)}
+    </span>
+  ));
+}
+
+function HiddenRowFields(
+  { fields, id, layout }: {
+    fields: readonly DocumentFieldModel[];
+    id: string;
+    layout: ViewerLayout;
+  },
+) {
+  if (fields.length === 0) return null;
+  return (
+    <dl
+      id={id}
+      class={cx(
+        "grid gap-x-4 gap-y-2 border-b border-line-soft bg-row-selected px-3 py-2.5",
+        layout === "panel" ? "grid-cols-1" : "grid-cols-3",
+      )}
+    >
+      {fields.map((field) => (
+        <div key={field.key} class="flex min-w-0 flex-col gap-1">
+          <dt class="font-mono text-nano uppercase tracking-label text-ink-faint">
+            {field.label}
+          </dt>
+          <dd class="min-w-0 truncate text-data text-ink-2">
+            <DocumentFieldValue field={field} />
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function ExpandableRow({
+  children,
+  rowId,
+  expanded,
+  onToggle,
+  class: klass,
+  label,
+}: {
+  children: ComponentChildren;
+  rowId: string;
+  expanded: boolean;
+  onToggle: () => void;
+  class: string;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-expanded={expanded}
+      aria-controls={rowId}
+      onClick={onToggle}
+      class={cx(
+        "w-full border-b border-line-soft text-left transition-colors",
+        "hover:bg-row-hover focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent",
+        expanded && "border-r-2 border-r-accent bg-row-selected",
+        klass,
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function ChildTableSection({
+  table,
+  layout,
+  idPrefix = "document-table",
+  class: klass,
+}: ChildTableSectionProps) {
+  const t = useT();
+  const [open, setOpen] = useState<{ table: string; row: number } | null>(null);
+  const columns = childTableColumnsForLayout(table, layout);
+  const tableId = `${idPrefix}-${table.key.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+  const panel = layout === "panel";
+
+  return (
+    <section
+      aria-label={table.label}
+      class={cx("flex min-w-0 flex-col", klass)}
+    >
+      <div class="flex items-baseline justify-between gap-3 px-4 pb-2 pt-3.5">
+        <Label>{table.label}</Label>
+        <CountBadge narrow>{table.rows.length}</CountBadge>
+      </div>
+
+      {columns.length === 0
+        ? (
+          <p class="px-4 pb-3.5 font-mono text-chip text-ink-faint">
+            {t("document.table.no_columns")}
+          </p>
+        )
+        : panel
+        ? (
+          <div class="flex flex-col border-t border-line-soft">
+            {table.rows.map((row, rowIndex) => {
+              const hidden = childTableHiddenEntries(table, rowIndex, layout);
+              const expanded = open?.table === tableId &&
+                open.row === rowIndex;
+              const rowId = `${tableId}-row-${rowIndex}-details`;
+              const content = (
+                <span class="flex flex-col gap-1.5 px-3.5 py-2.5">
+                  {columns.map((column) => (
+                    <span
+                      key={column.key}
+                      class="flex min-w-0 items-baseline justify-between gap-3"
+                    >
+                      <span class="shrink-0 font-mono text-chip text-ink-faint">
+                        {column.label}
+                      </span>
+                      <span
+                        class={cx(
+                          "min-w-0 truncate text-right text-data text-ink-2",
+                          column.numeric && "font-mono tabular-nums",
+                        )}
+                      >
+                        {valueText(row[column.key], t)}
+                      </span>
+                    </span>
+                  ))}
+                </span>
+              );
+              return (
+                <div key={rowIndex}>
+                  {hidden.length > 0
+                    ? (
+                      <ExpandableRow
+                        rowId={rowId}
+                        expanded={expanded}
+                        onToggle={() =>
+                          setOpen(
+                            expanded ? null : { table: tableId, row: rowIndex },
+                          )}
+                        class="block"
+                        label={`${table.label} ${rowIndex + 1}`}
+                      >
+                        {content}
+                      </ExpandableRow>
+                    )
+                    : <div class="border-b border-line-soft">{content}</div>}
+                  {expanded && (
+                    <HiddenRowFields
+                      fields={hidden}
+                      id={rowId}
+                      layout={layout}
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )
+        : (
+          <div class="min-w-0 border-t border-line-soft">
+            <div
+              role="row"
+              class={cx(
+                "grid gap-3 border-b border-line bg-sunken px-4 py-1.5",
+                gridClass(layout, columns.length),
+              )}
+            >
+              {columns.map((column) => (
+                <span
+                  key={column.key}
+                  role="columnheader"
+                  class={cx(
+                    "truncate font-mono text-nano uppercase tracking-label text-ink-faint",
+                    column.numeric && "text-right",
+                  )}
+                >
+                  {column.label}
+                </span>
+              ))}
+            </div>
+            {table.rows.map((row, rowIndex) => {
+              const hidden = childTableHiddenEntries(table, rowIndex, layout);
+              const expanded = open?.table === tableId &&
+                open.row === rowIndex;
+              const rowId = `${tableId}-row-${rowIndex}-details`;
+              const rowClass = cx(
+                "grid items-center gap-3 border-l-2 border-l-transparent px-4",
+                layout === "mobile" ? "min-h-10 py-1" : "min-h-9 py-2",
+                gridClass(layout, columns.length),
+              );
+              return (
+                <div key={rowIndex}>
+                  {hidden.length > 0
+                    ? (
+                      <ExpandableRow
+                        rowId={rowId}
+                        expanded={expanded}
+                        onToggle={() =>
+                          setOpen(
+                            expanded ? null : { table: tableId, row: rowIndex },
+                          )}
+                        class={rowClass}
+                        label={`${table.label} ${rowIndex + 1}`}
+                      >
+                        {cells(row, columns, t)}
+                      </ExpandableRow>
+                    )
+                    : (
+                      <div class={cx(rowClass, "border-b border-line-soft")}>
+                        {cells(row, columns, t)}
+                      </div>
+                    )}
+                  {expanded && (
+                    <HiddenRowFields
+                      fields={hidden}
+                      id={rowId}
+                      layout={layout}
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+      {table.total && (
+        <TotalRow label={table.total.label} layout={layout}>
+          {formatNumber(table.total.value, 2)}
+        </TotalRow>
+      )}
+    </section>
+  );
+}

--- a/src/ui/shared/document/DocumentHeader.tsx
+++ b/src/ui/shared/document/DocumentHeader.tsx
@@ -1,0 +1,121 @@
+/** @jsxImportSource preact */
+
+import type { ComponentChildren } from "preact";
+import { useT } from "../i18n-hook";
+import { TONE_BADGE, toneForStatus } from "../status";
+import type { ViewerLayout } from "../useViewerLayout";
+import { cx, Label, LiveDot } from "../ui";
+
+export interface DocumentHeaderProps {
+  doctype: string;
+  name: string;
+  title: string;
+  status?: string;
+  docstatus?: number;
+  layout: ViewerLayout;
+  /** Retour ou fil d'Ariane fourni par la coque qui héberge la fiche. */
+  navigation?: ComponentChildren;
+  /** Refresh, JSON ou toute autre action propre à la coque. */
+  trailing?: ComponentChildren;
+  live?: boolean;
+}
+
+function StatusBadge(
+  { status, pill }: { status: string; pill?: boolean },
+) {
+  return (
+    <span
+      class={cx(
+        "inline-flex shrink-0 font-mono text-micro uppercase tracking-chip",
+        pill ? "rounded-pill px-2 py-[3px]" : "rounded-badge px-[7px] py-0.5",
+        TONE_BADGE[toneForStatus(status)],
+      )}
+    >
+      {status}
+    </span>
+  );
+}
+
+export function DocumentHeader({
+  doctype,
+  name,
+  title,
+  status,
+  docstatus,
+  layout,
+  navigation,
+  trailing,
+  live,
+}: DocumentHeaderProps) {
+  const t = useT();
+  const narrow = layout !== "wide";
+
+  if (narrow) {
+    return (
+      <header aria-label={t("document.header")} class="shrink-0">
+        <div class="flex min-h-10 items-center justify-between gap-2.5 px-3 py-2">
+          <div class="min-w-0 flex-1">{navigation}</div>
+          <Label class="max-w-[45%] truncate text-center">{doctype}</Label>
+          <div class="flex min-w-0 flex-1 items-center justify-end gap-1.5">
+            {trailing}
+            {live && (
+              <span aria-hidden="true" class="size-1.5 rounded-full bg-ok" />
+            )}
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-1.5 border-b border-line px-3 pb-3 pt-1">
+          <span class="truncate font-mono text-nano uppercase tracking-label text-ink-faint">
+            {name}
+          </span>
+          <h2 class="text-pretty font-display text-card-title font-semibold text-ink">
+            {title}
+          </h2>
+          {(status || docstatus !== undefined) && (
+            <div class="flex flex-wrap items-center gap-[7px]">
+              {status && <StatusBadge status={status} pill />}
+              {docstatus !== undefined && (
+                <span class="font-mono text-chip text-ink-faint">
+                  {t("document.docstatus", { value: docstatus })}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+      </header>
+    );
+  }
+
+  return (
+    <header
+      aria-label={t("document.header")}
+      class="flex shrink-0 items-start justify-between gap-4 border-b border-line px-4 py-[13px]"
+    >
+      <div class="flex min-w-0 items-start gap-3">
+        {navigation && <div class="shrink-0 pt-0.5">{navigation}</div>}
+        <div class="flex min-w-0 flex-col gap-1">
+          <span class="truncate font-mono text-micro uppercase tracking-label text-ink-faint">
+            {doctype} · {name}
+          </span>
+          <h2 class="truncate font-display text-title font-semibold tracking-title text-ink">
+            {title}
+          </h2>
+          {(status || docstatus !== undefined || live) && (
+            <div class="flex flex-wrap items-center gap-[7px]">
+              {status && <StatusBadge status={status} />}
+              {docstatus !== undefined && (
+                <span class="font-mono text-chip text-ink-faint">
+                  {t("document.docstatus", { value: docstatus })}
+                </span>
+              )}
+              {live && <LiveDot />}
+            </div>
+          )}
+        </div>
+      </div>
+      {trailing && (
+        <div class="flex shrink-0 items-center gap-1.5">{trailing}</div>
+      )}
+    </header>
+  );
+}

--- a/src/ui/shared/document/DocumentSectionTabs.tsx
+++ b/src/ui/shared/document/DocumentSectionTabs.tsx
@@ -1,0 +1,102 @@
+/** @jsxImportSource preact */
+
+import type { JSX } from "preact";
+import { useT } from "../i18n-hook";
+import type { ViewerLayout } from "../useViewerLayout";
+import { cx } from "../ui";
+
+export interface DocumentSectionTab {
+  id: string;
+  label: string;
+  count?: number;
+  disabled?: boolean;
+}
+
+export interface DocumentSectionTabsProps {
+  tabs: readonly DocumentSectionTab[];
+  activeId: string;
+  onChange: (id: string) => void;
+  layout: ViewerLayout;
+  idPrefix?: string;
+}
+
+export function DocumentSectionTabs({
+  tabs,
+  activeId,
+  onChange,
+  layout,
+  idPrefix = "document",
+}: DocumentSectionTabsProps) {
+  const t = useT();
+
+  function moveFrom(
+    event: JSX.TargetedKeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) {
+    if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) {
+      return;
+    }
+    event.preventDefault();
+    const enabled = tabs
+      .map((tab, tabIndex) => ({ tab, tabIndex }))
+      .filter(({ tab }) => !tab.disabled);
+    if (enabled.length === 0) return;
+
+    const current = enabled.findIndex(({ tabIndex }) => tabIndex === index);
+    const target = event.key === "Home"
+      ? enabled[0]
+      : event.key === "End"
+      ? enabled[enabled.length - 1]
+      : enabled[
+        (current + (event.key === "ArrowRight" ? 1 : -1) + enabled.length) %
+        enabled.length
+      ];
+    onChange(target.tab.id);
+    document.getElementById(`${idPrefix}-tab-${target.tab.id}`)?.focus();
+  }
+
+  return (
+    <div
+      role="tablist"
+      aria-label={t("document.sections")}
+      class={cx(
+        "drag-scroll flex shrink-0 gap-1.5 overflow-x-auto border-b border-line",
+        layout === "mobile" ? "px-3 py-2.5" : "px-3.5 py-2.5",
+      )}
+    >
+      {tabs.map((tab, index) => {
+        const active = tab.id === activeId;
+        return (
+          <button
+            key={tab.id}
+            id={`${idPrefix}-tab-${tab.id}`}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            aria-controls={`${idPrefix}-panel-${tab.id}`}
+            tabIndex={active ? 0 : -1}
+            disabled={tab.disabled}
+            onClick={() => onChange(tab.id)}
+            onKeyDown={(event) => moveFrom(event, index)}
+            class={cx(
+              "shrink-0 border font-mono text-chip uppercase tracking-chip transition-colors",
+              "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
+              layout === "mobile"
+                ? "rounded-pill px-2.5 py-1"
+                : "rounded-control px-2.5 py-[5px]",
+              active
+                ? "border-accent bg-accent/14 text-accent-text"
+                : "border-line bg-control text-ink-muted hover:border-line-hover hover:text-ink",
+              "disabled:cursor-not-allowed disabled:opacity-40",
+            )}
+          >
+            {tab.label}
+            {tab.count !== undefined && (
+              <span class="ml-1.5 text-ink-faint">{tab.count}</span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/ui/shared/document/DocumentSurface.tsx
+++ b/src/ui/shared/document/DocumentSurface.tsx
@@ -1,0 +1,284 @@
+/** @jsxImportSource preact */
+
+import type { ComponentChildren } from "preact";
+import { useState } from "preact/hooks";
+import { useT } from "../i18n-hook";
+import type { ViewerLayout } from "../useViewerLayout";
+import { cx } from "../ui";
+import { ChildTableSection } from "./ChildTableSection";
+import { DocumentHeader } from "./DocumentHeader";
+import {
+  type DocumentSectionTab,
+  DocumentSectionTabs,
+} from "./DocumentSectionTabs";
+import { ScalarFields } from "./ScalarFields";
+import type { ChildTableModel, DocumentModel } from "./types.ts";
+
+export interface DocumentSurfaceProps {
+  model: DocumentModel;
+  layout: ViewerLayout;
+  /** Retour, fil d'Ariane ou fermeture appartenant à la coque hôte. */
+  navigation?: ComponentChildren;
+  /** Outils courts de l'en-tête, par exemple refresh et JSON. */
+  headerActions?: ComponentChildren;
+  /** Surface pièces jointes déjà capability-gated par la coque. */
+  attachments?: ComponentChildren;
+  /** Actions métier déjà capability-gated par la coque. */
+  actions?: ComponentChildren;
+  footer?: ComponentChildren;
+  live?: boolean;
+  class?: string;
+  idPrefix?: string;
+  /** Permet à un hôte de piloter les onglets mobiles. */
+  activeSectionId?: string;
+  onActiveSectionChange?: (id: string) => void;
+}
+
+interface TableSection {
+  id: string;
+  table: ChildTableModel;
+}
+
+function slug(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]/g, "-");
+}
+
+function hasSlot(slot: ComponentChildren | undefined): boolean {
+  return slot !== undefined && slot !== null && slot !== false;
+}
+
+function DocumentFields(
+  { model, layout }: { model: DocumentModel; layout: ViewerLayout },
+) {
+  return (
+    <ScalarFields
+      fields={model.fields}
+      longFields={model.longFields}
+      progressFields={model.progressFields}
+      collections={model.collections}
+      systemFields={model.systemFields}
+      layout={layout}
+    />
+  );
+}
+
+function SlotSection(
+  { children, class: klass }: { children: ComponentChildren; class?: string },
+) {
+  return (
+    <section class={cx("min-w-0 border-t border-line", klass)}>
+      {children}
+    </section>
+  );
+}
+
+export function DocumentSurface({
+  model,
+  layout,
+  navigation,
+  headerActions,
+  attachments,
+  actions,
+  footer,
+  live,
+  class: klass,
+  idPrefix,
+  activeSectionId,
+  onActiveSectionChange,
+}: DocumentSurfaceProps) {
+  const t = useT();
+  const defaultPrefix = `document-${slug(model.envelope.doctype)}-${
+    slug(model.envelope.name)
+  }`;
+  const domPrefix = idPrefix ?? defaultPrefix;
+  const documentKey = `${model.envelope.doctype}:${model.envelope.name}`;
+  const [localSelection, setLocalSelection] = useState({
+    documentKey,
+    sectionId: "fields",
+  });
+  const localActive = localSelection.documentKey === documentKey
+    ? localSelection.sectionId
+    : "fields";
+  const hasAttachments = hasSlot(attachments);
+  const hasActions = hasSlot(actions);
+  const hasSidebar = hasAttachments || hasActions;
+  const hasFields = model.fields.length > 0 || model.longFields.length > 0 ||
+    model.progressFields.length > 0 || model.collections.length > 0 ||
+    model.systemFields.length > 0;
+  const tableSections: TableSection[] = model.childTables.map((
+    table,
+    index,
+  ) => ({
+    id: `table-${slug(table.key)}-${index}`,
+    table,
+  }));
+  const tabs: DocumentSectionTab[] = [
+    ...(hasFields ? [{ id: "fields", label: t("document.fields") }] : []),
+    ...tableSections.map(({ id, table }) => ({
+      id,
+      label: table.label,
+      count: table.rows.length,
+    })),
+    ...(hasAttachments
+      ? [{ id: "attachments", label: t("document.attachments") }]
+      : []),
+  ];
+  const requestedActive = activeSectionId ?? localActive;
+  const active = tabs.some((tab) => tab.id === requestedActive)
+    ? requestedActive
+    : tabs[0]?.id ?? "fields";
+
+  function selectSection(id: string) {
+    if (activeSectionId === undefined) {
+      setLocalSelection({ documentKey, sectionId: id });
+    }
+    onActiveSectionChange?.(id);
+  }
+
+  const header = (
+    <DocumentHeader
+      doctype={model.envelope.doctype}
+      name={model.envelope.name}
+      title={model.title}
+      status={model.status}
+      docstatus={model.docstatus}
+      layout={layout}
+      navigation={navigation}
+      trailing={headerActions}
+      live={live}
+    />
+  );
+
+  if (layout === "wide") {
+    return (
+      <article
+        aria-label={t("document.surface", { name: model.envelope.name })}
+        class={cx("flex min-h-0 flex-1 flex-col bg-surface", klass)}
+      >
+        {header}
+        <div
+          class={cx(
+            "grid min-h-0 flex-1",
+            hasSidebar ? "grid-cols-[minmax(0,1fr)_268px]" : "grid-cols-1",
+          )}
+        >
+          <main
+            class={cx(
+              "scroll-slim min-w-0 overflow-y-auto",
+              hasSidebar && "border-r border-line",
+            )}
+          >
+            {hasFields && <DocumentFields model={model} layout={layout} />}
+            {tableSections.map(({ id, table }) => (
+              <ChildTableSection
+                key={id}
+                table={table}
+                layout={layout}
+                idPrefix={domPrefix}
+                class="border-t border-line-soft"
+              />
+            ))}
+          </main>
+          {hasSidebar && (
+            <aside
+              aria-label={t("document.sidebar")}
+              class="scroll-slim min-w-0 overflow-y-auto bg-sunken"
+            >
+              {hasAttachments && <div>{attachments}</div>}
+              {hasActions && <SlotSection class="p-3.5">{actions}</SlotSection>}
+            </aside>
+          )}
+        </div>
+        {hasSlot(footer) && (
+          <footer class="shrink-0 border-t border-line">{footer}</footer>
+        )}
+      </article>
+    );
+  }
+
+  if (layout === "panel") {
+    return (
+      <article
+        aria-label={t("document.surface", { name: model.envelope.name })}
+        class={cx("flex min-h-0 flex-1 flex-col bg-surface", klass)}
+      >
+        {header}
+        <main class="scroll-slim min-h-0 flex-1 overflow-y-auto">
+          {hasFields && <DocumentFields model={model} layout={layout} />}
+          {tableSections.map(({ id, table }) => (
+            <ChildTableSection
+              key={id}
+              table={table}
+              layout={layout}
+              idPrefix={domPrefix}
+              class="border-t border-line"
+            />
+          ))}
+          {hasAttachments && <SlotSection>{attachments}</SlotSection>}
+          {hasActions && <SlotSection class="p-3.5">{actions}</SlotSection>}
+        </main>
+        {hasSlot(footer) && (
+          <footer class="shrink-0 border-t border-line">{footer}</footer>
+        )}
+      </article>
+    );
+  }
+
+  const activeTable = tableSections.find(({ id }) => id === active);
+  return (
+    <article
+      aria-label={t("document.surface", { name: model.envelope.name })}
+      class={cx("flex min-h-0 flex-1 flex-col bg-surface", klass)}
+    >
+      {header}
+      {tabs.length > 0 && (
+        <DocumentSectionTabs
+          tabs={tabs}
+          activeId={active}
+          onChange={selectSection}
+          layout={layout}
+          idPrefix={domPrefix}
+        />
+      )}
+      <main class="scroll-slim min-h-0 flex-1 overflow-y-auto">
+        {active === "fields" && hasFields && (
+          <div
+            id={`${domPrefix}-panel-fields`}
+            role="tabpanel"
+            aria-labelledby={`${domPrefix}-tab-fields`}
+          >
+            <DocumentFields model={model} layout={layout} />
+          </div>
+        )}
+        {activeTable && (
+          <div
+            id={`${domPrefix}-panel-${activeTable.id}`}
+            role="tabpanel"
+            aria-labelledby={`${domPrefix}-tab-${activeTable.id}`}
+          >
+            <ChildTableSection
+              table={activeTable.table}
+              layout={layout}
+              idPrefix={domPrefix}
+            />
+          </div>
+        )}
+        {active === "attachments" && hasAttachments && (
+          <div
+            id={`${domPrefix}-panel-attachments`}
+            role="tabpanel"
+            aria-labelledby={`${domPrefix}-tab-attachments`}
+          >
+            {attachments}
+          </div>
+        )}
+      </main>
+      {hasActions && (
+        <div class="shrink-0 border-t border-line p-3">{actions}</div>
+      )}
+      {hasSlot(footer) && (
+        <footer class="shrink-0 border-t border-line">{footer}</footer>
+      )}
+    </article>
+  );
+}

--- a/src/ui/shared/document/ScalarFields.tsx
+++ b/src/ui/shared/document/ScalarFields.tsx
@@ -1,0 +1,244 @@
+/** @jsxImportSource preact */
+
+import type { ComponentChildren } from "preact";
+import { formatNumber, toNumber } from "../format";
+import { type TFunction, useT } from "../i18n-hook";
+import { TONE_BADGE, toneForStatus } from "../status";
+import type { ViewerLayout } from "../useViewerLayout";
+import { CountBadge, cx, Label, ProgressBar } from "../ui";
+import type {
+  DocumentCollectionModel,
+  DocumentDisplayValue,
+  DocumentFieldModel,
+} from "./types.ts";
+
+export interface ScalarFieldsProps {
+  fields: readonly DocumentFieldModel[];
+  longFields?: readonly DocumentFieldModel[];
+  progressFields?: readonly DocumentFieldModel[];
+  collections?: readonly DocumentCollectionModel[];
+  systemFields?: readonly DocumentFieldModel[];
+  layout: ViewerLayout;
+  /** `null` retire le titre quand la surface hôte le fournit déjà. */
+  heading?: string | null;
+  class?: string;
+}
+
+function displayValue(value: DocumentDisplayValue, t: TFunction): string {
+  if (value === null || value === "") return t("document.empty_value");
+  if (typeof value === "boolean") {
+    return t(value ? "document.boolean.true" : "document.boolean.false");
+  }
+  if (typeof value === "number") {
+    return formatNumber(value, Number.isInteger(value) ? 0 : 2);
+  }
+  return value;
+}
+
+export function DocumentFieldValue(
+  { field, class: klass }: { field: DocumentFieldModel; class?: string },
+) {
+  const t = useT();
+  if (field.kind === "status" && field.value !== null) {
+    const status = String(field.value);
+    return (
+      <span
+        class={cx(
+          "inline-flex rounded-badge px-[7px] py-0.5 font-mono text-micro uppercase tracking-chip",
+          TONE_BADGE[toneForStatus(status)],
+          klass,
+        )}
+      >
+        {status}
+      </span>
+    );
+  }
+  return (
+    <span
+      class={cx(
+        field.kind === "number" || field.kind === "date" ||
+          field.kind === "datetime"
+          ? "font-mono tabular-nums"
+          : undefined,
+        field.kind === "empty" ? "text-ink-dim" : undefined,
+        klass,
+      )}
+    >
+      {displayValue(field.value, t)}
+    </span>
+  );
+}
+
+function FieldsGrid(
+  { fields, layout }: {
+    fields: readonly DocumentFieldModel[];
+    layout: ViewerLayout;
+  },
+) {
+  return (
+    <dl
+      class={cx(
+        "grid gap-x-7",
+        layout === "wide" ? "grid-cols-2 gap-y-2" : "grid-cols-1 gap-y-1",
+      )}
+    >
+      {fields.map((field) => (
+        <div
+          key={field.key}
+          class={cx(
+            "flex min-w-0 items-baseline justify-between gap-2.5",
+            layout !== "wide" && "min-h-6",
+          )}
+        >
+          <dt class="shrink-0 font-mono text-chip text-ink-faint">
+            {field.label}
+          </dt>
+          <dd class="min-w-0 truncate text-right text-note text-ink-2">
+            <DocumentFieldValue field={field} />
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function Section(
+  { label, aside, children, first }: {
+    label: string | null;
+    aside?: ComponentChildren;
+    children: ComponentChildren;
+    first?: boolean;
+  },
+) {
+  return (
+    <section
+      class={cx(
+        "flex flex-col gap-2 px-4 py-3.5",
+        !first && "border-t border-line-soft",
+      )}
+    >
+      {(label || aside) && (
+        <div class="flex items-baseline justify-between gap-3">
+          {label ? <Label>{label}</Label> : <span />}
+          {aside}
+        </div>
+      )}
+      {children}
+    </section>
+  );
+}
+
+export function ScalarFields({
+  fields,
+  longFields = [],
+  progressFields = [],
+  collections = [],
+  systemFields = [],
+  layout,
+  heading,
+  class: klass,
+}: ScalarFieldsProps) {
+  const t = useT();
+  const title = heading === undefined ? t("document.fields") : heading;
+  const hasContent = fields.length > 0 || longFields.length > 0 ||
+    progressFields.length > 0 || collections.length > 0 ||
+    systemFields.length > 0;
+  if (!hasContent) return null;
+
+  let first = true;
+  const consumeFirst = () => {
+    const current = first;
+    first = false;
+    return current;
+  };
+
+  return (
+    <div class={cx("flex flex-col", klass)}>
+      {fields.length > 0 && (
+        <Section label={title} first={consumeFirst()}>
+          <FieldsGrid fields={fields} layout={layout} />
+        </Section>
+      )}
+
+      {longFields.map((field) => (
+        <Section key={field.key} label={field.label} first={consumeFirst()}>
+          {field.kind === "json"
+            ? (
+              <pre class="scroll-slim max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-control border border-line-soft bg-sunken p-2.5 font-mono text-chip leading-relaxed text-ink-2">
+                {displayValue(field.value, t)}
+              </pre>
+            )
+            : (
+              <p class="whitespace-pre-wrap break-words text-cell leading-[1.55] text-ink-2">
+                {displayValue(field.value, t)}
+              </p>
+            )}
+        </Section>
+      ))}
+
+      {progressFields.map((field) => {
+        const value = toNumber(field.value) ?? 0;
+        return (
+          <Section
+            key={field.key}
+            label={field.label}
+            first={consumeFirst()}
+            aside={
+              <span class="font-mono text-meta tabular-nums text-ink-muted">
+                {t("document.progress_value", {
+                  value: formatNumber(value, 0),
+                })}
+              </span>
+            }
+          >
+            <ProgressBar value={value} />
+          </Section>
+        );
+      })}
+
+      {collections.map((collection) => (
+        <Section
+          key={collection.key}
+          label={collection.label}
+          first={consumeFirst()}
+        >
+          {collection.values.length === 0
+            ? (
+              <span class="font-mono text-chip text-ink-dim">
+                {t("document.empty_value")}
+              </span>
+            )
+            : (
+              <div class="flex flex-wrap gap-1.5">
+                {collection.values.map((value, index) => (
+                  <span
+                    key={`${collection.key}-${index}`}
+                    class="max-w-full truncate rounded-chip border border-line bg-control px-2 py-1 font-mono text-chip text-ink-muted"
+                  >
+                    {displayValue(value, t)}
+                  </span>
+                ))}
+              </div>
+            )}
+        </Section>
+      ))}
+
+      {systemFields.length > 0 && (
+        <details
+          class={cx(
+            "group border-t border-line-soft px-4 py-3",
+            first && "border-t-0",
+          )}
+        >
+          <summary class="flex cursor-pointer list-none items-center justify-between gap-3 rounded-control font-mono text-micro uppercase tracking-label text-ink-faint focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent">
+            <span>{t("document.system_fields")}</span>
+            <CountBadge narrow>{systemFields.length}</CountBadge>
+          </summary>
+          <div class="pt-3">
+            <FieldsGrid fields={systemFields} layout={layout} />
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/src/ui/shared/document/attachment-results.ts
+++ b/src/ui/shared/document/attachment-results.ts
@@ -1,0 +1,106 @@
+import { extractToolResultText } from "../refresh.ts";
+
+export interface DocumentAttachment {
+  /** Canonical Frappe File document id. Never use file_url as authority. */
+  id: string;
+  fileName: string;
+  fileSize: number | null;
+  isPrivate: boolean;
+  attachedToField?: string;
+  createdAt?: string;
+  modifiedAt?: string;
+  owner?: string;
+}
+
+export interface EmbeddedDownloadResource {
+  type: "resource";
+  resource: {
+    uri: string;
+    mimeType?: string;
+    blob: string;
+  };
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+/** Parse the bounded attachment-list contract without trusting file URLs. */
+export function attachmentListFromToolResult(
+  result: unknown,
+): DocumentAttachment[] {
+  const toolResult = record(result);
+  if (!toolResult || toolResult.isError === true) {
+    throw new Error("attachment list failed");
+  }
+  const text = extractToolResultText(toolResult);
+  if (!text) throw new Error("attachment list is empty");
+
+  const payload = record(JSON.parse(text));
+  if (!payload || !Array.isArray(payload.data)) {
+    throw new Error("attachment list is malformed");
+  }
+
+  return payload.data.map((raw, index) => {
+    const file = record(raw);
+    const id = optionalString(file?.name);
+    const fileName = optionalString(file?.file_name);
+    if (!file || !id || !fileName) {
+      throw new Error(`attachment ${index + 1} has no canonical identity`);
+    }
+    const size = file.file_size;
+    const fileSize = size === null || size === undefined
+      ? null
+      : typeof size === "number" && Number.isFinite(size) && size >= 0
+      ? size
+      : null;
+    return {
+      id,
+      fileName,
+      fileSize,
+      isPrivate: file.is_private === true || file.is_private === 1,
+      attachedToField: optionalString(file.attached_to_field),
+      createdAt: optionalString(file.creation),
+      modifiedAt: optionalString(file.modified),
+      owner: optionalString(file.owner),
+    };
+  });
+}
+
+/**
+ * Extract the single inline resource returned by the app-only download tool.
+ * It is deliberately returned only to the click handler, never persisted in UI
+ * state, so large base64 data is eligible for collection immediately afterward.
+ */
+export function downloadResourceFromToolResult(
+  result: unknown,
+): EmbeddedDownloadResource {
+  const toolResult = record(result);
+  if (!toolResult || toolResult.isError === true) {
+    throw new Error("attachment download failed");
+  }
+  const content = Array.isArray(toolResult.content) ? toolResult.content : [];
+  const resources = content.flatMap((raw) => {
+    const block = record(raw);
+    const resource = record(block?.resource);
+    if (block?.type !== "resource" || !resource) return [];
+    const uri = optionalString(resource.uri);
+    const blob = optionalString(resource.blob);
+    if (!uri || !blob) return [];
+    const mimeType = optionalString(resource.mimeType);
+    return [{
+      type: "resource" as const,
+      resource: { uri, ...(mimeType ? { mimeType } : {}), blob },
+    }];
+  });
+  if (resources.length !== 1) {
+    throw new Error("attachment download did not return one inline resource");
+  }
+  return resources[0];
+}

--- a/src/ui/shared/document/attachment-results_test.ts
+++ b/src/ui/shared/document/attachment-results_test.ts
@@ -1,0 +1,97 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  attachmentListFromToolResult,
+  downloadResourceFromToolResult,
+} from "./attachment-results.ts";
+
+Deno.test("attachment list keeps canonical File ids and ignores URLs", () => {
+  const files = attachmentListFromToolResult({
+    content: [{
+      type: "text",
+      text: JSON.stringify({
+        count: 1,
+        data: [{
+          name: "FILE-7",
+          file_name: "report.pdf",
+          file_url: "https://attacker.invalid/report.pdf",
+          file_size: 42,
+          is_private: 1,
+          owner: "alice@example.com",
+        }],
+      }),
+    }],
+  });
+
+  assertEquals(files, [{
+    id: "FILE-7",
+    fileName: "report.pdf",
+    fileSize: 42,
+    isPrivate: true,
+    owner: "alice@example.com",
+    attachedToField: undefined,
+    createdAt: undefined,
+    modifiedAt: undefined,
+  }]);
+  assertEquals("fileUrl" in files[0], false);
+});
+
+Deno.test("attachment list rejects rows without canonical identity", () => {
+  assertThrows(
+    () =>
+      attachmentListFromToolResult({
+        structuredContent: { data: [{ file_name: "report.pdf" }] },
+      }),
+    Error,
+    "canonical identity",
+  );
+});
+
+Deno.test("download extracts one exact embedded resource", () => {
+  const resource = downloadResourceFromToolResult({
+    content: [
+      { type: "text", text: "download ready" },
+      {
+        type: "resource",
+        resource: {
+          uri: "file:///report.pdf",
+          mimeType: "application/pdf",
+          blob: "JVBERg==",
+        },
+      },
+    ],
+  });
+  assertEquals(resource, {
+    type: "resource",
+    resource: {
+      uri: "file:///report.pdf",
+      mimeType: "application/pdf",
+      blob: "JVBERg==",
+    },
+  });
+});
+
+Deno.test("download rejects links and ambiguous multiple resources", () => {
+  assertThrows(
+    () =>
+      downloadResourceFromToolResult({
+        content: [{
+          type: "resource_link",
+          uri: "https://example.invalid/report.pdf",
+          name: "report.pdf",
+        }],
+      }),
+    Error,
+    "one inline resource",
+  );
+  assertThrows(
+    () =>
+      downloadResourceFromToolResult({
+        content: [
+          { type: "resource", resource: { uri: "file:///a", blob: "YQ==" } },
+          { type: "resource", resource: { uri: "file:///b", blob: "Yg==" } },
+        ],
+      }),
+    Error,
+    "one inline resource",
+  );
+});

--- a/src/ui/shared/document/attachments-state.ts
+++ b/src/ui/shared/document/attachments-state.ts
@@ -1,0 +1,100 @@
+export type AttachmentLoadState = "idle" | "loading" | "ready" | "error";
+export type AttachmentUploadState =
+  | "idle"
+  | "reading"
+  | "uploading"
+  | "relisting"
+  | "error";
+
+export interface PersistentAttachmentError {
+  operation: "list" | "upload" | "download";
+  message: string;
+  fileName?: string;
+}
+
+export interface AttachmentsState {
+  documentKey: string;
+  revision: number;
+  nextRequest: number;
+  load: AttachmentLoadState;
+  upload: AttachmentUploadState;
+  downloadingFile: string | null;
+  error: PersistentAttachmentError | null;
+}
+
+export interface AttachmentToken {
+  documentKey: string;
+  revision: number;
+  request: number;
+}
+
+export function createAttachmentsState(documentKey: string): AttachmentsState {
+  return {
+    documentKey,
+    revision: 0,
+    nextRequest: 1,
+    load: "idle",
+    upload: "idle",
+    downloadingFile: null,
+    error: null,
+  };
+}
+
+export function resetAttachmentsState(
+  state: AttachmentsState,
+  documentKey: string,
+): AttachmentsState {
+  if (state.documentKey === documentKey) return state;
+  return {
+    ...createAttachmentsState(documentKey),
+    revision: state.revision + 1,
+    nextRequest: state.nextRequest,
+  };
+}
+
+export function reserveAttachmentRequest(
+  state: AttachmentsState,
+): { state: AttachmentsState; token: AttachmentToken } {
+  return {
+    state: { ...state, nextRequest: state.nextRequest + 1 },
+    token: {
+      documentKey: state.documentKey,
+      revision: state.revision,
+      request: state.nextRequest,
+    },
+  };
+}
+
+export function invalidateAttachmentRequests(
+  state: AttachmentsState,
+): AttachmentsState {
+  return { ...state, revision: state.revision + 1 };
+}
+
+export function acceptsAttachmentToken(
+  state: AttachmentsState,
+  token: AttachmentToken,
+): boolean {
+  return state.documentKey === token.documentKey &&
+    state.revision === token.revision &&
+    state.nextRequest === token.request + 1;
+}
+
+export function canStartAttachmentUpload(state: AttachmentsState): boolean {
+  return state.upload === "idle" || state.upload === "error";
+}
+
+/**
+ * Settle an upload failure after its request superseded the current list load.
+ * The superseded list response can no longer leave `load` because its token is
+ * stale, so release that loading state and let the user retry explicitly.
+ */
+export function settleAttachmentUploadFailure(
+  state: AttachmentsState,
+): AttachmentsState {
+  return {
+    ...state,
+    load: state.load === "loading" ? "idle" : state.load,
+    upload: "error",
+  };
+}

--- a/src/ui/shared/document/attachments-state_test.ts
+++ b/src/ui/shared/document/attachments-state_test.ts
@@ -1,0 +1,78 @@
+import { assert, assertEquals } from "@std/assert";
+import {
+  acceptsAttachmentToken,
+  canStartAttachmentUpload,
+  createAttachmentsState,
+  invalidateAttachmentRequests,
+  reserveAttachmentRequest,
+  resetAttachmentsState,
+  settleAttachmentUploadFailure,
+} from "./attachments-state.ts";
+
+Deno.test("attachment token becomes stale when the document changes", () => {
+  const initial = createAttachmentsState("Task:TASK-1");
+  const reserved = reserveAttachmentRequest(initial);
+  const changed = resetAttachmentsState(reserved.state, "Task:TASK-2");
+  assertEquals(acceptsAttachmentToken(changed, reserved.token), false);
+});
+
+Deno.test("post-mutation invalidation rejects an older attachment list", () => {
+  const reserved = reserveAttachmentRequest(
+    createAttachmentsState("Task:TASK-1"),
+  );
+  const invalidated = invalidateAttachmentRequests(reserved.state);
+  assertEquals(acceptsAttachmentToken(invalidated, reserved.token), false);
+  const fresh = reserveAttachmentRequest(invalidated);
+  assert(acceptsAttachmentToken(fresh.state, fresh.token));
+});
+
+Deno.test("only the newest attachment request wins within one revision", () => {
+  const first = reserveAttachmentRequest(
+    createAttachmentsState("Task:TASK-1"),
+  );
+  const second = reserveAttachmentRequest(first.state);
+
+  assertEquals(acceptsAttachmentToken(second.state, first.token), false);
+  assert(acceptsAttachmentToken(second.state, second.token));
+});
+
+Deno.test("attachment uploads are single-flight", () => {
+  const state = createAttachmentsState("Task:TASK-1");
+  assert(canStartAttachmentUpload(state));
+  assertEquals(
+    canStartAttachmentUpload({ ...state, upload: "reading" }),
+    false,
+  );
+  assertEquals(
+    canStartAttachmentUpload({ ...state, upload: "uploading" }),
+    false,
+  );
+  assertEquals(
+    canStartAttachmentUpload({ ...state, upload: "relisting" }),
+    false,
+  );
+  assert(canStartAttachmentUpload({ ...state, upload: "error" }));
+});
+
+Deno.test("failed upload releases the list load it superseded", () => {
+  const initialList = reserveAttachmentRequest(
+    createAttachmentsState("Task:TASK-1"),
+  );
+  const loading = { ...initialList.state, load: "loading" as const };
+  const upload = reserveAttachmentRequest(loading);
+  const uploading = { ...upload.state, upload: "uploading" as const };
+
+  // Starting the upload makes the slow initial list response stale.
+  assertEquals(acceptsAttachmentToken(uploading, initialList.token), false);
+  assert(acceptsAttachmentToken(uploading, upload.token));
+
+  const failed = settleAttachmentUploadFailure(uploading);
+
+  // The stale list can no longer settle this state, so the upload failure must
+  // release it and allow an explicit refresh to reserve the next valid token.
+  assertEquals(failed.load, "idle");
+  assertEquals(failed.upload, "error");
+  const retry = reserveAttachmentRequest(failed);
+  assert(acceptsAttachmentToken(retry.state, retry.token));
+  assertEquals(acceptsAttachmentToken(retry.state, initialList.token), false);
+});

--- a/src/ui/shared/document/capabilities.ts
+++ b/src/ui/shared/document/capabilities.ts
@@ -1,0 +1,42 @@
+import type { UiRefreshRequestData } from "../refresh.ts";
+
+export interface DocumentHostCapabilities {
+  serverTools?: unknown;
+  downloadFile?: unknown;
+}
+
+export interface DocumentCapabilities {
+  canRefresh: boolean;
+  canListAttachments: boolean;
+  canUploadAttachment: boolean;
+  canDownloadAttachment: boolean;
+  canSubmit: boolean;
+  canCancel: boolean;
+}
+
+/**
+ * Capabilities for document-initiated calls are deliberately fail-closed.
+ * A beta.2 document payload is required to carry the server-filtered manifest;
+ * an absent legacy manifest still renders the document, but exposes no action.
+ */
+export function documentCapabilities(
+  host: DocumentHostCapabilities | undefined,
+  availableTools: readonly string[] | undefined,
+  refreshRequest?: UiRefreshRequestData,
+): DocumentCapabilities {
+  const serverTools = Boolean(host?.serverTools);
+  const has = (toolName: string) =>
+    serverTools && Array.isArray(availableTools) &&
+    availableTools.includes(toolName);
+
+  const canListAttachments = has("erpnext_file_list");
+  return {
+    canRefresh: Boolean(refreshRequest && has(refreshRequest.toolName)),
+    canListAttachments,
+    canUploadAttachment: canListAttachments && has("erpnext_file_upload"),
+    canDownloadAttachment: canListAttachments &&
+      has("erpnext_file_download") && Boolean(host?.downloadFile),
+    canSubmit: has("erpnext_doc_submit"),
+    canCancel: has("erpnext_doc_cancel"),
+  };
+}

--- a/src/ui/shared/document/capabilities_test.ts
+++ b/src/ui/shared/document/capabilities_test.ts
@@ -1,0 +1,66 @@
+import { assertEquals } from "@std/assert";
+import { documentCapabilities } from "./capabilities.ts";
+
+const REFRESH = {
+  toolName: "erpnext_task_get",
+  arguments: { name: "TASK-1" },
+};
+
+Deno.test("document capabilities fail closed without a server manifest", () => {
+  assertEquals(
+    documentCapabilities(
+      { serverTools: {}, downloadFile: {} },
+      undefined,
+      REFRESH,
+    ),
+    {
+      canRefresh: false,
+      canListAttachments: false,
+      canUploadAttachment: false,
+      canDownloadAttachment: false,
+      canSubmit: false,
+      canCancel: false,
+    },
+  );
+});
+
+Deno.test("document capabilities require both host and exact tools", () => {
+  const tools = [
+    "erpnext_task_get",
+    "erpnext_file_list",
+    "erpnext_file_upload",
+    "erpnext_file_download",
+    "erpnext_doc_submit",
+    "erpnext_doc_cancel",
+  ];
+  assertEquals(
+    documentCapabilities({ serverTools: {}, downloadFile: {} }, tools, REFRESH),
+    {
+      canRefresh: true,
+      canListAttachments: true,
+      canUploadAttachment: true,
+      canDownloadAttachment: true,
+      canSubmit: true,
+      canCancel: true,
+    },
+  );
+  assertEquals(
+    documentCapabilities({ serverTools: {} }, tools, REFRESH)
+      .canDownloadAttachment,
+    false,
+  );
+  assertEquals(
+    documentCapabilities({ downloadFile: {} }, tools, REFRESH)
+      .canListAttachments,
+    false,
+  );
+});
+
+Deno.test("upload and download cannot bypass attachment listing", () => {
+  const capabilities = documentCapabilities(
+    { serverTools: {}, downloadFile: {} },
+    ["erpnext_file_upload", "erpnext_file_download"],
+  );
+  assertEquals(capabilities.canUploadAttachment, false);
+  assertEquals(capabilities.canDownloadAttachment, false);
+});

--- a/src/ui/shared/document/child-table-model.ts
+++ b/src/ui/shared/document/child-table-model.ts
@@ -1,0 +1,262 @@
+import type {
+  ChildTableColumn,
+  ChildTableModel,
+  ChildTableRow,
+  ChildTableTotal,
+  DocumentDisplayValue,
+  DocumentFieldKind,
+  DocumentFieldModel,
+  DocumentTableLayout,
+} from "./types.ts";
+
+const CHILD_SYSTEM_FIELDS = new Set([
+  "idx",
+  "parent",
+  "parenttype",
+  "parentfield",
+  "doctype",
+  "owner",
+  "creation",
+  "modified",
+  "modified_by",
+  "docstatus",
+]);
+
+const COLUMN_PRIORITY = [
+  "item_code",
+  "operation",
+  "activity_type",
+  "title",
+  "subject",
+  "description",
+  "qty",
+  "quantity",
+  "amount",
+  "operating_cost",
+  "rate",
+  "price",
+  "uom",
+  "item_name",
+  "warehouse",
+  "account",
+  "employee",
+  "name",
+  "id",
+  "base_amount",
+] as const;
+
+const ADDITIVE_FIELD_PRIORITY = [
+  "amount",
+  "base_amount",
+  "net_amount",
+  "base_net_amount",
+  "operating_cost",
+  "base_operating_cost",
+  "stock_value_difference",
+] as const;
+
+const NUMERIC_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function documentDisplayValue(value: unknown): DocumentDisplayValue {
+  if (
+    value === null || typeof value === "string" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : String(value);
+  }
+  return safeJson(value);
+}
+
+export function humanizeDocumentKey(key: string): string {
+  const words = key
+    .replace(/([a-z\d])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return words.length === 0
+    ? key
+    : words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+function numericValue(value: DocumentDisplayValue): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return NUMERIC_PATTERN.test(trimmed) ? Number(trimmed) : null;
+}
+
+function fieldKind(
+  key: string,
+  value: DocumentDisplayValue,
+): DocumentFieldKind {
+  if (value === null || value === "") return "empty";
+  if (typeof value === "number") return "number";
+  if (typeof value === "boolean") return "boolean";
+  if (/(^|_)(workflow_)?status($|_)/i.test(key)) return "status";
+  if (
+    typeof value === "string" &&
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(value)
+  ) {
+    return "datetime";
+  }
+  if (
+    typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value)
+  ) {
+    return "date";
+  }
+  if (
+    typeof value === "string" &&
+    (value.startsWith("{") || value.startsWith("["))
+  ) {
+    return "json";
+  }
+  return "text";
+}
+
+function isNumericColumn(
+  rows: readonly ChildTableRow[],
+  key: string,
+): boolean {
+  const present = rows
+    .map((row) => row[key])
+    .filter((value) => value !== undefined && value !== null && value !== "");
+  return present.length > 0 &&
+    present.every((value) => numericValue(value) !== null);
+}
+
+function tableTotal(
+  rows: readonly ChildTableRow[],
+  columns: readonly ChildTableColumn[],
+): ChildTableTotal | undefined {
+  for (const key of ADDITIVE_FIELD_PRIORITY) {
+    if (!columns.some((column) => column.key === key)) continue;
+    const values = rows
+      .map((row) => row[key])
+      .filter((value) => value !== undefined && value !== null && value !== "");
+    if (values.length === 0) continue;
+    const numbers = values.map(numericValue);
+    if (numbers.some((value) => value === null)) continue;
+    return {
+      key,
+      label: humanizeDocumentKey(key),
+      value: numbers.reduce<number>(
+        (sum, value) => sum + (value ?? 0),
+        0,
+      ),
+    };
+  }
+  return undefined;
+}
+
+function isFrappeChildRow(rows: readonly Record<string, unknown>[]): boolean {
+  return rows.some((row) =>
+    "parent" in row || "parenttype" in row || "parentfield" in row ||
+    "idx" in row
+  );
+}
+
+function businessKeys(
+  rows: readonly Record<string, unknown>[],
+): readonly string[] {
+  const seen = new Map<string, number>();
+  const hideChildName = isFrappeChildRow(rows);
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      if (
+        key.startsWith("_") || CHILD_SYSTEM_FIELDS.has(key) ||
+        (hideChildName && key === "name")
+      ) {
+        continue;
+      }
+      if (!seen.has(key)) seen.set(key, seen.size);
+    }
+  }
+
+  const priority = new Map<string, number>(
+    COLUMN_PRIORITY.map((key, index) => [key, index]),
+  );
+  return [...seen.keys()].sort((left, right) => {
+    const leftPriority = priority.get(left) ?? Number.MAX_SAFE_INTEGER;
+    const rightPriority = priority.get(right) ?? Number.MAX_SAFE_INTEGER;
+    return leftPriority - rightPriority ||
+      (seen.get(left) ?? 0) - (seen.get(right) ?? 0);
+  });
+}
+
+export function childTableModelOf(
+  key: string,
+  inputRows: readonly Record<string, unknown>[],
+): ChildTableModel {
+  const keys = businessKeys(inputRows);
+  const rows: ChildTableRow[] = inputRows.map((inputRow) =>
+    Object.fromEntries(
+      keys
+        .filter((field) =>
+          Object.prototype.hasOwnProperty.call(inputRow, field)
+        )
+        .map((field) => [field, documentDisplayValue(inputRow[field])]),
+    )
+  );
+  const columns: ChildTableColumn[] = keys.map((field) => ({
+    key: field,
+    label: humanizeDocumentKey(field),
+    numeric: isNumericColumn(rows, field),
+  }));
+  const total = tableTotal(rows, columns);
+
+  return {
+    key,
+    label: humanizeDocumentKey(key),
+    rows,
+    columns,
+    ...(total ? { total } : {}),
+  };
+}
+
+export function childTableColumnsForLayout(
+  table: ChildTableModel,
+  layout: DocumentTableLayout,
+): readonly ChildTableColumn[] {
+  return table.columns.slice(0, layout === "wide" ? 4 : 3);
+}
+
+export function childTableHiddenEntries(
+  table: ChildTableModel,
+  rowIndex: number,
+  layout: DocumentTableLayout,
+): readonly DocumentFieldModel[] {
+  const row = table.rows[rowIndex];
+  if (!row) return [];
+  const visible = new Set(
+    childTableColumnsForLayout(table, layout).map((column) => column.key),
+  );
+  return table.columns
+    .filter((column) => !visible.has(column.key))
+    .map((column) => ({
+      key: column.key,
+      label: column.label,
+      value: row[column.key] ?? null,
+      kind: fieldKind(column.key, row[column.key] ?? null),
+    }));
+}
+
+export function isChildTableValue(
+  value: unknown,
+): value is readonly Record<string, unknown>[] {
+  return Array.isArray(value) && value.length > 0 && value.every(isRecord);
+}

--- a/src/ui/shared/document/child-table-model_test.ts
+++ b/src/ui/shared/document/child-table-model_test.ts
@@ -1,0 +1,159 @@
+import { assertEquals } from "@std/assert";
+import {
+  childTableColumnsForLayout,
+  childTableHiddenEntries,
+  childTableModelOf,
+  humanizeDocumentKey,
+  isChildTableValue,
+} from "./child-table-model.ts";
+
+Deno.test("childTableModelOf builds stable business columns from heterogeneous rows", () => {
+  const table = childTableModelOf("items", [{
+    idx: 1,
+    parent: "SO-1",
+    parenttype: "Sales Order",
+    parentfield: "items",
+    name: "ROW-a8fb",
+    batch_no: "B-1",
+    amount: 25,
+    item_code: "ITEM-1",
+    description: "Widget",
+    qty: 2,
+  }, {
+    idx: 2,
+    parent: "SO-1",
+    amount: "15.50",
+    item_code: "ITEM-2",
+    qty: 1,
+    warehouse: "Stores",
+  }]);
+
+  assertEquals(table.columns.map((column) => column.key), [
+    "item_code",
+    "description",
+    "qty",
+    "amount",
+    "warehouse",
+    "batch_no",
+  ]);
+  assertEquals(table.columns.map((column) => column.numeric), [
+    false,
+    false,
+    true,
+    true,
+    false,
+    false,
+  ]);
+  assertEquals(table.rows[0], {
+    item_code: "ITEM-1",
+    description: "Widget",
+    qty: 2,
+    amount: 25,
+    batch_no: "B-1",
+  });
+  assertEquals("idx" in table.rows[0], false);
+  assertEquals("name" in table.rows[0], false);
+});
+
+Deno.test("child table layouts expose four wide columns and three narrow columns", () => {
+  const table = childTableModelOf("items", [{
+    item_code: "ITEM-1",
+    description: "Widget",
+    qty: 2,
+    amount: 25,
+    warehouse: "Stores",
+    batch_no: "B-1",
+  }]);
+
+  assertEquals(
+    childTableColumnsForLayout(table, "wide").map((column) => column.key),
+    ["item_code", "description", "qty", "amount"],
+  );
+  assertEquals(
+    childTableColumnsForLayout(table, "panel").map((column) => column.key),
+    ["item_code", "description", "qty"],
+  );
+  assertEquals(
+    childTableColumnsForLayout(table, "mobile").map((column) => column.key),
+    ["item_code", "description", "qty"],
+  );
+  assertEquals(
+    childTableHiddenEntries(table, 0, "mobile").map((field) => field.key),
+    ["amount", "warehouse", "batch_no"],
+  );
+  assertEquals(childTableHiddenEntries(table, 99, "wide"), []);
+});
+
+Deno.test("child table totals only exact additive fields", () => {
+  assertEquals(
+    childTableModelOf("items", [
+      { amount: 10, score: 3 },
+      { amount: "2.50", score: 4 },
+      { amount: null, score: 5 },
+    ]).total,
+    { key: "amount", label: "Amount", value: 12.5 },
+  );
+  assertEquals(
+    childTableModelOf("scores", [{ score: 3 }, { score: 4 }]).total,
+    undefined,
+  );
+});
+
+Deno.test("invalid or incomplete amount totals fall through safely", () => {
+  assertEquals(
+    childTableModelOf("items", [
+      { amount: 10, base_amount: 20 },
+      { amount: "not-a-number", base_amount: 5 },
+      { base_amount: null },
+    ]).total,
+    { key: "base_amount", label: "Base amount", value: 25 },
+  );
+  assertEquals(
+    childTableModelOf("items", [
+      { amount: 10 },
+      { amount: "not-a-number" },
+    ]).total,
+    undefined,
+  );
+});
+
+Deno.test("name remains a business column outside Frappe child-row metadata", () => {
+  const table = childTableModelOf("contacts", [{
+    name: "Ada Lovelace",
+    email: "ada@example.com",
+  }]);
+  assertEquals(table.columns.map((column) => column.key), ["name", "email"]);
+});
+
+Deno.test("nested child values are serialized before reaching components", () => {
+  const table = childTableModelOf("steps", [{
+    title: "Inspect",
+    settings: { tolerance: 0.1 },
+    tags: ["quality", "line-1"],
+  }]);
+  assertEquals(table.rows[0].settings, '{"tolerance":0.1}');
+  assertEquals(table.rows[0].tags, '["quality","line-1"]');
+  assertEquals(
+    table.columns.find((column) => column.key === "settings")?.numeric,
+    false,
+  );
+});
+
+Deno.test("child table detection is explicit for non-empty object arrays", () => {
+  assertEquals(
+    isChildTableValue([{ item_code: "A" }, { item_code: "B" }]),
+    true,
+  );
+  assertEquals(isChildTableValue([]), false);
+  assertEquals(isChildTableValue(["A", "B"]), false);
+  assertEquals(isChildTableValue([{ item_code: "A" }, "B"]), false);
+});
+
+Deno.test("humanizeDocumentKey handles snake, kebab, and camel case", () => {
+  assertEquals(
+    humanizeDocumentKey("expected_start_date"),
+    "Expected start date",
+  );
+  assertEquals(humanizeDocumentKey("item-code"), "Item code");
+  assertEquals(humanizeDocumentKey("baseGrandTotal"), "Base Grand Total");
+});

--- a/src/ui/shared/document/model.ts
+++ b/src/ui/shared/document/model.ts
@@ -1,0 +1,322 @@
+import type { NavHint } from "../jumps.ts";
+import type { UiRefreshRequestData } from "../refresh.ts";
+import {
+  childTableModelOf,
+  documentDisplayValue,
+  humanizeDocumentKey,
+  isChildTableValue,
+} from "./child-table-model.ts";
+import type {
+  DocumentCollectionModel,
+  DocumentDisplayValue,
+  DocumentEnvelope,
+  DocumentFieldKind,
+  DocumentFieldModel,
+  DocumentModel,
+} from "./types.ts";
+
+const ENVELOPE_FIELDS = new Set([
+  "_availableTools",
+  "_sendMessageHints",
+  "refreshRequest",
+]);
+
+const SYSTEM_FIELDS = new Set([
+  "name",
+  "doctype",
+  "owner",
+  "creation",
+  "modified",
+  "modified_by",
+  "docstatus",
+  "idx",
+  "_user_tags",
+  "_comments",
+  "_assign",
+  "_liked_by",
+  "__islocal",
+  "__unsaved",
+]);
+
+const TITLE_FIELDS = [
+  "title",
+  "subject",
+  "item_name",
+  "customer_name",
+  "supplier_name",
+  "project_name",
+  "employee_name",
+] as const;
+
+const LONG_FIELD_PATTERN =
+  /(^|_)(description|notes?|remarks?|terms|instructions?|content|message|details?)($|_)/i;
+const NUMERIC_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function stringArray(value: unknown): readonly string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return [
+    ...new Set(
+      value.filter((item): item is string =>
+        typeof item === "string" && item.length > 0
+      ),
+    ),
+  ];
+}
+
+function refreshRequestOf(value: unknown): UiRefreshRequestData | undefined {
+  if (!isRecord(value)) return undefined;
+  const toolName = nonEmptyString(value.toolName);
+  if (!toolName || !isRecord(value.arguments)) return undefined;
+  return { toolName, arguments: { ...value.arguments } };
+}
+
+function sendMessageHintsOf(value: unknown): readonly NavHint[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.flatMap((entry): NavHint[] => {
+    if (!isRecord(entry)) return [];
+    const label = nonEmptyString(entry.label);
+    if (!label) return [];
+    const kind = entry.kind === "list" || entry.kind === "record" ||
+        entry.kind === "chart"
+      ? entry.kind
+      : undefined;
+    return [{
+      label,
+      ...(nonEmptyString(entry.key) ? { key: nonEmptyString(entry.key)! } : {}),
+      ...(nonEmptyString(entry.message)
+        ? { message: nonEmptyString(entry.message)! }
+        : {}),
+      ...(nonEmptyString(entry.tool)
+        ? { tool: nonEmptyString(entry.tool)! }
+        : {}),
+      ...(isRecord(entry.args) ? { args: { ...entry.args } } : {}),
+      ...(kind ? { kind } : {}),
+    }];
+  });
+}
+
+function normalizedEnvelope(value: unknown): DocumentEnvelope | null {
+  if (!isRecord(value) || !isRecord(value.document)) return null;
+  const doctype = nonEmptyString(value.document.doctype) ??
+    nonEmptyString(value.doctype);
+  const name = nonEmptyString(value.document.name) ??
+    nonEmptyString(value.name);
+  if (!doctype || !name) return null;
+  return {
+    ...(value as unknown as DocumentEnvelope),
+    document: value.document,
+    doctype,
+    name,
+  };
+}
+
+/**
+ * Reads both the normal `{ data: document }` tool result and a legacy direct
+ * record. UI-only envelope fields never leak into the rendered ERP document.
+ */
+export function documentEnvelopeOf(payload: unknown): DocumentEnvelope | null {
+  if (!isRecord(payload)) return null;
+
+  const nestedCandidate = isRecord(payload.data) ? payload.data : null;
+  // `data` can itself be a business field on a direct Frappe document. Only
+  // the explicit document identity makes it an envelope payload.
+  const nestedDocument = nestedCandidate &&
+      nonEmptyString(nestedCandidate.doctype) &&
+      nonEmptyString(nestedCandidate.name)
+    ? nestedCandidate
+    : null;
+  const source = nestedDocument ?? payload;
+  const document = Object.fromEntries(
+    Object.entries(source).filter(([key]) => !ENVELOPE_FIELDS.has(key)),
+  );
+  const doctype = nonEmptyString(document.doctype) ??
+    nonEmptyString(payload.doctype);
+  const name = nonEmptyString(document.name) ?? nonEmptyString(payload.name);
+  if (!doctype || !name) return null;
+
+  const availableTools = stringArray(payload._availableTools);
+  const refreshRequest = refreshRequestOf(payload.refreshRequest);
+  const sendMessageHints = sendMessageHintsOf(payload._sendMessageHints);
+  return {
+    document,
+    doctype,
+    name,
+    ...(availableTools !== undefined ? { availableTools } : {}),
+    ...(refreshRequest ? { refreshRequest } : {}),
+    ...(sendMessageHints !== undefined ? { sendMessageHints } : {}),
+  };
+}
+
+function numericValue(value: unknown): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return NUMERIC_PATTERN.test(trimmed) ? Number(trimmed) : null;
+}
+
+function isProgressField(key: string, value: unknown): boolean {
+  return numericValue(value) !== null &&
+    (key === "progress" || key.endsWith("_progress") ||
+      key === "percent_complete" || key === "percentage_complete" ||
+      key === "completion_percentage");
+}
+
+function fieldKind(key: string, value: unknown): DocumentFieldKind {
+  if (isProgressField(key, value)) return "progress";
+  if (value === null || value === undefined || value === "") return "empty";
+  if (typeof value === "number") return "number";
+  if (typeof value === "boolean") return "boolean";
+  if (
+    key === "status" || key === "workflow_state" || key.endsWith("_status")
+  ) {
+    return "status";
+  }
+  if (isRecord(value) || Array.isArray(value)) return "json";
+  if (
+    typeof value === "string" &&
+    (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(value) ||
+      key.endsWith("_datetime") || key.endsWith("_timestamp"))
+  ) {
+    return "datetime";
+  }
+  if (
+    typeof value === "string" &&
+    (/^\d{4}-\d{2}-\d{2}$/.test(value) || key.endsWith("_date"))
+  ) {
+    return "date";
+  }
+  return "text";
+}
+
+function safePrettyJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function documentFieldOf(
+  key: string,
+  value: unknown,
+): DocumentFieldModel {
+  const kind = fieldKind(key, value);
+  let displayValue: DocumentDisplayValue = kind === "json"
+    ? safePrettyJson(value)
+    : documentDisplayValue(value);
+  if (kind === "progress") displayValue = numericValue(value);
+  return {
+    key,
+    label: humanizeDocumentKey(key),
+    value: displayValue,
+    kind,
+  };
+}
+
+function isSystemField(key: string): boolean {
+  return key.startsWith("_") || SYSTEM_FIELDS.has(key);
+}
+
+function isLongField(field: DocumentFieldModel): boolean {
+  return field.kind === "json" ||
+    (typeof field.value === "string" &&
+      (field.value.includes("\n") || field.value.length >= 120 ||
+        LONG_FIELD_PATTERN.test(field.key)));
+}
+
+function titleOf(envelope: DocumentEnvelope): string {
+  for (const key of TITLE_FIELDS) {
+    const value = envelope.document[key];
+    if (
+      (typeof value === "string" || typeof value === "number") &&
+      String(value).trim().length > 0
+    ) {
+      return String(value).trim();
+    }
+  }
+  return envelope.name;
+}
+
+function statusOf(document: Record<string, unknown>): string | undefined {
+  for (const key of ["workflow_state", "status"] as const) {
+    const value = document[key];
+    if (
+      (typeof value === "string" || typeof value === "number" ||
+        typeof value === "boolean") && String(value).trim().length > 0
+    ) {
+      return String(value).trim();
+    }
+  }
+  return undefined;
+}
+
+function collectionOf(
+  key: string,
+  values: readonly unknown[],
+): DocumentCollectionModel {
+  return {
+    key,
+    label: humanizeDocumentKey(key),
+    values: values.map(documentDisplayValue),
+  };
+}
+
+export function documentModelOf(envelope: DocumentEnvelope): DocumentModel;
+export function documentModelOf(payload: unknown): DocumentModel | null;
+export function documentModelOf(payload: unknown): DocumentModel | null {
+  const envelope = normalizedEnvelope(payload) ?? documentEnvelopeOf(payload);
+  if (!envelope) return null;
+
+  const fields: DocumentFieldModel[] = [];
+  const longFields: DocumentFieldModel[] = [];
+  const progressFields: DocumentFieldModel[] = [];
+  const collections: DocumentCollectionModel[] = [];
+  const childTables = [];
+  const systemFields: DocumentFieldModel[] = [];
+
+  for (const [key, value] of Object.entries(envelope.document)) {
+    if (isSystemField(key)) {
+      systemFields.push(documentFieldOf(key, value));
+      continue;
+    }
+    if (key === "status" || key === "workflow_state") continue;
+    if (isChildTableValue(value)) {
+      childTables.push(childTableModelOf(key, value));
+      continue;
+    }
+    if (Array.isArray(value)) {
+      collections.push(collectionOf(key, value));
+      continue;
+    }
+
+    const field = documentFieldOf(key, value);
+    if (field.kind === "progress") progressFields.push(field);
+    else if (isLongField(field)) longFields.push(field);
+    else fields.push(field);
+  }
+
+  const docstatus = numericValue(envelope.document.docstatus);
+  const status = statusOf(envelope.document);
+  return {
+    envelope,
+    title: titleOf(envelope),
+    ...(status ? { status } : {}),
+    ...(docstatus !== null ? { docstatus } : {}),
+    fields,
+    longFields,
+    progressFields,
+    collections,
+    childTables,
+    systemFields,
+  };
+}

--- a/src/ui/shared/document/model_test.ts
+++ b/src/ui/shared/document/model_test.ts
@@ -1,0 +1,215 @@
+import { assert, assertEquals } from "@std/assert";
+import {
+  documentEnvelopeOf,
+  documentFieldOf,
+  documentModelOf,
+} from "./model.ts";
+
+Deno.test("documentEnvelopeOf preserves a valid wrapper and canonical document identity", () => {
+  const payload = {
+    doctype: "Task",
+    name: "TASK-REQUESTED",
+    data: {
+      doctype: "Task",
+      name: "TASK-CANONICAL",
+      subject: "Commissioning",
+    },
+    _availableTools: ["erpnext_task_get", "erpnext_file_list"],
+    refreshRequest: {
+      toolName: "erpnext_task_get",
+      arguments: { name: "TASK-REQUESTED" },
+    },
+    _sendMessageHints: [{
+      key: "timesheets",
+      label: "Timesheets",
+      tool: "erpnext_timesheet_list",
+      args: { task: "{name}" },
+      kind: "list",
+    }],
+  };
+
+  assertEquals(documentEnvelopeOf(payload), {
+    document: payload.data,
+    doctype: "Task",
+    name: "TASK-CANONICAL",
+    availableTools: ["erpnext_task_get", "erpnext_file_list"],
+    refreshRequest: {
+      toolName: "erpnext_task_get",
+      arguments: { name: "TASK-REQUESTED" },
+    },
+    sendMessageHints: [{
+      key: "timesheets",
+      label: "Timesheets",
+      tool: "erpnext_timesheet_list",
+      args: { task: "{name}" },
+      kind: "list",
+    }],
+  });
+});
+
+Deno.test("documentEnvelopeOf accepts direct records and strips UI metadata", () => {
+  const envelope = documentEnvelopeOf({
+    doctype: "Project",
+    name: "PROJ-1",
+    project_name: "New plant",
+    _availableTools: [],
+    _sendMessageHints: [],
+    refreshRequest: {
+      toolName: "erpnext_project_get",
+      arguments: { name: "PROJ-1" },
+    },
+  });
+
+  assertEquals(envelope?.document, {
+    doctype: "Project",
+    name: "PROJ-1",
+    project_name: "New plant",
+  });
+  assertEquals(envelope?.availableTools, []);
+  assertEquals(envelope?.sendMessageHints, []);
+});
+
+Deno.test("documentEnvelopeOf keeps a direct document business data object", () => {
+  const payload = {
+    doctype: "Data Export",
+    name: "EXP-1",
+    title: "Export",
+    data: { rows: 7 },
+  };
+
+  assertEquals(documentEnvelopeOf(payload)?.document, payload);
+});
+
+Deno.test("documentEnvelopeOf rejects malformed payloads and incomplete identity", () => {
+  assertEquals(documentEnvelopeOf(null), null);
+  assertEquals(documentEnvelopeOf([]), null);
+  assertEquals(documentEnvelopeOf({ data: [] }), null);
+  assertEquals(documentEnvelopeOf({ data: { name: "TASK-1" } }), null);
+  assertEquals(documentEnvelopeOf({ data: { doctype: "Task" } }), null);
+  assertEquals(
+    documentEnvelopeOf({ data: { doctype: "Task", name: " " } }),
+    null,
+  );
+});
+
+Deno.test("documentEnvelopeOf drops malformed envelope members without losing the document", () => {
+  const envelope = documentEnvelopeOf({
+    data: { doctype: "Task", name: "TASK-1" },
+    _availableTools: ["erpnext_task_get", 42, "", "erpnext_task_get"],
+    refreshRequest: { toolName: "erpnext_task_get", arguments: null },
+    _sendMessageHints: [null, { label: "" }, { label: "Issues", kind: "bad" }],
+  });
+
+  assertEquals(envelope?.availableTools, ["erpnext_task_get"]);
+  assertEquals(envelope?.refreshRequest, undefined);
+  assertEquals(envelope?.sendMessageHints, [{ label: "Issues" }]);
+});
+
+Deno.test("documentModelOf classifies a raw Frappe document deterministically", () => {
+  const model = documentModelOf({
+    data: {
+      name: "TASK-0001",
+      doctype: "Task",
+      owner: "user@example.com",
+      creation: "2026-08-24T08:30:00",
+      docstatus: "1",
+      subject: "Commission the line",
+      workflow_state: "In progress",
+      customer: "ACME",
+      expected_start_date: "2026-08-25",
+      progress: "64",
+      description: "Short text still belongs in its named long-text section.",
+      configuration: { safe: true, threshold: 3 },
+      tags: ["urgent", 2, true, null],
+      empty_links: [],
+      mixed_values: [{ key: "one" }, "two"],
+      items: [{ item_code: "A", qty: 2, amount: 12.5 }],
+    },
+  });
+
+  assert(model);
+  assertEquals(model.title, "Commission the line");
+  assertEquals(model.status, "In progress");
+  assertEquals(model.docstatus, 1);
+  assertEquals(model.fields.map((field) => field.key), [
+    "subject",
+    "customer",
+    "expected_start_date",
+  ]);
+  assertEquals(model.fields[2].kind, "date");
+  assertEquals(model.progressFields, [{
+    key: "progress",
+    label: "Progress",
+    value: 64,
+    kind: "progress",
+  }]);
+  assertEquals(model.longFields.map((field) => field.key), [
+    "description",
+    "configuration",
+  ]);
+  assertEquals(typeof model.longFields[1].value, "string");
+  assertEquals(model.collections.map((collection) => collection.key), [
+    "tags",
+    "empty_links",
+    "mixed_values",
+  ]);
+  assertEquals(model.collections[0].values, ["urgent", 2, true, null]);
+  assertEquals(model.collections[1].values, []);
+  assertEquals(model.collections[2].values, ['{"key":"one"}', "two"]);
+  assertEquals(model.childTables.map((table) => table.key), ["items"]);
+  assertEquals(model.systemFields.map((field) => field.key), [
+    "name",
+    "doctype",
+    "owner",
+    "creation",
+    "docstatus",
+  ]);
+  assertEquals(
+    model.fields.some((field) => field.key === "workflow_state"),
+    false,
+  );
+});
+
+Deno.test("documentModelOf follows title and status priority then falls back to name", () => {
+  const titled = documentModelOf({
+    doctype: "Issue",
+    name: "ISS-1",
+    title: "Primary title",
+    subject: "Secondary subject",
+    workflow_state: "Review",
+    status: "Open",
+  });
+  assert(titled);
+  assertEquals(titled.title, "Primary title");
+  assertEquals(titled.status, "Review");
+
+  const fallback = documentModelOf({ doctype: "Warehouse", name: "Stores" });
+  assert(fallback);
+  assertEquals(fallback.title, "Stores");
+  assertEquals(fallback.status, undefined);
+  assertEquals(fallback.docstatus, undefined);
+});
+
+Deno.test("documentModelOf prefers canonical identity inside a normalized envelope", () => {
+  const model = documentModelOf({
+    document: {
+      doctype: "Task",
+      name: "TASK-CANONICAL",
+      subject: "Canonical task",
+    },
+    doctype: "Task",
+    name: "TASK-REQUESTED",
+  });
+
+  assertEquals(model.envelope.name, "TASK-CANONICAL");
+  assertEquals(model.envelope.doctype, "Task");
+});
+
+Deno.test("documentFieldOf produces display-only primitives for nested values", () => {
+  const field = documentFieldOf("unsafe_payload", {
+    markup: "<script>alert(1)</script>",
+  });
+  assertEquals(field.kind, "json");
+  assertEquals(typeof field.value, "string");
+  assert(String(field.value).includes("<script>alert(1)</script>"));
+});

--- a/src/ui/shared/document/types.ts
+++ b/src/ui/shared/document/types.ts
@@ -1,0 +1,75 @@
+import type { NavHint } from "../jumps.ts";
+import type { UiRefreshRequestData } from "../refresh.ts";
+
+export type DocumentDisplayValue = string | number | boolean | null;
+
+export type DocumentFieldKind =
+  | "text"
+  | "number"
+  | "boolean"
+  | "date"
+  | "datetime"
+  | "status"
+  | "progress"
+  | "json"
+  | "empty";
+
+export interface DocumentEnvelope {
+  document: Record<string, unknown>;
+  doctype: string;
+  name: string;
+  availableTools?: readonly string[];
+  refreshRequest?: UiRefreshRequestData;
+  sendMessageHints?: readonly NavHint[];
+}
+
+export interface DocumentFieldModel {
+  key: string;
+  label: string;
+  value: DocumentDisplayValue;
+  kind: DocumentFieldKind;
+}
+
+export interface DocumentCollectionModel {
+  key: string;
+  label: string;
+  values: readonly DocumentDisplayValue[];
+}
+
+export interface ChildTableColumn {
+  key: string;
+  label: string;
+  numeric: boolean;
+}
+
+export type ChildTableRow = Readonly<Record<string, DocumentDisplayValue>>;
+
+export interface ChildTableTotal {
+  key: string;
+  label: string;
+  value: number;
+}
+
+export interface ChildTableModel {
+  key: string;
+  label: string;
+  rows: readonly ChildTableRow[];
+  /** All business columns. Layout helpers choose the visible subset. */
+  columns: readonly ChildTableColumn[];
+  total?: ChildTableTotal;
+}
+
+export interface DocumentModel {
+  envelope: DocumentEnvelope;
+  title: string;
+  status?: string;
+  docstatus?: number;
+  fields: readonly DocumentFieldModel[];
+  longFields: readonly DocumentFieldModel[];
+  progressFields: readonly DocumentFieldModel[];
+  collections: readonly DocumentCollectionModel[];
+  childTables: readonly ChildTableModel[];
+  systemFields: readonly DocumentFieldModel[];
+}
+
+export type DocumentTableLayout = "wide" | "panel" | "mobile";

--- a/src/ui/shared/document/useAttachments.ts
+++ b/src/ui/shared/document/useAttachments.ts
@@ -1,0 +1,409 @@
+import type { App } from "@modelcontextprotocol/ext-apps";
+import { useCallback, useLayoutEffect, useRef, useState } from "preact/hooks";
+import { useT } from "../i18n-hook.ts";
+import type { DocumentChangeEvent } from "../document-events.ts";
+import { extractToolResultText } from "../refresh.ts";
+import {
+  acceptsAttachmentToken,
+  type AttachmentsState,
+  canStartAttachmentUpload,
+  createAttachmentsState,
+  invalidateAttachmentRequests,
+  reserveAttachmentRequest,
+  resetAttachmentsState,
+  settleAttachmentUploadFailure,
+} from "./attachments-state.ts";
+import type { DocumentCapabilities } from "./capabilities.ts";
+import {
+  attachmentListFromToolResult,
+  type DocumentAttachment,
+  downloadResourceFromToolResult,
+} from "./attachment-results.ts";
+import type { DocumentEnvelope } from "./types.ts";
+
+const TOOL_CALL_TIMEOUT_MS = 30_000;
+
+export interface AttachmentsController {
+  state: AttachmentsState;
+  files: readonly DocumentAttachment[];
+  readProgress: number | null;
+  refresh: () => Promise<boolean>;
+  upload: (file: File, isPrivate: boolean) => Promise<boolean>;
+  download: (file: DocumentAttachment) => Promise<boolean>;
+  dismissError: () => void;
+}
+
+export interface UseAttachmentsOptions {
+  app: App;
+  envelope: DocumentEnvelope;
+  capabilities: DocumentCapabilities;
+  fixtureFiles?: readonly DocumentAttachment[];
+  /** Called after ERPNext commits the attachment, before the mandatory relist. */
+  onDocumentChanged?: (event: DocumentChangeEvent) => void;
+}
+
+function documentKey(envelope: DocumentEnvelope): string {
+  return `${envelope.doctype}\u0000${envelope.name}`;
+}
+
+function resultError(result: unknown, fallback: string): string {
+  if (result && typeof result === "object") {
+    const text = extractToolResultText(result as Record<string, unknown>);
+    if (text && !text.trim().startsWith("{")) return text;
+  }
+  return fallback;
+}
+
+function readFile(
+  file: File,
+  onProgress: (progress: number | null) => void,
+  onReader: (reader: FileReader | null) => void,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    onReader(reader);
+    reader.onprogress = (event) => {
+      onProgress(
+        event.lengthComputable && event.total > 0
+          ? event.loaded / event.total
+          : null,
+      );
+    };
+    reader.onerror = () =>
+      reject(reader.error ?? new Error("file read failed"));
+    reader.onabort = () => reject(new Error("file read aborted"));
+    reader.onload = () => {
+      const value = typeof reader.result === "string" ? reader.result : "";
+      const comma = value.indexOf(",");
+      if (comma < 0 || !value.slice(comma + 1)) {
+        reject(new Error("file read is empty"));
+        return;
+      }
+      resolve(value.slice(comma + 1));
+    };
+    reader.onloadend = () => onReader(null);
+    reader.readAsDataURL(file);
+  });
+}
+
+export function useAttachments({
+  app,
+  envelope,
+  capabilities,
+  fixtureFiles,
+  onDocumentChanged,
+}: UseAttachmentsOptions): AttachmentsController {
+  const t = useT();
+  const { doctype, name } = envelope;
+  const key = documentKey(envelope);
+  const identityRef = useRef(key);
+  const stateRef = useRef(createAttachmentsState(key));
+  const [state, setState] = useState(stateRef.current);
+  const [files, setFiles] = useState<readonly DocumentAttachment[]>(
+    fixtureFiles ?? [],
+  );
+  const [readProgress, setReadProgress] = useState<number | null>(null);
+  const uploadInFlightRef = useRef(false);
+  const downloadInFlightRef = useRef<string | null>(null);
+  const readerRef = useRef<FileReader | null>(null);
+
+  // Invalidate old async work synchronously during render. The layout effect
+  // then swaps the visible state before the browser paints the new document.
+  if (identityRef.current !== key) {
+    identityRef.current = key;
+    stateRef.current = resetAttachmentsState(stateRef.current, key);
+    uploadInFlightRef.current = false;
+    downloadInFlightRef.current = null;
+    readerRef.current?.abort();
+    readerRef.current = null;
+  }
+
+  const commitState = useCallback(
+    (update: (current: AttachmentsState) => AttachmentsState) => {
+      const next = update(stateRef.current);
+      stateRef.current = next;
+      setState(next);
+      return next;
+    },
+    [],
+  );
+
+  const load = useCallback(async (
+    reason: "refresh" | "after-upload" = "refresh",
+  ): Promise<boolean> => {
+    if (!capabilities.canListAttachments) return false;
+    const base = resetAttachmentsState(stateRef.current, key);
+    const reserved = reserveAttachmentRequest(base);
+    const token = reserved.token;
+    commitState(() => ({
+      ...reserved.state,
+      load: "loading",
+      upload: reason === "after-upload" ? "relisting" : reserved.state.upload,
+    }));
+
+    try {
+      const result = await app.callServerTool({
+        name: "erpnext_file_list",
+        arguments: {
+          attached_to_doctype: doctype,
+          attached_to_name: name,
+          limit: 50,
+        },
+      }, { timeout: TOOL_CALL_TIMEOUT_MS });
+      if (
+        identityRef.current !== key ||
+        !acceptsAttachmentToken(stateRef.current, token)
+      ) return false;
+      const nextFiles = attachmentListFromToolResult(result);
+      setFiles(nextFiles);
+      commitState((current) => ({
+        ...current,
+        load: "ready",
+        upload: reason === "after-upload" ? "idle" : current.upload,
+        error: current.error?.operation === "list" ||
+            (reason === "after-upload" && current.error?.operation === "upload")
+          ? null
+          : current.error,
+      }));
+      return true;
+    } catch {
+      if (
+        identityRef.current !== key ||
+        !acceptsAttachmentToken(stateRef.current, token)
+      ) return false;
+      commitState((current) => ({
+        ...current,
+        load: "error",
+        upload: reason === "after-upload" ? "error" : current.upload,
+        error: {
+          operation: reason === "after-upload" ? "upload" : "list",
+          message: t(
+            reason === "after-upload"
+              ? "document.attachments.error.relist"
+              : "document.attachments.error.list",
+          ),
+        },
+      }));
+      return false;
+    }
+  }, [
+    app,
+    capabilities.canListAttachments,
+    commitState,
+    doctype,
+    key,
+    name,
+    t,
+  ]);
+
+  const upload = useCallback(async (
+    file: File,
+    isPrivate: boolean,
+  ): Promise<boolean> => {
+    if (
+      !capabilities.canUploadAttachment || uploadInFlightRef.current ||
+      !canStartAttachmentUpload(stateRef.current)
+    ) return false;
+
+    uploadInFlightRef.current = true;
+    const base = resetAttachmentsState(stateRef.current, key);
+    const reserved = reserveAttachmentRequest(base);
+    const token = reserved.token;
+    commitState(() => ({
+      ...reserved.state,
+      upload: "reading",
+      error: null,
+    }));
+    setReadProgress(0);
+
+    try {
+      const contentBase64 = await readFile(
+        file,
+        (progress) => {
+          if (
+            identityRef.current === key &&
+            acceptsAttachmentToken(stateRef.current, token)
+          ) setReadProgress(progress);
+        },
+        (reader) => {
+          readerRef.current = reader;
+        },
+      );
+      if (
+        identityRef.current !== key ||
+        !acceptsAttachmentToken(stateRef.current, token)
+      ) return false;
+
+      commitState((current) => ({ ...current, upload: "uploading" }));
+      setReadProgress(null);
+      const result = await app.callServerTool({
+        name: "erpnext_file_upload",
+        arguments: {
+          file_name: file.name,
+          content_base64: contentBase64,
+          attached_to_doctype: doctype,
+          attached_to_name: name,
+          is_private: isPrivate,
+        },
+      }, { timeout: TOOL_CALL_TIMEOUT_MS });
+      if (
+        identityRef.current !== key ||
+        !acceptsAttachmentToken(stateRef.current, token)
+      ) return false;
+      if (result.isError) {
+        throw new Error(
+          resultError(result, t("document.attachments.error.upload")),
+        );
+      }
+
+      // The mutation is committed. Invalidate every earlier list response and
+      // emit before the mandatory canonical relist.
+      commitState((current) => ({
+        ...invalidateAttachmentRequests(current),
+        upload: "relisting",
+      }));
+      onDocumentChanged?.({
+        doctype,
+        name,
+        mutation: "attachment.added",
+        committedAt: new Date().toISOString(),
+        source: "document.attachments",
+      });
+      return await load("after-upload");
+    } catch (cause) {
+      if (
+        identityRef.current !== key ||
+        !acceptsAttachmentToken(stateRef.current, token)
+      ) return false;
+      commitState((current) => ({
+        ...settleAttachmentUploadFailure(current),
+        error: {
+          operation: "upload",
+          fileName: file.name,
+          message: cause instanceof Error && cause.message
+            ? cause.message
+            : t("document.attachments.error.upload"),
+        },
+      }));
+      return false;
+    } finally {
+      if (identityRef.current === key) {
+        uploadInFlightRef.current = false;
+        setReadProgress(null);
+      }
+    }
+  }, [
+    app,
+    capabilities.canUploadAttachment,
+    commitState,
+    doctype,
+    key,
+    load,
+    name,
+    onDocumentChanged,
+    t,
+  ]);
+
+  const download = useCallback(async (
+    file: DocumentAttachment,
+  ): Promise<boolean> => {
+    if (
+      !capabilities.canDownloadAttachment ||
+      downloadInFlightRef.current !== null
+    ) return false;
+    downloadInFlightRef.current = file.id;
+    commitState((current) => ({
+      ...current,
+      downloadingFile: file.id,
+      error: null,
+    }));
+    const requestKey = key;
+    try {
+      const result = await app.callServerTool({
+        name: "erpnext_file_download",
+        arguments: {
+          file_id: file.id,
+          attached_to_doctype: doctype,
+          attached_to_name: name,
+        },
+      }, { timeout: TOOL_CALL_TIMEOUT_MS });
+      if (identityRef.current !== requestKey) return false;
+      if (result.isError) {
+        throw new Error(
+          resultError(result, t("document.attachments.error.download")),
+        );
+      }
+      const resource = downloadResourceFromToolResult(result);
+      if (identityRef.current !== requestKey) return false;
+      const hostResult = await app.downloadFile(
+        { contents: [resource] },
+        { timeout: TOOL_CALL_TIMEOUT_MS },
+      );
+      if (hostResult.isError) {
+        throw new Error(t("document.attachments.error.host_denied"));
+      }
+      return true;
+    } catch (cause) {
+      if (identityRef.current !== requestKey) return false;
+      commitState((current) => ({
+        ...current,
+        error: {
+          operation: "download",
+          fileName: file.fileName,
+          message: cause instanceof Error && cause.message
+            ? cause.message
+            : t("document.attachments.error.download"),
+        },
+      }));
+      return false;
+    } finally {
+      if (
+        identityRef.current === requestKey &&
+        downloadInFlightRef.current === file.id
+      ) {
+        downloadInFlightRef.current = null;
+        commitState((current) => ({ ...current, downloadingFile: null }));
+      }
+    }
+  }, [
+    app,
+    capabilities.canDownloadAttachment,
+    commitState,
+    doctype,
+    key,
+    name,
+    t,
+  ]);
+
+  useLayoutEffect(() => {
+    readerRef.current?.abort();
+    readerRef.current = null;
+    uploadInFlightRef.current = false;
+    downloadInFlightRef.current = null;
+    const next = resetAttachmentsState(stateRef.current, key);
+    stateRef.current = next;
+    setState(next);
+    setFiles(fixtureFiles ?? []);
+    setReadProgress(null);
+    if (!fixtureFiles && capabilities.canListAttachments) void load();
+    return () => readerRef.current?.abort();
+  }, [key, fixtureFiles, capabilities.canListAttachments, load]);
+
+  const dismissError = useCallback(() => {
+    commitState((current) => ({
+      ...current,
+      error: null,
+      upload: current.upload === "error" ? "idle" : current.upload,
+    }));
+  }, [commitState]);
+
+  return {
+    state,
+    files: state.documentKey === key ? files : [],
+    readProgress,
+    refresh: load,
+    upload,
+    download,
+    dismissError,
+  };
+}

--- a/src/ui/shared/i18n/en.ts
+++ b/src/ui/shared/i18n/en.ts
@@ -36,6 +36,50 @@ export const en: Record<string, string> = {
   "common.progress.label": "Progress",
   "common.assignees.label": "Assignees",
 
+  // ── Generic document surface ─────────────────────────────────────────────
+  "document.header": "Document header",
+  "document.docstatus": "docstatus {value}",
+  "document.sections": "Document sections",
+  "document.fields": "Fields",
+  "document.attachments": "Attachments",
+  "document.surface": "Document {name}",
+  "document.sidebar": "Document actions and attachments",
+  "document.empty_value": "—",
+  "document.boolean.true": "Yes",
+  "document.boolean.false": "No",
+  "document.progress_value": "{value}%",
+  "document.system_fields": "System fields",
+  "document.table.no_columns": "No displayable columns",
+  "document.json": "Raw document JSON",
+  "document.action.refresh_pending":
+    "Change committed — refresh is still pending",
+  "document.attachments.add": "Add file",
+  "document.attachments.refresh": "Refresh attachments",
+  "document.attachments.loading": "Loading attachments…",
+  "document.attachments.empty": "No attachments yet",
+  "document.attachments.unavailable":
+    "Attachments are not available in this host",
+  "document.attachments.private": "Private",
+  "document.attachments.public": "Public",
+  "document.attachments.privacy": "Attachment privacy",
+  "document.attachments.private_hint":
+    "Only authenticated ERPNext users with access can retrieve this file",
+  "document.attachments.public_hint":
+    "ERPNext will expose this file from its public files area",
+  "document.attachments.download": "Download {name}",
+  "document.attachments.reading": "Reading file…",
+  "document.attachments.reading_progress": "Reading {value}%",
+  "document.attachments.uploading": "Uploading…",
+  "document.attachments.relisting": "Verifying…",
+  "document.attachments.dismiss_error": "Dismiss attachment error",
+  "document.attachments.error.list": "Could not load attachments",
+  "document.attachments.error.upload": "Could not upload this file",
+  "document.attachments.error.relist":
+    "File added, but the attachment list could not be verified",
+  "document.attachments.error.download": "Could not download this file",
+  "document.attachments.error.host_denied":
+    "The host cancelled or refused the download",
+
   // ── Mise en page / marqueurs ─────────────────────────────────────────────
   "layout.live": "live",
 

--- a/src/ui/shared/i18n/fr.ts
+++ b/src/ui/shared/i18n/fr.ts
@@ -33,6 +33,50 @@ export const fr: Record<string, string> = {
   "common.progress.label": "Progression",
   "common.assignees.label": "Responsables",
 
+  // ── Fiche documentaire générique ─────────────────────────────────────────
+  "document.header": "En-tête du document",
+  "document.docstatus": "docstatus {value}",
+  "document.sections": "Sections du document",
+  "document.fields": "Champs",
+  "document.attachments": "Pièces jointes",
+  "document.surface": "Document {name}",
+  "document.sidebar": "Actions et pièces jointes du document",
+  "document.empty_value": "—",
+  "document.boolean.true": "Oui",
+  "document.boolean.false": "Non",
+  "document.progress_value": "{value} %",
+  "document.system_fields": "Champs système",
+  "document.table.no_columns": "Aucune colonne affichable",
+  "document.json": "JSON brut du document",
+  "document.action.refresh_pending":
+    "Modification enregistrée — le rafraîchissement reste en attente",
+  "document.attachments.add": "Ajouter un fichier",
+  "document.attachments.refresh": "Rafraîchir les pièces jointes",
+  "document.attachments.loading": "Chargement des pièces jointes…",
+  "document.attachments.empty": "Aucune pièce jointe",
+  "document.attachments.unavailable":
+    "Les pièces jointes ne sont pas disponibles dans cet hôte",
+  "document.attachments.private": "Privé",
+  "document.attachments.public": "Public",
+  "document.attachments.privacy": "Confidentialité de la pièce jointe",
+  "document.attachments.private_hint":
+    "Seuls les utilisateurs ERPNext authentifiés et autorisés pourront récupérer ce fichier",
+  "document.attachments.public_hint":
+    "ERPNext exposera ce fichier depuis son espace de fichiers publics",
+  "document.attachments.download": "Télécharger {name}",
+  "document.attachments.reading": "Lecture du fichier…",
+  "document.attachments.reading_progress": "Lecture {value} %",
+  "document.attachments.uploading": "Envoi…",
+  "document.attachments.relisting": "Vérification…",
+  "document.attachments.dismiss_error": "Fermer l'erreur de pièce jointe",
+  "document.attachments.error.list": "Impossible de charger les pièces jointes",
+  "document.attachments.error.upload": "Impossible d'envoyer ce fichier",
+  "document.attachments.error.relist":
+    "Fichier ajouté, mais la liste des pièces jointes n'a pas pu être vérifiée",
+  "document.attachments.error.download": "Impossible de télécharger ce fichier",
+  "document.attachments.error.host_denied":
+    "L'hôte a annulé ou refusé le téléchargement",
+
   // ── Mise en page / marqueurs ─────────────────────────────────────────────
   "layout.live": "live",
 

--- a/src/ui/shared/levels/LevelBody.tsx
+++ b/src/ui/shared/levels/LevelBody.tsx
@@ -6,18 +6,25 @@
 
 import type { App } from "@modelcontextprotocol/ext-apps";
 import type { ComponentChildren } from "preact";
+import { AttachmentsSection } from "../document/AttachmentsSection.tsx";
+import { documentCapabilities } from "../document/capabilities.ts";
+import { documentModelOf } from "../document/model.ts";
+import { DocumentSurface } from "../document/DocumentSurface.tsx";
+import type { DocumentEnvelope } from "../document/types.ts";
+import { useAttachments } from "../document/useAttachments.ts";
+import type { DocumentChangeEvent } from "../document-events.ts";
 import { DoclistBody } from "../doclist/DoclistBody";
 import { LoadingSkeleton } from "../doclist/LoadingSkeleton";
 import type { DoclistData } from "../doclist/types";
 import type { DoclistState } from "../doclist/useDoclist";
-import { type Jump, jumpFromHint } from "../jumps";
+import { fillTemplate, hintLabel, type Jump, jumpFromHint } from "../jumps";
 import type { NavLevel } from "../nav-stack";
 import { useT } from "../i18n-hook";
-import { StateMessage } from "../ui";
+import { Label, StateMessage } from "../ui";
 import type { ViewerLayout } from "../useViewerLayout";
 import { BarsLevel } from "./BarsLevel";
 import { chartHintAt, chartOf, listOf, recordOf } from "./bodies";
-import { RecordLevel } from "./RecordLevel";
+import { JumpList } from "./JumpList";
 
 export const EMPTY_LIST: DoclistData = { count: 0, data: [] };
 
@@ -39,6 +46,7 @@ export function LevelBody(
     onError,
     onRefresh,
     onMutated,
+    onDocumentChanged,
     onMutationInvalidate,
     onMutationRefresh,
     children,
@@ -56,6 +64,8 @@ export function LevelBody(
     onRefresh?: () => void;
     /** Une action d'un niveau vient de changer `subject`. */
     onMutated?: (subject: string) => void;
+    /** Changement canonique structuré, indépendant de son transport futur. */
+    onDocumentChanged?: (event: DocumentChangeEvent) => void;
     /** Invalider puis relire la racine autour d'une mutation de liste. */
     onMutationInvalidate?: () => void;
     onMutationRefresh?: () => void;
@@ -73,24 +83,21 @@ export function LevelBody(
     <StateMessage tone="bad">{t("nav.unexpected_body")}</StateMessage>
   );
   if (level.kind === "record") {
-    const record = recordOf(level.body);
-    if (!record) return unexpected;
-    const name = typeof record.name === "string" ? record.name : undefined;
-    const doctype = typeof record.doctype === "string" ? record.doctype : "";
-    const asks = onAsk && name
-      ? [{
-        label: t("nav.ask"),
-        message: t("doclist.detail.full_detail_message", { doctype, id: name }),
-      }]
-      : undefined;
+    const envelope = recordOf(level.body);
+    if (!envelope) return unexpected;
     return (
-      <RecordLevel
-        record={record}
-        jumps={level.jumps}
-        asks={asks}
+      <RecordDocumentLevel
+        key={`${envelope.doctype}\u0000${envelope.name}`}
+        app={app}
+        envelope={envelope}
+        levelJumps={level.jumps}
+        layout={layout}
         onJump={onJump}
         onAsk={onAsk}
-        narrow={narrow}
+        onMutated={onMutated}
+        onDocumentChanged={onDocumentChanged}
+        onMutationInvalidate={onMutationInvalidate}
+        onMutationRefresh={onMutationRefresh}
       />
     );
   }
@@ -152,8 +159,126 @@ export function LevelBody(
       stale={level.stale}
       onRefresh={onRefresh}
       onMutated={onMutated}
+      onDocumentChanged={onDocumentChanged}
       onMutationInvalidate={onMutationInvalidate}
       onMutationRefresh={onMutationRefresh}
+    />
+  );
+}
+
+function RecordDocumentLevel({
+  app,
+  envelope,
+  levelJumps,
+  layout,
+  onJump,
+  onAsk,
+  onMutated,
+  onDocumentChanged,
+  onMutationInvalidate,
+  onMutationRefresh,
+}: {
+  app: App;
+  envelope: DocumentEnvelope;
+  levelJumps?: Jump[];
+  layout: ViewerLayout;
+  onJump?: (jump: Jump) => void;
+  onAsk?: (message: string) => void;
+  onMutated?: (subject: string) => void;
+  onDocumentChanged?: (event: DocumentChangeEvent) => void;
+  onMutationInvalidate?: () => void;
+  onMutationRefresh?: () => void;
+}) {
+  const t = useT();
+  const model = documentModelOf(envelope);
+  const capabilities = documentCapabilities(
+    app.getHostCapabilities(),
+    envelope.availableTools,
+    envelope.refreshRequest,
+  );
+  const changed = (event: DocumentChangeEvent) => {
+    onMutated?.(event.name);
+    onDocumentChanged?.(event);
+    onMutationInvalidate?.();
+    onMutationRefresh?.();
+  };
+  const attachments = useAttachments({
+    app,
+    envelope,
+    capabilities,
+    onDocumentChanged: changed,
+  });
+
+  const vars = {
+    id: envelope.name,
+    name: envelope.name,
+    doctype: envelope.doctype,
+  };
+  const hints = envelope.sendMessageHints ?? [];
+  const exactTools = envelope.availableTools;
+  const hintJumps = onJump
+    ? hints
+      .filter((hint) =>
+        hint.tool && app.getHostCapabilities()?.serverTools && exactTools &&
+        exactTools.includes(hint.tool)
+      )
+      .map((hint) =>
+        jumpFromHint(
+          hint,
+          vars,
+          t("nav.linked_to", { id: envelope.name }),
+        )
+      )
+      .filter((jump): jump is Jump => jump !== null)
+    : [];
+  const jumps = [...(levelJumps ?? []), ...hintJumps];
+  const asks = onAsk
+    ? hints.flatMap((hint) => {
+      if (!hint.message || (onJump && hint.tool)) return [];
+      return [{
+        label: hintLabel(hint),
+        message: fillTemplate(hint.message, vars),
+      }];
+    })
+    : [];
+  if (onAsk && asks.length === 0 && jumps.length === 0) {
+    asks.push({
+      label: t("nav.ask"),
+      message: t("doclist.detail.full_detail_message", {
+        doctype: envelope.doctype,
+        id: envelope.name,
+      }),
+    });
+  }
+  const actions = jumps.length > 0 || asks.length > 0
+    ? (
+      <div class="flex flex-col gap-2">
+        {jumps.length > 0 && <Label>{t("nav.goto")}</Label>}
+        <JumpList
+          narrow={layout !== "wide"}
+          jumps={jumps}
+          asks={asks}
+          onJump={onJump}
+          onAsk={onAsk}
+        />
+      </div>
+    )
+    : undefined;
+
+  return (
+    <DocumentSurface
+      model={model}
+      layout={layout}
+      attachments={capabilities.canListAttachments
+        ? (
+          <AttachmentsSection
+            controller={attachments}
+            capabilities={capabilities}
+            layout={layout}
+          />
+        )
+        : undefined}
+      actions={actions}
     />
   );
 }

--- a/src/ui/shared/levels/bodies.ts
+++ b/src/ui/shared/levels/bodies.ts
@@ -7,6 +7,13 @@
  * qui ne correspond pas donne `null`, jamais une exception.
  */
 
+import {
+  type DocumentChangeEvent,
+  type DocumentMutationKind,
+  isDocumentChangeEvent,
+} from "../document-events.ts";
+import { documentEnvelopeOf } from "../document/model.ts";
+import type { DocumentEnvelope } from "../document/types.ts";
 import type { NavHint } from "../jumps.ts";
 
 export type BarsChartType =
@@ -117,12 +124,72 @@ export function chartSeriesFormat(
   return chart.unit ? { unit: chart.unit } : {};
 }
 
-/** `{ data: {...} }` ou l'objet lui-même — jamais un tableau. */
-export function recordOf(body: unknown): Record<string, unknown> | null {
-  if (!body || typeof body !== "object") return null;
-  const inner = (body as { data?: unknown }).data;
-  const record = inner && typeof inner === "object" ? inner : body;
-  return Array.isArray(record) ? null : record as Record<string, unknown>;
+export interface RecordIdentityFallback {
+  doctype?: string;
+  name?: string;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function plainRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+/**
+ * Une fiche garde son enveloppe serveur complète. Le fallback ne complète que
+ * l'identité d'un ancien détail local ; il n'invente jamais de capacités.
+ */
+export function recordOf(
+  body: unknown,
+  fallback: RecordIdentityFallback = {},
+): DocumentEnvelope | null {
+  const exact = documentEnvelopeOf(body);
+  if (exact) return exact;
+
+  const payload = plainRecord(body);
+  if (!payload) return null;
+  const document = plainRecord(payload.data) ?? payload;
+  const doctype = nonEmptyString(document.doctype) ??
+    nonEmptyString(fallback.doctype);
+  const name = nonEmptyString(document.name) ?? nonEmptyString(fallback.name);
+  if (!doctype || !name) return null;
+
+  return documentEnvelopeOf({
+    ...payload,
+    data: { ...document, doctype, name },
+  });
+}
+
+const DOCUMENT_MUTATION_BY_TOOL: Readonly<
+  Record<string, DocumentMutationKind>
+> = {
+  erpnext_doc_submit: "submit",
+  erpnext_doc_cancel: "cancel",
+};
+
+/** Événement canonique des seules mutations de fiche gérées ici. */
+export function documentChangeForTool(
+  envelope: Pick<DocumentEnvelope, "doctype" | "name">,
+  toolName: string,
+  committedAt: string,
+  source?: string,
+): DocumentChangeEvent | null {
+  const mutation = DOCUMENT_MUTATION_BY_TOOL[toolName];
+  if (!mutation) return null;
+  const event: DocumentChangeEvent = {
+    doctype: envelope.doctype,
+    name: envelope.name,
+    mutation,
+    committedAt,
+    ...(source ? { source } : {}),
+  };
+  return isDocumentChangeEvent(event) ? event : null;
 }
 
 /**

--- a/src/ui/shared/levels/bodies_test.ts
+++ b/src/ui/shared/levels/bodies_test.ts
@@ -4,16 +4,100 @@ import {
   chartOf,
   chartSeriesFormat,
   chartSeriesType,
+  documentChangeForTool,
   listOf,
   recordOf,
 } from "./bodies.ts";
 
-Deno.test("recordOf - { data: {...} }, l'objet lui-même, jamais un tableau", () => {
-  assertEquals(recordOf({ data: { name: "X" } }), { name: "X" });
-  assertEquals(recordOf({ name: "X" }), { name: "X" });
+Deno.test("recordOf - conserve l'enveloppe et les capacités exactes de la fiche", () => {
+  const payload = {
+    data: {
+      doctype: "Sales Invoice",
+      name: "SINV-1",
+      items: [{ item_code: "A", qty: 2 }],
+    },
+    _availableTools: ["erpnext_doc_submit", "erpnext_file_list"],
+    _sendMessageHints: [{
+      label: "Payments",
+      tool: "erpnext_doc_list",
+      args: { doctype: "Payment Entry" },
+      kind: "list" as const,
+    }],
+    refreshRequest: {
+      toolName: "erpnext_sales_invoice_get",
+      arguments: { name: "SINV-1" },
+    },
+  };
+
+  assertEquals(recordOf(payload), {
+    document: payload.data,
+    doctype: "Sales Invoice",
+    name: "SINV-1",
+    availableTools: ["erpnext_doc_submit", "erpnext_file_list"],
+    sendMessageHints: payload._sendMessageHints,
+    refreshRequest: payload.refreshRequest,
+  });
+});
+
+Deno.test("recordOf - complète seulement l'identité d'un ancien détail local", () => {
+  assertEquals(
+    recordOf({ subject: "Legacy" }, {
+      doctype: "Task",
+      name: "TASK-1",
+    }),
+    {
+      document: {
+        subject: "Legacy",
+        doctype: "Task",
+        name: "TASK-1",
+      },
+      doctype: "Task",
+      name: "TASK-1",
+    },
+  );
+  assertEquals(recordOf({ name: "X" }), null);
   assertEquals(recordOf({ data: [1] }), null);
   assertEquals(recordOf(null), null);
   assertEquals(recordOf("x"), null);
+});
+
+Deno.test("documentChangeForTool - submit/cancel seulement, avec identité enfant", () => {
+  const envelope = { doctype: "Sales Invoice", name: "SINV-1" };
+  assertEquals(
+    documentChangeForTool(
+      envelope,
+      "erpnext_doc_submit",
+      "2026-08-24T06:02:03.456Z",
+      "doclist.inline-detail",
+    ),
+    {
+      doctype: "Sales Invoice",
+      name: "SINV-1",
+      mutation: "submit",
+      committedAt: "2026-08-24T06:02:03.456Z",
+      source: "doclist.inline-detail",
+    },
+  );
+  assertEquals(
+    documentChangeForTool(
+      envelope,
+      "erpnext_doc_cancel",
+      "2026-08-24T06:02:04.000Z",
+    )?.mutation,
+    "cancel",
+  );
+  assertEquals(
+    documentChangeForTool(
+      envelope,
+      "erpnext_doc_update",
+      "2026-08-24T06:02:05.000Z",
+    ),
+    null,
+  );
+  assertEquals(
+    documentChangeForTool(envelope, "erpnext_doc_submit", "not-a-date"),
+    null,
+  );
 });
 
 Deno.test("chartOf - labels + values devient une série simple", () => {

--- a/src/ui/shared/nav-stack.ts
+++ b/src/ui/shared/nav-stack.ts
@@ -14,6 +14,7 @@
  */
 
 import type { Jump } from "./jumps.ts";
+import type { DocumentChangeEvent } from "./document-events.ts";
 
 export type LevelKind = "root" | "list" | "record" | "chart";
 
@@ -46,6 +47,15 @@ export interface LevelUi {
   searchOpen?: boolean;
 }
 
+export interface StaleSnapshot {
+  /** Libellé court déjà consommé par l'interface, par exemple « 14:02 ». */
+  at: string;
+  /** Compatibilité avec l'UX existante qui met le document touché en évidence. */
+  subject?: string;
+  /** Référence canonique structurée, conservée pour l'UX et le diagnostic. */
+  documentChange?: DocumentChangeEvent;
+}
+
 export interface NavLevel {
   id: string;
   /** Le segment du fil : « Factures », « SO-1043 ». */
@@ -69,7 +79,7 @@ export interface NavLevel {
   /** Racine seulement : la nature du niveau 1, pour colorer l'origine du fil. */
   origin?: Exclude<LevelKind, "root">;
   /** Une action plus bas a changé ce que ce niveau montre ; à l'utilisateur d'actualiser. */
-  stale?: { at: string; subject?: string };
+  stale?: StaleSnapshot;
 }
 
 export interface NavStack {
@@ -238,6 +248,27 @@ export function markStale(
   return {
     ...stack,
     levels: stack.levels.map((level) => ({ ...level, stale: { at, subject } })),
+  };
+}
+
+/**
+ * Un document canonique vient de changer. Tant que les dépendances métier des
+ * niveaux ne sont pas déclarées, chaque snapshot ouvert est potentiellement
+ * concerné : on les marque donc tous sans toucher à leur corps ni à leur UI.
+ */
+export function reportDocumentChange(
+  stack: NavStack,
+  at: string,
+  event: DocumentChangeEvent,
+): NavStack {
+  // La copie garde la pile indépendante d'un objet possédé par l'émetteur.
+  const documentChange: DocumentChangeEvent = { ...event };
+  return {
+    ...stack,
+    levels: stack.levels.map((level) => ({
+      ...level,
+      stale: { at, subject: event.name, documentChange },
+    })),
   };
 }
 

--- a/src/ui/shared/nav-stack_test.ts
+++ b/src/ui/shared/nav-stack_test.ts
@@ -1,4 +1,5 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertNotStrictEquals } from "@std/assert";
+import type { DocumentChangeEvent } from "./document-events.ts";
 import {
   clearStale,
   createStack,
@@ -14,6 +15,7 @@ import {
   popToLevel,
   pushLevel,
   reconcileRoot,
+  reportDocumentChange,
   viewerRootKey,
 } from "./nav-stack.ts";
 
@@ -251,6 +253,93 @@ Deno.test("markStale / clearStale - tous les niveaux marqués, un seul effacé",
   assertEquals(cleared.levels[1].stale, undefined);
   assertEquals(cleared.levels[0].stale?.at, "14:02");
   assertEquals(clearStale(cleared, cleared.levels[1].id), cleared);
+});
+
+Deno.test("reportDocumentChange - invalide tous les snapshots sans perdre navigation ni UI", () => {
+  const rootBody = { rows: [{ name: "SINV-00046", total: 42 }] };
+  const parentBody = { document: { name: "SINV-00046", docstatus: 0 } };
+  const childBody = { attachments: [{ name: "invoice.pdf" }] };
+  let stack = createStack({
+    title: "Factures",
+    kind: "root",
+    origin: "list",
+    key: "invoice-list",
+    body: rootBody,
+    ui: { sortKey: "total", sortDir: "desc", page: 2 },
+  });
+  stack = pushLevel(stack, {
+    title: "SINV-00046",
+    kind: "record",
+    key: "invoice:SINV-00046",
+    body: parentBody,
+    ui: { expandedId: "items", searchOpen: true },
+  });
+  stack = pushLevel(stack, {
+    title: "Pièces jointes",
+    kind: "list",
+    key: "attachments:SINV-00046",
+    body: childBody,
+    ui: { page: 3, filter: "invoice" },
+  });
+  const before = stack;
+  const event = Object.freeze<DocumentChangeEvent>({
+    doctype: "Sales Invoice",
+    name: "SINV-00046",
+    mutation: "submit",
+    committedAt: "2026-08-24T06:02:03.456Z",
+    source: "document-viewer",
+  });
+
+  const changed = reportDocumentChange(stack, "14:02", event);
+
+  assertEquals(changed.levels.map((level) => level.stale), [
+    { at: "14:02", subject: "SINV-00046", documentChange: event },
+    { at: "14:02", subject: "SINV-00046", documentChange: event },
+    { at: "14:02", subject: "SINV-00046", documentChange: event },
+  ]);
+  assertEquals(changed.levels.map((level) => level.body), [
+    rootBody,
+    parentBody,
+    childBody,
+  ]);
+  assertEquals(changed.levels.map((level) => level.ui), [
+    { sortKey: "total", sortDir: "desc", page: 2 },
+    { expandedId: "items", searchOpen: true },
+    { page: 3, filter: "invoice" },
+  ]);
+  assertEquals(changed.rootIdentity, before.rootIdentity);
+  assertEquals(changed.nextId, before.nextId);
+  assertEquals(event, {
+    doctype: "Sales Invoice",
+    name: "SINV-00046",
+    mutation: "submit",
+    committedAt: "2026-08-24T06:02:03.456Z",
+    source: "document-viewer",
+  });
+  assertNotStrictEquals(changed.levels[0].stale?.documentChange, event);
+
+  const parentId = changed.levels[1].id;
+  const cleared = clearStale(changed, parentId);
+  assertEquals(cleared.levels[0].stale?.documentChange, event);
+  assertEquals(cleared.levels[1].stale, undefined);
+  assertEquals(cleared.levels[2].stale?.documentChange, event);
+  assertEquals(cleared.levels[1].body, parentBody);
+  assertEquals(cleared.levels[1].ui, {
+    expandedId: "items",
+    searchOpen: true,
+  });
+
+  const reset = reconcileRoot(cleared, {
+    title: "Commandes",
+    kind: "root",
+    origin: "list",
+    key: "order-list",
+    body: { rows: [] },
+  });
+  assertEquals(reset.levels.length, 1);
+  assertEquals(reset.levels[0].title, "Commandes");
+  assertEquals(reset.levels[0].stale, undefined);
+  assertEquals(reset.nextId, 1);
 });
 
 Deno.test("pushLevel - un niveau repoussé après un retour n'hérite pas de l'id de l'ancien", () => {

--- a/src/ui/shared/useNavStack.ts
+++ b/src/ui/shared/useNavStack.ts
@@ -7,8 +7,9 @@
  */
 
 import { useCallback, useLayoutEffect, useMemo, useState } from "preact/hooks";
-import type { Jump, ToolHost } from "./jumps";
-import { jumpInto, refreshCurrent, type StackStore } from "./nav-jump";
+import type { DocumentChangeEvent } from "./document-events.ts";
+import type { Jump, ToolHost } from "./jumps.ts";
+import { jumpInto, refreshCurrent, type StackStore } from "./nav-jump.ts";
 import {
   clearStale,
   createStack,
@@ -22,7 +23,8 @@ import {
   popLevel,
   popToLevel,
   reconcileRoot,
-} from "./nav-stack";
+  reportDocumentChange as reportDocumentChangeLevels,
+} from "./nav-stack.ts";
 
 export function useNavStack(host: ToolHost, root: LevelInit) {
   const [stack, setStack] = useState<NavStack>(() => createStack(root));
@@ -61,6 +63,17 @@ export function useNavStack(host: ToolHost, root: LevelInit) {
   }, []);
 
   /**
+   * Conserve la mutation canonique dans chaque snapshot potentiellement périmé.
+   * Le transport éventuel de l'événement reste extérieur à cette pile.
+   */
+  const reportDocumentChange = useCallback((event: DocumentChangeEvent) => {
+    const committedAt = new Date(event.committedAt);
+    setStack((s) =>
+      reportDocumentChangeLevels(s, timeLabel(committedAt), event)
+    );
+  }, []);
+
+  /**
    * Recharge le niveau courant s'il sait comment (un outil) ; la racine
    * relève de la vue, qui garde son propre rafraîchissement.
    */
@@ -83,6 +96,7 @@ export function useNavStack(host: ToolHost, root: LevelInit) {
     popTo,
     patchUi,
     markStale,
+    reportDocumentChange,
     refreshLevel,
     clearStale: clearStaleLevel,
   };

--- a/src/ui/stock-viewer/src/StockViewer.tsx
+++ b/src/ui/stock-viewer/src/StockViewer.tsx
@@ -8,7 +8,13 @@
  * une ligne empile la fiche article dans la vue. Sans outils, le comportement
  * actuel (expansion inline) reste strictement identique.
  */
-import { useEffect, useMemo, useRef, useState } from "preact/hooks";
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "preact/hooks";
 import { App } from "@modelcontextprotocol/ext-apps";
 import { bindHostContext } from "~/shared/host-context-hook";
 import {
@@ -108,10 +114,13 @@ export function StockViewer() {
   );
   const [loading, setLoading] = useState(!fixture);
   const [refreshing, setRefreshing] = useState(false);
+  const [rootFreshEvent, setRootFreshEvent] = useState(0);
+  const [rootMutationEvent, setRootMutationEvent] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const dataRef = useRef<StockData | null>(fixture ? STOCK_FIXTURE : null);
   const refreshRequestRef = useRef<UiRefreshRequestData | null>(null);
   const refreshSequenceRef = useRef(createUiRefreshSequence());
+  const rootEventRef = useRef(0);
   const lastRefreshStartedAtRef = useRef(0);
 
   function hydrateData(nextData: StockData) {
@@ -121,6 +130,7 @@ export function StockViewer() {
       refreshRequestRef.current,
     );
     setData(nextData);
+    setRootFreshEvent(++rootEventRef.current);
   }
 
   function consumeToolResult(result: ToolResultPayload): boolean {
@@ -281,13 +291,38 @@ export function StockViewer() {
     );
   }
 
+  const rootRefreshRequest = resolveUiRefreshRequest(
+    data,
+    refreshRequestRef.current,
+  );
+  const canRefreshRoot = Boolean(
+    !fixture &&
+      rootRefreshRequest &&
+      app.getHostCapabilities()?.serverTools &&
+      data._availableTools?.includes(rootRefreshRequest.toolName),
+  );
+
   return (
     <StockContent
       data={data}
       error={error}
       refreshing={refreshing}
       fixture={fixture}
-      onRefresh={() => void requestRefresh({ ignoreInterval: true })}
+      rootRefreshRequest={rootRefreshRequest}
+      rootFreshEvent={rootFreshEvent}
+      rootMutationEvent={rootMutationEvent}
+      canRefreshRoot={canRefreshRoot}
+      onRefresh={() =>
+        void requestRefresh({ ignoreInterval: true, force: true })}
+      onMutationInvalidate={() => {
+        setRootMutationEvent(++rootEventRef.current);
+        refreshSequenceRef.current = invalidateUiRefresh(
+          refreshSequenceRef.current,
+        );
+      }}
+      onMutationRefresh={canRefreshRoot
+        ? () => void requestRefresh({ ignoreInterval: true, force: true })
+        : undefined}
       onError={setError}
     />
   );
@@ -299,16 +334,28 @@ function StockContent(
   {
     data,
     error,
-    refreshing: _refreshing,
+    refreshing,
     fixture,
-    onRefresh: _onRefresh,
+    rootRefreshRequest,
+    rootFreshEvent,
+    rootMutationEvent,
+    canRefreshRoot,
+    onRefresh,
+    onMutationInvalidate,
+    onMutationRefresh,
     onError,
   }: {
     data: StockData;
     error: string | null;
     refreshing: boolean;
     fixture: boolean;
+    rootRefreshRequest: UiRefreshRequestData | null;
+    rootFreshEvent: number;
+    rootMutationEvent: number;
+    canRefreshRoot: boolean;
     onRefresh: () => void;
+    onMutationInvalidate: () => void;
+    onMutationRefresh?: () => void;
     onError: (msg: string | null) => void;
   },
 ) {
@@ -326,10 +373,18 @@ function StockContent(
     title: t("stock.title"),
     kind: "root",
     origin: "list",
-    key: viewerRootKey("stock", data.refreshRequest, { doctype: "Bin" }),
+    key: viewerRootKey("stock", rootRefreshRequest ?? undefined, {
+      doctype: "Bin",
+    }),
   }, { fixture });
   const nav = viewerNav.nav;
   const { isRoot, current } = nav;
+  useLayoutEffect(() => {
+    const root = nav.stack.levels[0];
+    if (rootFreshEvent > rootMutationEvent && root?.stale) {
+      nav.clearStale(root.id);
+    }
+  }, [rootFreshEvent, rootMutationEvent]);
   const { jumpsEnabled, messagesEnabled } = viewerNav;
   // list est nécessaire pour que LevelBody rende les niveaux liste.
   const { list } = viewerNav;
@@ -485,6 +540,35 @@ function StockContent(
         </div>
         {isRoot && (
           <div class="flex min-w-0 shrink-0 items-center gap-2">
+            {current.stale && (
+              <div
+                role="status"
+                title={t("nav.stale_title")}
+                class="flex items-center gap-1.5 font-mono text-[9.5px] text-warn"
+              >
+                <span
+                  aria-hidden="true"
+                  class="size-[5px] rounded-full bg-warn"
+                />
+                {!isMobile && (
+                  <span>
+                    {t("nav.stale_values", { at: current.stale.at })}
+                  </span>
+                )}
+                {canRefreshRoot && (
+                  <button
+                    type="button"
+                    disabled={refreshing}
+                    onClick={onRefresh}
+                    aria-label={t("nav.refresh")}
+                    title={t("nav.refresh")}
+                    class="rounded-[3px] px-1 text-[12px] leading-none text-warn hover:bg-warn/10 disabled:opacity-50"
+                  >
+                    {refreshing ? "…" : "↻"}
+                  </button>
+                )}
+              </div>
+            )}
             {warehouse && (
               <span
                 class={cx(
@@ -534,6 +618,9 @@ function StockContent(
         onAsk={ask}
         onError={onError}
         onMutated={nav.markStale}
+        onDocumentChanged={nav.reportDocumentChange}
+        onMutationInvalidate={onMutationInvalidate}
+        onMutationRefresh={onMutationRefresh}
         onRefresh={() => void nav.refreshLevel()}
       >
         {/* ── Erreur de rafraîchissement — uniquement au niveau racine ── */}

--- a/src/ui/stock-viewer/src/types.ts
+++ b/src/ui/stock-viewer/src/types.ts
@@ -1,5 +1,5 @@
-import type { UiRefreshRequestData } from "~/shared/refresh";
-import type { NavHint } from "~/shared/jumps";
+import type { UiRefreshRequestData } from "../../shared/refresh.ts";
+import type { NavHint } from "../../shared/jumps.ts";
 
 export interface StockEntry {
   item_code: string;

--- a/src/ui/viewers.ts
+++ b/src/ui/viewers.ts
@@ -2,6 +2,7 @@ export const UI_VIEWERS = [
   "invoice-viewer",
   "stock-viewer",
   "doclist-viewer",
+  "doc-viewer",
   "chart-viewer",
   "kpi-viewer",
   "funnel-viewer",

--- a/src/ui/viewers_test.ts
+++ b/src/ui/viewers_test.ts
@@ -3,9 +3,10 @@ import { UI_VIEWERS } from "./viewers.ts";
 
 Deno.test("UI_VIEWERS includes the canonical kanban viewer", () => {
   assert(UI_VIEWERS.includes("kanban-viewer"));
+  assert(UI_VIEWERS.includes("doc-viewer"));
   assertEquals(
     (UI_VIEWERS as readonly string[]).includes("order-pipeline-viewer"),
     false,
   );
-  assertEquals(UI_VIEWERS.length, 7);
+  assertEquals(UI_VIEWERS.length, 8);
 });


### PR DESCRIPTION
## Summary

- add the generic document viewer and child-table detail surface
- add attachment list, upload, and capability-gated download workflows
- propagate document changes through nested viewer navigation
- prepare version 3.1.0-beta.2 for the npm next channel

## Validation

- 678 tests passed, 4 ignored
- all eight MCP Apps viewers built from a clean archive
- Node distribution built and npm pack includes all eight viewers
- JSR publish dry-run passed
- Sales viewer bindings are covered by the exhaustive mapping test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds authenticated file download with parent/privacy checks, path validation, no-redirect fetch, and size limits—security-sensitive even with those guards. Also changes how most record reads are presented in compatible hosts.
> 
> **Overview**
> Ships **3.1.0-beta.2**: most dedicated `_get` tools and `erpnext_doc_get` now open a generic `doc-viewer` (fields, child tables, guarded submit/cancel). Sales Order, Sales Invoice, and Quotation stay on `invoice-viewer`. Hosts without MCP Apps still get the ordinary JSON result.
> 
> Adds **attachment list/upload** in document surfaces and an app-only `erpnext_file_download` tool (126 tools, eight viewers). Downloads re-fetch the File row, check parent and privacy, accept only a local Frappe path, refuse redirects, and return one bounded embedded resource. Cap is 10 MiB via `ERPNEXT_MAX_DOWNLOAD_BYTES`.
> 
> Confirmed update/submit/cancel/upload events mark snapshots in the **current navigation stack** stale until that surface is re-read. Child drill-downs keep their own tool manifest. Sync across separate viewers is explicitly out of scope for this beta.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca076b5f9bad17dc2c92ff49c4f283fd8c9e7f27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->