### PR TITLE
fix: serve MCP Apps viewers from JSR URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `@casys/mcp-erpnext` will be documented in this file.
 
+## [3.1.0-beta.3] - 2026-08-25
+
+### Fixed
+
+- **JSR installations now register and serve the same MCP Apps viewers as the
+  npm bundle.** Published JSR modules retain an HTTPS `import.meta.url`; viewer
+  resources now preserve that URL and load their packaged HTML from JSR instead
+  of treating it as a local filesystem path. This restores `doc-viewer`, Sales
+  inspectors, and nested document details for Deno installations.
+
 ## [3.1.0-beta.2] - 2026-08-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ English | [繁體中文](README.zh-TW.md)
 
 > [!IMPORTANT]
 > **Installing the 3.1 beta:** pin the prerelease while this UX is being
-> validated. For npm/Node use `npx -y @casys/mcp-erpnext@3.1.0-beta.2`; for Deno
-> use `deno run -A jsr:@casys/mcp-erpnext@3.1.0-beta.2/server`. The moving npm
-> alias is `@next`. Beta 2 adds the generic document viewer and attachment
+> validated. For npm/Node use `npx -y @casys/mcp-erpnext@3.1.0-beta.3`; for Deno
+> use `deno run -A jsr:@casys/mcp-erpnext@3.1.0-beta.3/server`. The moving npm
+> alias is `@next`. The beta adds the generic document viewer and attachment
 > workflows, so test it with the MCP host your users actually run before
 > replacing a stable deployment.
 
