### PR TITLE
feat(operations): add erpnext_method_call escape hatch

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -19,13 +19,14 @@ fallback rule.
 
 Always required, regardless of transport (stdio or HTTP).
 
-| Variable                     | Type             | Default             | Required | Notes                                                                                                                     |
-| ---------------------------- | ---------------- | ------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `ERPNEXT_URL`                | string (URL)     | —                   | **Yes**  | Base URL of the ERPNext instance, e.g. `http://localhost:8000`. No trailing slash.                                        |
-| `ERPNEXT_API_KEY`            | string           | —                   | **Yes**  | API key from ERPNext User Settings → API Access.                                                                          |
-| `ERPNEXT_API_SECRET`         | string           | —                   | **Yes**  | API secret paired with the key above.                                                                                     |
-| `ERPNEXT_MAX_UPLOAD_BYTES`   | positive integer | `10485760` (10 MiB) | No       | Upper bound in decoded bytes for file uploads. Missing or blank uses the default; an invalid value fails client creation. |
-| `ERPNEXT_MAX_DOWNLOAD_BYTES` | positive integer | `10485760` (10 MiB) | No       | Upper bound in bytes for attachment downloads. Missing or blank uses the default; an invalid value fails client creation. |
+| Variable                     | Type                     | Default             | Required | Notes                                                                                                                                                                                                             |
+| ---------------------------- | ------------------------ | ------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ERPNEXT_URL`                | string (URL)             | —                   | **Yes**  | Base URL of the ERPNext instance, e.g. `http://localhost:8000`. No trailing slash.                                                                                                                                |
+| `ERPNEXT_API_KEY`            | string                   | —                   | **Yes**  | API key from ERPNext User Settings → API Access.                                                                                                                                                                  |
+| `ERPNEXT_API_SECRET`         | string                   | —                   | **Yes**  | API secret paired with the key above.                                                                                                                                                                             |
+| `ERPNEXT_MAX_UPLOAD_BYTES`   | positive integer         | `10485760` (10 MiB) | No       | Upper bound in decoded bytes for file uploads. Missing or blank uses the default; an invalid value fails client creation.                                                                                         |
+| `ERPNEXT_MAX_DOWNLOAD_BYTES` | positive integer         | `10485760` (10 MiB) | No       | Upper bound in bytes for attachment downloads. Missing or blank uses the default; an invalid value fails client creation.                                                                                         |
+| `ERPNEXT_METHOD_ALLOWLIST`   | string (comma-separated) | — (deny-by-default) | No       | Gates `erpnext_method_call`. Each entry is an exact dotted method path or a `prefix.*` wildcard; `*` allows any method. Unset or blank means no method is callable. Read per call, not cached at client creation. |
 
 ---
 
@@ -70,6 +71,8 @@ set.
   ERPNEXT_URL / ERPNEXT_API_KEY / ERPNEXT_API_SECRET /
   ERPNEXT_MAX_UPLOAD_BYTES / ERPNEXT_MAX_DOWNLOAD_BYTES:
     src/api/frappe-client.ts (file limits and getFrappeClient)
+  ERPNEXT_METHOD_ALLOWLIST:
+    src/tools/method-allowlist.ts (loadMethodAllowlist, isMethodAllowed)
   MCP_MRTR_SIGNING_KEY:
     src/mrtr/config.ts:23-32 (loadMrtrConfig, regex validation)
   MCP_AUTH_TOKEN / MCP_AUTH_TOKENS / MCP_OAUTH_JWKS_URL:

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,4 +1,4 @@
-# Tools Reference (126)
+# Tools Reference (127)
 
 Full reference for all ERPNext MCP tools. See [README](../README.md) for
 overview.
@@ -153,25 +153,37 @@ overview.
 | `erpnext_asset_maintenance_get`  | Asset Maintenance | Get with maintenance tasks                            |
 | `erpnext_asset_category_list`    | Asset Category    | List all categories                                   |
 
-## Generic Operations (12) → doc-viewer / doclist-viewer
+## Generic Operations (13) → doc-viewer / doclist-viewer
 