@@ -80,7 +80,7 @@ See the [CHANGELOG](CHANGELOG.md) for the full release history, or the
 [latest release](https://github.com/Casys-AI/mcp-erpnext/releases/latest) for
 the current version's highlights.
 
-> **3.1 beta 2 preview:** the beta keeps the 3.0 tool surface and adds a generic
+> **3.1 beta preview:** the beta keeps the 3.0 tool surface and adds a generic
 > document viewer, child tables, document attachments, in-view navigation, and
 > active context. Features remain capability-gated by the MCP host. In
 > particular, downloads require both proxied server tools and the MCP Apps
@@ -235,7 +235,7 @@ tool is never replayed automatically. Overlapping or stale responses are ignored
 when a newer host payload or mutation has already won. A confirmed document
 change marks every potentially derived snapshot in the current navigation stack
 as stale; each marker is removed only when that surface has actually been read
-again. Separate MCP Apps are not synchronized automatically in beta 2.
+again. Separate MCP Apps are not synchronized automatically in the 3.1 beta.
 
 ### Building UI viewers
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -10,9 +10,9 @@
 
 > [!IMPORTANT]
 > **安裝 3.1 Beta：** 在新版 UX 驗證期間，請固定使用預發布版本。npm/Node 請執行
-> `npx -y @casys/mcp-erpnext@3.1.0-beta.2`；Deno 請執行
-> `deno run -A jsr:@casys/mcp-erpnext@3.1.0-beta.2/server`。npm 的浮動標籤為
-> `@next`。Beta 2 新增通用文件檢視器及附件流程；在取代穩定版部署前，請務必
+> `npx -y @casys/mcp-erpnext@3.1.0-beta.3`；Deno 請執行
+> `deno run -A jsr:@casys/mcp-erpnext@3.1.0-beta.3/server`。npm 的浮動標籤為
+> `@next`。此 Beta 新增通用文件檢視器及附件流程；在取代穩定版部署前，請務必
 > 使用實際的 MCP 主機進行測試。
 
 讓任何相容 MCP 的 AI 智慧代理操作您的 [ERPNext](https://erpnext.com) / Frappe

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@casys/mcp-erpnext",
-  "version": "3.1.0-beta.2",
+  "version": "3.1.0-beta.3",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {
     "age": "PT24H",

--- a/server.ts
+++ b/server.ts
@@ -35,7 +35,10 @@ import { launchInspector, MCP_APP_MIME_TYPE, McpApp } from "@casys/mcp-server";
 import { ErpNextToolsClient } from "./src/client.ts";
 import { FrappeAPIError } from "./src/api/frappe-client.ts";
 import { UI_VIEWERS } from "./src/ui/viewers.ts";
-import { resolveViewerDistPath } from "./src/ui/viewer-resource-paths.ts";
+import {
+  readViewerDist,
+  resolveViewerDistPath,
+} from "./src/ui/viewer-resource-paths.ts";
 import {
   exit,
   getArgs,
@@ -102,7 +105,7 @@ async function main() {
   // Build MCP server
   const server = new McpApp({
     name: "mcp-erpnext",
-    version: "3.1.0-beta.2",
+    version: "3.1.0-beta.3",
     transport: "stateless",
     cache: {
       ttlMs: 3_600_000,
@@ -150,7 +153,7 @@ async function main() {
           mimeType: MCP_APP_MIME_TYPE,
         },
         async () => {
-          const html = await readTextFile(distPath);
+          const html = await readViewerDist(distPath, readTextFile);
           return { uri: resourceUri, mimeType: MCP_APP_MIME_TYPE, text: html };
         },
       );

--- a/src/ui/doc-viewer/src/DocViewer.tsx
+++ b/src/ui/doc-viewer/src/DocViewer.tsx
@@ -45,7 +45,7 @@ import { DOC_FIXTURE, DOC_FIXTURE_FILES, isFixtureMode } from "./fixture.ts";
 
 const app = new App({
   name: "ERPNext Document Viewer",
-  version: "3.1.0-beta.2",
+  version: "3.1.0-beta.3",
 });
 const REFRESH_INTERVAL_MS = 15_000;
 const TOOL_CALL_TIMEOUT_MS = 10_000;

--- a/src/ui/viewer-resource-paths.ts
+++ b/src/ui/viewer-resource-paths.ts
@@ -14,13 +14,29 @@ function fileUrlToPath(url: URL): string {
   return decodedPath;
 }
 
+function isRemoteUrl(url: URL): boolean {
+  return url.protocol === "http:" || url.protocol === "https:";
+}
+
 export function resolveViewerDistPath(
   moduleUrl: string,
   viewerName: string,
   exists: (path: string) => boolean,
 ): string | null {
+  const sourceDistUrl = new URL(
+    `./src/ui/dist/${viewerName}/index.html`,
+    moduleUrl,
+  );
+
+  // JSR keeps import.meta.url as the published https://jsr.io module URL.
+  // Its package manifest already guarantees that src/ui/dist is present, so
+  // preserve that URL and load the viewer lazily when resources/read is called.
+  if (isRemoteUrl(sourceDistUrl)) {
+    return sourceDistUrl.href;
+  }
+
   const candidates = [
-    fileUrlToPath(new URL(`./src/ui/dist/${viewerName}/index.html`, moduleUrl)),
+    fileUrlToPath(sourceDistUrl),
     fileUrlToPath(new URL(`./ui-dist/${viewerName}/index.html`, moduleUrl)),
   ];
 
@@ -31,4 +47,32 @@ export function resolveViewerDistPath(
   }
 
   return null;
+}
+
+interface FetchTextResponse {
+  readonly ok: boolean;
+  readonly status: number;
+  readonly statusText: string;
+  text(): Promise<string>;
+}
+
+type FetchText = (url: string) => Promise<FetchTextResponse>;
+
+export async function readViewerDist(
+  location: string,
+  readLocal: (path: string) => Promise<string>,
+  fetchRemote: FetchText = fetch,
+): Promise<string> {
+  const url = new URL(location, "file:///");
+  if (!isRemoteUrl(url)) {
+    return await readLocal(location);
+  }
+
+  const response = await fetchRemote(location);
+  if (!response.ok) {
+    throw new Error(
+      `Viewer resource fetch failed (${response.status} ${response.statusText})`,
+    );
+  }
+  return await response.text();
 }

--- a/src/ui/viewer-resource-paths_test.ts
+++ b/src/ui/viewer-resource-paths_test.ts
@@ -1,5 +1,8 @@
 import { assertEquals } from "@std/assert";
-import { resolveViewerDistPath } from "./viewer-resource-paths.ts";
+import {
+  readViewerDist,
+  resolveViewerDistPath,
+} from "./viewer-resource-paths.ts";
 
 Deno.test("resolveViewerDistPath prefers source dist in repo mode", () => {
   const resolved = resolveViewerDistPath(
@@ -53,4 +56,59 @@ Deno.test("resolveViewerDistPath returns null when no viewer build exists", () =
   );
 
   assertEquals(resolved, null);
+});
+
+Deno.test("resolveViewerDistPath preserves the published JSR viewer URL", () => {
+  let localProbeCalled = false;
+  const resolved = resolveViewerDistPath(
+    "https://jsr.io/@casys/mcp-erpnext/3.1.0-beta.3/server.ts",
+    "doc-viewer",
+    () => {
+      localProbeCalled = true;
+      return false;
+    },
+  );
+
+  assertEquals(
+    resolved,
+    "https://jsr.io/@casys/mcp-erpnext/3.1.0-beta.3/src/ui/dist/doc-viewer/index.html",
+  );
+  assertEquals(localProbeCalled, false);
+});
+
+Deno.test("readViewerDist fetches a published viewer URL", async () => {
+  const calls: string[] = [];
+  const html = await readViewerDist(
+    "https://jsr.io/@casys/mcp-erpnext/3.1.0-beta.3/src/ui/dist/doc-viewer/index.html",
+    () => Promise.reject(new Error("local reader must not run")),
+    (url) => {
+      calls.push(url);
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        text: () => Promise.resolve("<html>published viewer</html>"),
+      });
+    },
+  );
+
+  assertEquals(html, "<html>published viewer</html>");
+  assertEquals(calls, [
+    "https://jsr.io/@casys/mcp-erpnext/3.1.0-beta.3/src/ui/dist/doc-viewer/index.html",
+  ]);
+});
+
+Deno.test("readViewerDist keeps local npm and repository reads local", async () => {
+  const calls: string[] = [];
+  const html = await readViewerDist(
+    "/workspace/ui-dist/doc-viewer/index.html",
+    (path) => {
+      calls.push(path);
+      return Promise.resolve("<html>local viewer</html>");
+    },
+    () => Promise.reject(new Error("remote fetch must not run")),
+  );
+
+  assertEquals(html, "<html>local viewer</html>");
+  assertEquals(calls, ["/workspace/ui-dist/doc-viewer/index.html"]);
 });


### PR DESCRIPTION
## Summary

- preserve published HTTP viewer locations instead of treating them as local paths
- load viewer HTML lazily from JSR while keeping repository and npm reads local
- bump the prerelease to 3.1.0-beta.3 and update pinned beta install examples

## Why

The published npm beta 2 exposes all eight MCP Apps resources, but a fresh JSR run resolves import.meta.url to jsr.io and therefore registered no resources.

## Validation

- full release check passed: 681 tests, 0 failed, 4 ignored
- all eight viewers and the Node bundle built
- JSR publish dry-run passed
- remote-module simulation passed resources/list for all eight viewers and resources/read for doc-viewer
- npm tarball dry-run includes all eight viewers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted packaging/runtime path fix with tests; no ERPNext tool or auth changes, though JSR deployments now depend on successful HTTPS fetches at resource read time.
> 
> **Overview**
> **Fixes Deno/JSR installs where MCP App viewer resources failed to register** because `import.meta.url` resolves to `https://jsr.io/...` and the server previously treated viewer paths as local filesystem locations.
> 
> **`resolveViewerDistPath`** now keeps the published HTTPS URL to packaged `src/ui/dist/{viewer}/index.html` when the module URL is remote, skipping local existence checks. **Repository and npm** behavior is unchanged (probe `src/ui/dist` and `ui-dist` on disk).
> 
> **`readViewerDist`** loads viewer HTML on **`resources/read`**: **HTTP fetch** for remote URLs, **local read** otherwise. **`server.ts`** uses this instead of reading paths directly.
> 
> Prerelease **3.1.0-beta.3** with changelog and README install pins updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a4eaf144e7e549907d222c1e4972d9e1f732a01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->