-| Tool                    | Operation | Notes                                                   |
-| ----------------------- | --------- | ------------------------------------------------------- |
-| `erpnext_doc_create`    | Create    | Any DocType — essential for master data setup           |
-| `erpnext_doc_get`       | Get       | Any document by DocType + name                          |
-| `erpnext_doc_list`      | List      | Any DocType with fields, filters, limit, order_by       |
-| `erpnext_doc_update`    | Update    | Partial patch — pass only fields to change              |
-| `erpnext_doc_delete`    | Delete    | Draft documents only                                    |
-| `erpnext_doc_submit`    | Submit    | Any submittable document                                |
-| `erpnext_doc_cancel`    | Cancel    | Any submitted document                                  |
-| `erpnext_doc_assign`    | Assign    | Native assignment (ToDo + notification) to users        |
-| `erpnext_doc_unassign`  | Unassign  | Remove one user's native assignment                     |
-| `erpnext_file_list`     | List      | Read attachments and native File metadata               |
-| `erpnext_file_upload`   | Upload    | Attach base64 data as a native File                     |
-| `erpnext_file_download` | Download  | App-only, authenticated and bounded attachment download |
+| Tool                    | Operation | Notes                                                                    |
+| ----------------------- | --------- | ------------------------------------------------------------------------ |
+| `erpnext_doc_create`    | Create    | Any DocType — essential for master data setup                            |
+| `erpnext_doc_get`       | Get       | Any document by DocType + name                                           |
+| `erpnext_doc_list`      | List      | Any DocType with fields, filters, limit, order_by                        |
+| `erpnext_doc_update`    | Update    | Partial patch — pass only fields to change                               |
+| `erpnext_doc_delete`    | Delete    | Draft documents only                                                     |
+| `erpnext_doc_submit`    | Submit    | Any submittable document                                                 |
+| `erpnext_doc_cancel`    | Cancel    | Any submitted document                                                   |
+| `erpnext_doc_assign`    | Assign    | Native assignment (ToDo + notification) to users                         |
+| `erpnext_doc_unassign`  | Unassign  | Remove one user's native assignment                                      |
+| `erpnext_file_list`     | List      | Read attachments and native File metadata                                |
+| `erpnext_file_upload`   | Upload    | Attach base64 data as a native File                                      |
+| `erpnext_file_download` | Download  | App-only, authenticated and bounded attachment download                  |
+| `erpnext_method_call`   | Call      | Escape hatch for whitelisted Frappe methods (deny-by-default, see below) |
 
 `erpnext_file_list` requires `attached_to_doctype` and `attached_to_name`. Its
 optional `limit` is an integer from 1 to 500 and defaults to 50.
+
+`erpnext_method_call` calls `/api/method/{method}` directly for behaviour that
+is not a plain document write — custom-app `@frappe.whitelist` methods,
+`validate` hooks that reject a direct field update, or GET-only endpoints. It
+takes `method` (dotted path), optional `args`, optional `http_method`
+(`GET`/`POST`, default `POST`), and optional `invalidate: { doctype, name }` to
+drop a document from the read cache after a mutating call. The method must match
+an entry in `ERPNEXT_METHOD_ALLOWLIST` — an exact path or a `prefix.*` wildcard
+— or the call is rejected before it reaches ERPNext; the variable is unset by
+default, so no method is callable until configured. See
+[environment-variables.md](./environment-variables.md).
 
 `erpnext_file_upload` requires `file_name`, `content_base64`,
 `attached_to_doctype`, and `attached_to_name`; `attached_to_field` is optional.

--- a/src/api/frappe-client.ts
+++ b/src/api/frappe-client.ts
@@ -1032,12 +1032,33 @@ export class FrappeClient {
 
   /**
    * Call a whitelisted Frappe method.
-   * POST /api/method/{method}
+   * POST /api/method/{method}, or GET for methods declared
+   * `@frappe.whitelist(methods=["GET"])` — Frappe reads GET arguments from
+   * the query string into `frappe.form_dict`, JSON-encoding non-string values
+   * the same way the list/resource GET endpoints already do in this client.
    */
   async callMethod<T = unknown>(
     method: string,
     args: Record<string, unknown> = {},
+    httpMethod: "GET" | "POST" = "POST",
   ): Promise<T> {
+    if (httpMethod === "GET") {
+      const params = new URLSearchParams();
+      for (const [key, value] of Object.entries(args)) {
+        if (value === undefined) continue;
+        params.set(
+          key,
+          typeof value === "string" ? value : JSON.stringify(value),
+        );
+      }
+      const query = params.toString() ? `?${params.toString()}` : "";
+      const res = await this.request<FrappeMethodResponse<T>>(
+        "GET",
+        `/api/method/${method}${query}`,
+      );
+      return res.message;
+    }
+
     const res = await this.request<FrappeMethodResponse<T>>(
       "POST",
       `/api/method/${method}`,

--- a/src/api/frappe-client_test.ts
+++ b/src/api/frappe-client_test.ts
@@ -1343,3 +1343,90 @@ Deno.test("FrappeClient.invalidate() - clears resolveLink's negative-match cache
 
   assertEquals(cache.get("resolve:miss:Customer:Acme"), undefined);
 });
+
+// ── callMethod ────────────────────────────────────────────────────────────────
+
+Deno.test("FrappeClient.callMethod() - defaults to POST with a JSON body", async () => {
+  const original = globalThis.fetch;
+  let seen: { url: string; method: string; body: unknown } | undefined;
+  globalThis.fetch = async (
+    url: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    seen = {
+      url: String(url),
+      method: init?.method ?? "GET",
+      body: init?.body,
+    };
+    return jsonResponse({ message: 42 });
+  };
+
+  try {
+    const client = makeClient();
+    const result = await client.callMethod("frappe.client.get_count", {
+      doctype: "Task",
+    });
+    assertEquals(result, 42);
+    assertEquals(
+      seen?.url,
+      "http://localhost:8000/api/method/frappe.client.get_count",
+    );
+    assertEquals(seen?.method, "POST");
+    assertEquals(seen?.body, JSON.stringify({ doctype: "Task" }));
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("FrappeClient.callMethod() - GET encodes args into the query string", async () => {
+  const original = globalThis.fetch;
+  let seen: { url: string; method: string; body: unknown } | undefined;
+  globalThis.fetch = async (
+    url: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    seen = {
+      url: String(url),
+      method: init?.method ?? "GET",
+      body: init?.body,
+    };
+    return jsonResponse({ message: { ok: true } });
+  };
+
+  try {
+    const client = makeClient();
+    const result = await client.callMethod(
+      "my_app.api.status",
+      { doctype: "Task", limit: 5 },
+      "GET",
+    );
+    assertEquals(result, { ok: true });
+    assertEquals(seen?.method, "GET");
+    assertEquals(seen?.body, undefined);
+    const url = new URL(seen!.url);
+    assertEquals(url.pathname, "/api/method/my_app.api.status");
+    assertEquals(url.searchParams.get("doctype"), "Task");
+    assertEquals(url.searchParams.get("limit"), "5");
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("FrappeClient.callMethod() - GET with no args omits the query string", async () => {
+  const original = globalThis.fetch;
+  let seenUrl: string | undefined;
+  globalThis.fetch = async (
+    url: string | URL | Request,
+  ): Promise<Response> => {
+    seenUrl = String(url);
+    return jsonResponse({ message: null });
+  };
+
+  try {
+    const client = makeClient();
+    await client.callMethod("my_app.api.ping", {}, "GET");
+    assertEquals(seenUrl, "http://localhost:8000/api/method/my_app.api.ping");
+  } finally {
+    globalThis.fetch = original;
+  }
+});

--- a/src/tools/method-allowlist.ts
+++ b/src/tools/method-allowlist.ts
@@ -1,0 +1,46 @@
+/**
+ * Method Allowlist — gates `erpnext_method_call` against ERPNEXT_METHOD_ALLOWLIST.
+ *
+ * Deny-by-default: with the variable unset, no method is callable. `*` opts
+ * a session fully in. Entries are either an exact dotted path or a
+ * `prefix.*` wildcard matching any method under that module prefix.
+ *
+ * @module lib/erpnext/tools/method-allowlist
+ */
+
+import { env } from "../runtime.ts";
+
+const METHOD_PATH_RE = /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$/;
+
+/** Validates a dotted Frappe method path (no wildcard, no leading/trailing dot). */
+export function isValidMethodPath(method: string): boolean {
+  return METHOD_PATH_RE.test(method);
+}
+
+function parseAllowlist(raw: string | undefined): string[] {
+  if (!raw || !raw.trim()) return [];
+  return raw.split(",").map((entry) => entry.trim()).filter(Boolean);
+}
+
+/**
+ * Returns true if `method` is permitted by `allowlist`.
+ * Each allowlist entry is either an exact match or a `prefix.*` wildcard.
+ */
+export function isMethodAllowed(method: string, allowlist: string[]): boolean {
+  for (const entry of allowlist) {
+    if (entry === "*") return true;
+    if (entry === method) return true;
+    if (entry.endsWith(".*")) {
+      const prefix = entry.slice(0, -1); // keep trailing "."
+      if (method.startsWith(prefix) && method.length > prefix.length) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/** Reads and parses ERPNEXT_METHOD_ALLOWLIST from the environment. */
+export function loadMethodAllowlist(): string[] {
+  return parseAllowlist(env("ERPNEXT_METHOD_ALLOWLIST"));
+}

--- a/src/tools/method-allowlist_test.ts
+++ b/src/tools/method-allowlist_test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for method-allowlist.ts
+ *
+ * @module lib/erpnext/tests/tools/method-allowlist_test
+ */
+
+import { assertEquals } from "@std/assert";
+import {
+  isMethodAllowed,
+  isValidMethodPath,
+  loadMethodAllowlist,
+} from "./method-allowlist.ts";
+
+Deno.test("isValidMethodPath - accepts dotted paths", () => {
+  assertEquals(isValidMethodPath("frappe.client.get_count"), true);
+  assertEquals(isValidMethodPath("my_app.api.reconcile"), true);
+  assertEquals(isValidMethodPath("a"), true);
+});
+
+Deno.test("isValidMethodPath - rejects malformed paths", () => {
+  for (
+    const bad of [
+      "",
+      ".",
+      "frappe..client",
+      ".frappe.client",
+      "frappe.client.",
+      "frappe.client.*",
+      "frappe client",
+      "frappe/client",
+    ]
+  ) {
+    assertEquals(isValidMethodPath(bad), false, bad);
+  }
+});
+
+Deno.test("isMethodAllowed - deny-by-default with an empty allowlist", () => {
+  assertEquals(isMethodAllowed("frappe.client.get_count", []), false);
+});
+
+Deno.test("isMethodAllowed - '*' allows anything", () => {
+  assertEquals(isMethodAllowed("my_app.api.anything", ["*"]), true);
+});
+
+Deno.test("isMethodAllowed - exact match", () => {
+  const list = ["frappe.client.get_count"];
+  assertEquals(isMethodAllowed("frappe.client.get_count", list), true);
+  assertEquals(isMethodAllowed("frappe.client.get_list", list), false);
+});
+
+Deno.test("isMethodAllowed - 'prefix.*' wildcard matches methods under the prefix", () => {
+  const list = ["my_app.api.*"];
+  assertEquals(isMethodAllowed("my_app.api.reconcile", list), true);
+  assertEquals(isMethodAllowed("my_app.api.sub.reconcile", list), true);
+  assertEquals(isMethodAllowed("my_app.other.reconcile", list), false);
+});
+
+Deno.test("isMethodAllowed - 'prefix.*' does not match the bare prefix itself", () => {
+  assertEquals(isMethodAllowed("my_app.api", ["my_app.api.*"]), false);
+});
+
+Deno.test("loadMethodAllowlist - parses a comma-separated env var", () => {
+  using _ = withAllowlist("frappe.client.get_count, my_app.api.*");
+  assertEquals(loadMethodAllowlist(), [
+    "frappe.client.get_count",
+    "my_app.api.*",
+  ]);
+});
+
+Deno.test("loadMethodAllowlist - unset or blank yields an empty list", () => {
+  using _ = withAllowlist(undefined);
+  assertEquals(loadMethodAllowlist(), []);
+});
+
+function withAllowlist(value?: string): Disposable {
+  const previous = Deno.env.get("ERPNEXT_METHOD_ALLOWLIST");
+  Deno.env.delete("ERPNEXT_METHOD_ALLOWLIST");
+  if (value !== undefined) Deno.env.set("ERPNEXT_METHOD_ALLOWLIST", value);
+
+  return {
+    [Symbol.dispose]() {
+      Deno.env.delete("ERPNEXT_METHOD_ALLOWLIST");
+      if (previous !== undefined) {
+        Deno.env.set("ERPNEXT_METHOD_ALLOWLIST", previous);
+      }
+    },
+  };
+}

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -23,6 +23,11 @@ import {
   removeAssignment,
   validateAssignees,
 } from "./assignment.ts";
+import {
+  isMethodAllowed,
+  isValidMethodPath,
+  loadMethodAllowlist,
+} from "./method-allowlist.ts";
 
 function bytesToBase64(bytes: Uint8Array): string {
   const chunkSize = 32 * 1024;
@@ -844,6 +849,121 @@ export const operationsTools: ErpNextTool[] = [
         message: `${assignee} unassigned from ${doctype} ${name}`,
         assignment: unassignment,
       };
+    },
+  },
+
+  // ── Method Escape Hatch ────────────────────────────────────────────────────
+
+  {
+    name: "erpnext_method_call",
+    description:
+      "Call a whitelisted Frappe method directly (POST or GET /api/method/{method}). " +
+      "Escape hatch for behaviour that is not a plain document write: custom-app " +
+      "@frappe.whitelist methods, validate hooks that reject direct field updates, " +
+      "and GET-only endpoints. Deny-by-default: the method must match an entry in " +
+      "ERPNEXT_METHOD_ALLOWLIST (exact dotted path or 'prefix.*' wildcard), or the " +
+      "call is rejected before it reaches ERPNext. Set ERPNEXT_METHOD_ALLOWLIST=* " +
+      "to allow any method for a fully open session.",
+    category: "operations",
+    inputSchema: {
+      type: "object",
+      properties: {
+        method: {
+          type: "string",
+          description:
+            "Dotted path to the whitelisted method, e.g. 'frappe.client.get_count' " +
+            "or 'my_app.api.reconcile'.",
+          minLength: 1,
+        },
+        args: {
+          type: "object",
+          description: "Keyword arguments passed to the method.",
+        },
+        http_method: {
+          type: "string",
+          enum: ["GET", "POST"],
+          description:
+            "HTTP verb to use. Defaults to POST. Use GET for methods declared " +
+            '@frappe.whitelist(methods=["GET"]), which reject POST.',
+        },
+        invalidate: {
+          type: "object",
+          description:
+            "Optional { doctype, name } to drop from the read cache after a " +
+            "mutating call, so the next read reflects the method's side effects.",
+          properties: {
+            doctype: { type: "string", minLength: 1 },
+            name: { type: "string", minLength: 1 },
+          },
+          required: ["doctype", "name"],
+        },
+      },
+      required: ["method"],
+    },
+    handler: async (input, ctx) => {
+      if (typeof input.method !== "string" || !input.method.trim()) {
+        throw new Error(
+          "[erpnext_method_call] 'method' must be a non-empty dotted path",
+        );
+      }
+      const method = input.method.trim();
+      if (!isValidMethodPath(method)) {
+        throw new Error(
+          `[erpnext_method_call] 'method' is not a valid dotted path: '${method}'`,
+        );
+      }
+
+      const allowlist = loadMethodAllowlist();
+      if (!isMethodAllowed(method, allowlist)) {
+        throw new Error(
+          `[erpnext_method_call] '${method}' is not permitted. Add it (or a ` +
+            "'prefix.*' covering it) to ERPNEXT_METHOD_ALLOWLIST, or set " +
+            "ERPNEXT_METHOD_ALLOWLIST=* to allow any method.",
+        );
+      }
+
+      if (
+        input.args !== undefined &&
+        (typeof input.args !== "object" || input.args === null ||
+          Array.isArray(input.args))
+      ) {
+        throw new Error(
+          "[erpnext_method_call] 'args' must be an object of keyword arguments",
+        );
+      }
+      const args = (input.args as Record<string, unknown> | undefined) ?? {};
+
+      let httpMethod: "GET" | "POST" = "POST";
+      if (input.http_method !== undefined) {
+        if (input.http_method !== "GET" && input.http_method !== "POST") {
+          throw new Error(
+            "[erpnext_method_call] 'http_method' must be 'GET' or 'POST'",
+          );
+        }
+        httpMethod = input.http_method;
+      }
+
+      let invalidate: { doctype: string; name: string } | undefined;
+      if (input.invalidate !== undefined) {
+        const inv = input.invalidate as Record<string, unknown>;
+        if (
+          typeof inv?.doctype !== "string" || !inv.doctype.trim() ||
+          typeof inv?.name !== "string" || !inv.name.trim()
+        ) {
+          throw new Error(
+            "[erpnext_method_call] 'invalidate' requires non-empty 'doctype' and 'name'",
+          );
+        }
+        invalidate = { doctype: inv.doctype.trim(), name: inv.name.trim() };
+      }
+
+      const result = await ctx.client.callMethod(method, args, httpMethod);
+
+      if (invalidate) {
+        ctx.client.invalidate(invalidate.doctype, invalidate.name);
+      }
+
+      return { data: result };
     },
   },
 ];

--- a/src/tools/operations_test.ts
+++ b/src/tools/operations_test.ts
@@ -806,3 +806,194 @@ Deno.test("erpnext_doc_unassign - rejects a missing or empty assign_to", async (
     "non-empty user email",
   );
 });
+
+// ── erpnext_method_call ─────────────────────────────────────────────────────
+
+function withAllowlist(value?: string): Disposable {
+  const previous = Deno.env.get("ERPNEXT_METHOD_ALLOWLIST");
+  Deno.env.delete("ERPNEXT_METHOD_ALLOWLIST");
+  if (value !== undefined) Deno.env.set("ERPNEXT_METHOD_ALLOWLIST", value);
+
+  return {
+    [Symbol.dispose]() {
+      Deno.env.delete("ERPNEXT_METHOD_ALLOWLIST");
+      if (previous !== undefined) {
+        Deno.env.set("ERPNEXT_METHOD_ALLOWLIST", previous);
+      }
+    },
+  };
+}
+
+Deno.test("erpnext_method_call - exists in operations tools", () => {
+  const tool = getTool("erpnext_method_call");
+  assertEquals(tool.name, "erpnext_method_call");
+  assertEquals(tool.category, "operations");
+});
+
+Deno.test("erpnext_method_call - deny-by-default when ERPNEXT_METHOD_ALLOWLIST is unset", async () => {
+  using _ = withAllowlist(undefined);
+  await assertRejects(
+    () =>
+      getTool("erpnext_method_call").handler(
+        { method: "frappe.client.get_count" },
+        makeCtx(makeMockClient()),
+      ),
+    Error,
+    "is not permitted",
+  );
+});
+
+Deno.test("erpnext_method_call - rejects a method not covered by the allowlist", async () => {
+  using _ = withAllowlist("frappe.client.get_count");
+  await assertRejects(
+    () =>
+      getTool("erpnext_method_call").handler(
+        { method: "my_app.api.delete_everything" },
+        makeCtx(makeMockClient()),
+      ),
+    Error,
+    "is not permitted",
+  );
+});
+
+Deno.test("erpnext_method_call - calls an exactly-allowlisted method via POST by default", async () => {
+  using _ = withAllowlist("frappe.client.get_count");
+  let seen: [string, Record<string, unknown>, string] | undefined;
+  const tool = getTool("erpnext_method_call");
+  const result = await tool.handler(
+    { method: "frappe.client.get_count", args: { doctype: "Task" } },
+    makeCtx(makeMockClient({
+      callMethod: async (
+        method: string,
+        args: Record<string, unknown>,
+        httpMethod: string,
+      ) => {
+        seen = [method, args, httpMethod];
+        return 42;
+      },
+    })),
+  );
+  assertEquals(seen, [
+    "frappe.client.get_count",
+    { doctype: "Task" },
+    "POST",
+  ]);
+  assertEquals(result, { data: 42 });
+});
+
+Deno.test("erpnext_method_call - allows a 'prefix.*' wildcard and passes http_method through", async () => {
+  using _ = withAllowlist("my_app.api.*");
+  let seenHttpMethod: string | undefined;
+  const tool = getTool("erpnext_method_call");
+  await tool.handler(
+    { method: "my_app.api.reconcile", http_method: "GET" },
+    makeCtx(makeMockClient({
+      callMethod: async (
+        _method: string,
+        _args: Record<string, unknown>,
+        httpMethod: string,
+      ) => {
+        seenHttpMethod = httpMethod;
+        return null;
+      },
+    })),
+  );
+  assertEquals(seenHttpMethod, "GET");
+});
+
+Deno.test("erpnext_method_call - '*' allows any method", async () => {
+  using _ = withAllowlist("*");
+  const tool = getTool("erpnext_method_call");
+  const result = await tool.handler(
+    { method: "anything.goes.here" },
+    makeCtx(makeMockClient({ callMethod: async () => "ok" })),
+  );
+  assertEquals(result, { data: "ok" });
+});
+
+Deno.test("erpnext_method_call - invalidates the given doctype/name after a mutating call", async () => {
+  using _ = withAllowlist("my_app.api.*");
+  let invalidated: [string, string] | undefined;
+  const tool = getTool("erpnext_method_call");
+  await tool.handler(
+    {
+      method: "my_app.api.mark_paid",
+      invalidate: { doctype: "Sales Invoice", name: "SINV-001" },
+    },
+    makeCtx(makeMockClient({
+      callMethod: async () => ({ ok: true }),
+      invalidate: (doctype: string, name: string) => {
+        invalidated = [doctype, name];
+      },
+    })),
+  );
+  assertEquals(invalidated, ["Sales Invoice", "SINV-001"]);
+});
+
+Deno.test("erpnext_method_call - rejects a missing or empty method", async () => {
+  using _ = withAllowlist("*");
+  await assertRejects(
+    () =>
+      getTool("erpnext_method_call").handler(
+        { method: "  " },
+        makeCtx(makeMockClient()),
+      ),
+    Error,
+    "non-empty dotted path",
+  );
+});
+
+Deno.test("erpnext_method_call - rejects a malformed method path", async () => {
+  using _ = withAllowlist("*");
+  await assertRejects(
+    () =>
+      getTool("erpnext_method_call").handler(
+        { method: "frappe.client.*" },
+        makeCtx(makeMockClient()),
+      ),
+    Error,
+    "not a valid dotted path",
+  );
+});
+
+Deno.test("erpnext_method_call - rejects a non-object args", async () => {
+  using _ = withAllowlist("*");
+  await assertRejects(
+    () =>
+      getTool("erpnext_method_call").handler(
+        { method: "frappe.client.get_count", args: "nope" },
+        makeCtx(makeMockClient()),
+      ),
+    Error,
+    "'args' must be an object",
+  );
+});
+
+Deno.test("erpnext_method_call - rejects an invalid http_method", async () => {
+  using _ = withAllowlist("*");
+  await assertRejects(
+    () =>
+      getTool("erpnext_method_call").handler(
+        { method: "frappe.client.get_count", http_method: "DELETE" },
+        makeCtx(makeMockClient()),
+      ),
+    Error,
+    "'http_method' must be 'GET' or 'POST'",
+  );
+});
+
+Deno.test("erpnext_method_call - rejects an incomplete invalidate object", async () => {
+  using _ = withAllowlist("*");
+  await assertRejects(
+    () =>
+      getTool("erpnext_method_call").handler(
+        {
+          method: "frappe.client.get_count",
+          invalidate: { doctype: "Task" },
+        },
+        makeCtx(makeMockClient()),
+      ),
+    Error,
+    "'invalidate' requires non-empty",
+  );
+});


### PR DESCRIPTION
## Summary
- Adds `erpnext_method_call`, a tool wrapping `FrappeClient.callMethod` for behaviour that isn't a plain document write: custom-app `@frappe.whitelist` methods, `validate`-hook-gated business methods, and GET-only endpoints.
- `callMethod()` gains a GET branch (query-string args, JSON-encoded the same way `list()`/`get()` already do) alongside the existing POST path.
- Deny-by-default via `ERPNEXT_METHOD_ALLOWLIST`: entries are an exact dotted path or a `prefix.*` wildcard; `*` opts a session fully in. Unset means no method is callable.
- Optional `invalidate: { doctype, name }` drops the cached document after a mutating call.
- Docs updated: `docs/tools.md` and `docs/environment-variables.md`.

Closes #21.

## Test plan
- [x] `deno fmt --check`
- [x] `deno lint`
- [x] `deno task check`
- [x] `deno task test` — 730 passed / 0 failed / 4 ignored (24 new tests added: `method-allowlist_test.ts`, `erpnext_method_call` cases in `operations_test.ts`, GET-branch cases in `frappe-client_test.ts`)