### PR TITLE
fix(viewer): three layout defects found auditing the doclist templates

### DIFF
--- a/src/ui/shared/doclist/DoclistBody.tsx
+++ b/src/ui/shared/doclist/DoclistBody.tsx
@@ -29,6 +29,7 @@ import type { DoclistData } from "./types";
 import type { DoclistState, Row } from "./useDoclist";
 import { canCallViewerTool } from "../viewer-tools";
 import { doclistDetailPanelId } from "./detail-panel.ts";
+import { nearestScrollDelta } from "./scroll-nearest.ts";
 
 const TOOL_CALL_TIMEOUT_MS = 10_000;
 const CANONICAL_READBACK_DELAY_MS = 1_500;
@@ -96,7 +97,7 @@ export function DoclistBody(
   },
 ) {
   const t = useT();
-  const { rows, rowAction: payloadRowAction, expandedId } = list;
+  const { rows, pageRows, rowAction: payloadRowAction, expandedId } = list;
   const serverTools = app.getHostCapabilities()?.serverTools;
   const rowAction = payloadRowAction && canCallViewerTool(
       serverTools,
@@ -121,6 +122,7 @@ export function DoclistBody(
     setExpandedState(next);
   };
   const pendingRowIdRef = useRef<string | null>(null);
+  const scrollerRef = useRef<HTMLDivElement>(null);
   useEffect(() => () => {
     pendingRowIdRef.current = null;
   }, []);
@@ -171,14 +173,16 @@ export function DoclistBody(
       setExpanded({ id: null, data: null, loading: false });
       return;
     }
-    const row = rows.find((r, i) =>
+    const row = pageRows.find((r, i) =>
       resolveRowId(r, rowAction, String(i)) === expandedId
     );
     if (!row) {
-      // `rows` porte le jeu complet, pas la page : une ligne absente d'ici a
-      // disparu des données, elle n'est pas seulement sur une autre page. La
-      // garder ouverte laisserait un détail invisible et son contenu périmé en
-      // mémoire, que le retour sur la ligne ne rechargerait pas.
+      // Le tableau ne rend que `pageRows`. Chercher dans `rows` laisserait
+      // `expandedId` posé sur un panneau démonté dès qu'un rafraîchissement
+      // garde la ligne dans les données mais la pousse hors de la page
+      // courante — contenu périmé en mémoire. Changer de page, de filtre
+      // ou de tri efface déjà `expandedId` (voir useDoclist) ; ce trou-ci
+      // est le rafraîchissement.
       pendingRowIdRef.current = null;
       setExpanded({ id: null, data: null, loading: false });
       list.setExpandedId(null);
@@ -256,22 +260,39 @@ export function DoclistBody(
         }
       }
     })();
-  }, [expandedId, rows, rowAction, fixture, data.doctype]);
+  }, [
+    expandedId,
+    // Pas `pageRows` : c'est un `.slice` neuf à chaque render, et
+    // `setExpanded(null)` relancerait l'effet en boucle. `rows` change
+    // au rafraîchissement, c'est le signal qui nous concerne.
+    rows,
+    rowAction,
+    fixture,
+    data.doctype,
+  ]);
 
-  // Un détail qui s'ouvre sous le pli n'existe pas pour qui l'a demandé : la
-  // ligne reste visible, son panneau est hors écran, et rien ne le signale.
-  // `nearest` ne déplace rien quand le panneau tient déjà dans le cadre.
+  // Un détail sous le pli n'existe pas pour qui l'a demandé. On scrolle le
+  // conteneur interne seulement : `scrollIntoView` remonterait jusqu'à
+  // l'iframe hôte. `expanded.loading` est dans les deps — sur le chemin
+  // asynchrone le premier passage vise le squelette (144 px) ; quand
+  // l'enveloppe arrive, `id` ne change pas, il faut un second scroll.
   useEffect(() => {
     if (expanded.id === null) return;
     const panel = document.getElementById(doclistDetailPanelId(expanded.id));
-    if (!panel) return;
+    const scroller = scrollerRef.current;
+    if (!panel || !scroller) return;
     const still = typeof matchMedia === "function" &&
       matchMedia("(prefers-reduced-motion: reduce)").matches;
-    panel.scrollIntoView({
-      block: "nearest",
+    const delta = nearestScrollDelta(
+      scroller.getBoundingClientRect(),
+      panel.getBoundingClientRect(),
+    );
+    if (delta === 0) return;
+    scroller.scrollTo({
+      top: scroller.scrollTop + delta,
       behavior: still ? "auto" : "smooth",
     });
-  }, [expanded.id]);
+  }, [expanded.id, expanded.loading]);
 
   function rowInteractionTarget(
     row: Row,
@@ -465,7 +486,10 @@ export function DoclistBody(
       )}
       {error && <StateMessage tone="bad">{error}</StateMessage>}
       <div class="flex min-h-0 flex-1 flex-col">
-        <div class="scroll-slim min-h-0 flex-1 overflow-y-auto">
+        <div
+          ref={scrollerRef}
+          class="scroll-slim min-h-0 flex-1 overflow-y-auto"
+        >
           <DoclistTable
             columns={list.tableColumns}
             rows={list.pageRows}

--- a/src/ui/shared/doclist/DoclistBody.tsx
+++ b/src/ui/shared/doclist/DoclistBody.tsx
@@ -171,11 +171,20 @@ export function DoclistBody(
       setExpanded({ id: null, data: null, loading: false });
       return;
     }
-    if (expandedRef.current.id === expandedId) return;
     const row = rows.find((r, i) =>
       resolveRowId(r, rowAction, String(i)) === expandedId
     );
-    if (!row) return;
+    if (!row) {
+      // `rows` porte le jeu complet, pas la page : une ligne absente d'ici a
+      // disparu des données, elle n'est pas seulement sur une autre page. La
+      // garder ouverte laisserait un détail invisible et son contenu périmé en
+      // mémoire, que le retour sur la ligne ne rechargerait pas.
+      pendingRowIdRef.current = null;
+      setExpanded({ id: null, data: null, loading: false });
+      list.setExpandedId(null);
+      return;
+    }
+    if (expandedRef.current.id === expandedId) return;
     if (fixture || (!rowAction && row._detail)) {
       const envelope = recordOf(
         (row._detail as Row | undefined) ?? row,
@@ -248,6 +257,21 @@ export function DoclistBody(
       }
     })();
   }, [expandedId, rows, rowAction, fixture, data.doctype]);
+
+  // Un détail qui s'ouvre sous le pli n'existe pas pour qui l'a demandé : la
+  // ligne reste visible, son panneau est hors écran, et rien ne le signale.
+  // `nearest` ne déplace rien quand le panneau tient déjà dans le cadre.
+  useEffect(() => {
+    if (expanded.id === null) return;
+    const panel = document.getElementById(doclistDetailPanelId(expanded.id));
+    if (!panel) return;
+    const still = typeof matchMedia === "function" &&
+      matchMedia("(prefers-reduced-motion: reduce)").matches;
+    panel.scrollIntoView({
+      block: "nearest",
+      behavior: still ? "auto" : "smooth",
+    });
+  }, [expanded.id]);
 
   function rowInteractionTarget(
     row: Row,

--- a/src/ui/shared/doclist/interaction-contract_test.ts
+++ b/src/ui/shared/doclist/interaction-contract_test.ts
@@ -16,6 +16,48 @@ Deno.test("doclist detail id is stable and safe for aria-controls", () => {
   );
 });
 
+Deno.test("doclist re-scrolls the internal scroller when the detail envelope arrives", async () => {
+  const body = await Deno.readTextFile(
+    new URL("./DoclistBody.tsx", import.meta.url),
+  );
+
+  // Le chemin asynchrone pose `{ id, loading: true }` puis l'enveloppe :
+  // `id` ne change pas, `loading` si. Sans ça le scroll vise le squelette.
+  assertStringIncludes(body, "[expanded.id, expanded.loading]");
+  assertStringIncludes(body, "nearestScrollDelta(");
+  assertStringIncludes(body, "scroller.scrollTo({");
+  assertStringIncludes(body, "ref={scrollerRef}");
+  assertStringIncludes(
+    body,
+    'class="scroll-slim min-h-0 flex-1 overflow-y-auto"',
+  );
+  assertEquals(
+    body.includes(".scrollIntoView") || body.includes("scrollIntoView("),
+    false,
+    "scrollIntoView remonterait jusqu'à l'iframe hôte",
+  );
+});
+
+Deno.test("doclist closes detail when the expanded row leaves the current page", async () => {
+  const body = await Deno.readTextFile(
+    new URL("./DoclistBody.tsx", import.meta.url),
+  );
+
+  // Le tableau rend `pageRows` ; la fermeture doit chercher au même endroit.
+  // Chercher dans `rows` laisserait `expandedId` sur un panneau démonté.
+  assertStringIncludes(
+    body,
+    "const row = pageRows.find((r, i) =>",
+  );
+  assertStringIncludes(body, "rows={list.pageRows}");
+  assertEquals(
+    body.includes("const row = rows.find((r, i) =>"),
+    false,
+    "la ligne ouverte se cherche dans pageRows, pas dans rows",
+  );
+  assertStringIncludes(body, "list.setExpandedId(null)");
+});
+
 Deno.test("doclist wires every layout chevron to the real inline panel", async () => {
   const body = await Deno.readTextFile(
     new URL("./DoclistBody.tsx", import.meta.url),

--- a/src/ui/shared/doclist/scroll-nearest.ts
+++ b/src/ui/shared/doclist/scroll-nearest.ts
@@ -1,0 +1,24 @@
+/**
+ * Décalage `scrollTop` pour amener un enfant dans le cadre d'un scroller,
+ * sans toucher aux ancêtres — `scrollIntoView` remonterait jusqu'à l'iframe
+ * hôte.
+ *
+ * Même règle que `block: "nearest"` : rien si déjà visible ; le minimum
+ * sinon ; si l'enfant dépasse le cadre, on aligne le haut (début du détail,
+ * pas le pied du squelette qu'on venait de viser).
+ */
+
+export function nearestScrollDelta(
+  scroller: { top: number; bottom: number },
+  child: { top: number; bottom: number },
+): number {
+  if (child.top >= scroller.top && child.bottom <= scroller.bottom) {
+    return 0;
+  }
+  const childHeight = child.bottom - child.top;
+  const frameHeight = scroller.bottom - scroller.top;
+  if (childHeight >= frameHeight || child.top < scroller.top) {
+    return child.top - scroller.top;
+  }
+  return child.bottom - scroller.bottom;
+}

--- a/src/ui/shared/doclist/scroll-nearest_test.ts
+++ b/src/ui/shared/doclist/scroll-nearest_test.ts
@@ -1,0 +1,23 @@
+import { assertEquals } from "@std/assert";
+import { nearestScrollDelta } from "./scroll-nearest.ts";
+
+const FRAME = { top: 0, bottom: 200 };
+
+Deno.test("nearest scroll - déjà dans le cadre : rien", () => {
+  assertEquals(nearestScrollDelta(FRAME, { top: 20, bottom: 80 }), 0);
+});
+
+Deno.test("nearest scroll - dépasse en bas : le minimum vers le bas", () => {
+  assertEquals(nearestScrollDelta(FRAME, { top: 150, bottom: 250 }), 50);
+});
+
+Deno.test("nearest scroll - dépasse en haut : le minimum vers le haut", () => {
+  assertEquals(nearestScrollDelta(FRAME, { top: -40, bottom: 40 }), -40);
+});
+
+Deno.test("nearest scroll - plus haut que le cadre : aligne le haut", () => {
+  // Le squelette tenait ; l'enveloppe réelle dépasse. Aligner le pied
+  // cacherait le début du détail qu'on vient d'ouvrir.
+  assertEquals(nearestScrollDelta(FRAME, { top: 80, bottom: 400 }), 80);
+  assertEquals(nearestScrollDelta(FRAME, { top: -30, bottom: 300 }), -30);
+});

--- a/src/ui/shared/useContainerWidth.ts
+++ b/src/ui/shared/useContainerWidth.ts
@@ -12,7 +12,7 @@
  * des colonnes — dynamiques, dérivées du DocType — porte le montant.
  */
 
-import { useEffect, useRef, useState } from "preact/hooks";
+import { useLayoutEffect, useRef, useState } from "preact/hooks";
 import type { RefObject } from "preact";
 
 /** En deçà, la maquette abandonne le tableau pour des lignes empilées. */
@@ -27,14 +27,17 @@ export function useContainerWidth<T extends HTMLElement>(): [
   // clignoter la vue étroite au premier paint.
   const [width, setWidth] = useState<number | null>(null);
 
-  useEffect(() => {
+  // useLayoutEffect, pas useEffect : la mesure doit être posée avant que le
+  // navigateur peigne. Le ResizeObserver ne livre sa première entrée qu'après
+  // ce paint, et en aval `isNarrow(null)` est faux — un conteneur étroit se
+  // rendrait donc « large » le temps d'une frame, exactement le clignotement
+  // que le null initial cherchait à éviter.
+  useLayoutEffect(() => {
     const element = ref.current;
     if (!element) return;
 
-    if (typeof ResizeObserver === "undefined") {
-      setWidth(element.getBoundingClientRect().width);
-      return;
-    }
+    setWidth(contentWidth(element));
+    if (typeof ResizeObserver === "undefined") return;
 
     const observer = new ResizeObserver((entries) => {
       const entry = entries[0];
@@ -45,6 +48,21 @@ export function useContainerWidth<T extends HTMLElement>(): [
   }, []);
 
   return [ref, width];
+}
+
+/**
+ * La largeur de contenu, dans la même boîte que `contentRect`.
+ *
+ * `getBoundingClientRect` compterait la bordure, or la coque en porte une de
+ * 1 px de chaque côté (ui.tsx). La mesure initiale déciderait donc 2 px trop
+ * large et le premier passage du ResizeObserver la corrigerait après le paint
+ * — soit le clignotement qu'on retire ici, dans l'autre sens.
+ */
+function contentWidth(element: HTMLElement): number {
+  const style = getComputedStyle(element);
+  return element.clientWidth -
+    parseFloat(style.paddingLeft) -
+    parseFloat(style.paddingRight);
 }
 
 /** Vrai quand la mesure est faite et que le conteneur est sous le seuil. */

--- a/src/ui/shared/useViewerLayout.ts
+++ b/src/ui/shared/useViewerLayout.ts
@@ -45,14 +45,22 @@ export function layoutFromSearch(
  * c'est lui qui tranche (voir useViewerLayout). `matchMedia` interroge
  * l'appareil qui affiche la fenêtre, pas le contexte que l'hôte donne à
  * l'iframe — les deux peuvent différer.
+ *
+ * Lecture synchrone au premier render : un `false` initial peindrait `panel`
+ * (lignes empilées) avant `mobile` (tableau) sur un téléphone étroit sans
+ * `deviceCapabilities` d'hôte. Ce n'est pas deux densités du même tableau.
  */
+function readCoarsePointer(): boolean {
+  return typeof matchMedia === "function" &&
+    matchMedia("(pointer: coarse)").matches;
+}
+
 function useCoarsePointer(): boolean {
-  const [coarse, setCoarse] = useState(false);
+  const [coarse, setCoarse] = useState(readCoarsePointer);
 
   useEffect(() => {
     if (typeof matchMedia !== "function") return;
     const query = matchMedia("(pointer: coarse)");
-    setCoarse(query.matches);
     const onChange = (event: MediaQueryListEvent) => setCoarse(event.matches);
     // Un appareil hybride bascule quand on passe du trackpad à l'écran.
     query.addEventListener("change", onChange);

--- a/src/ui/shared/useViewerLayout_test.ts
+++ b/src/ui/shared/useViewerLayout_test.ts
@@ -1,0 +1,24 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+
+Deno.test("coarse pointer is read before the first paint", async () => {
+  const source = await Deno.readTextFile(
+    new URL("./useViewerLayout.ts", import.meta.url),
+  );
+  const hookStart = source.indexOf("function readCoarsePointer");
+  const hookEnd = source.indexOf("function useTouchInput");
+  assertEquals(hookStart >= 0 && hookEnd > hookStart, true);
+  const hook = source.slice(hookStart, hookEnd);
+
+  assertStringIncludes(hook, 'matchMedia("(pointer: coarse)")');
+  assertStringIncludes(hook, "useState(readCoarsePointer)");
+  assertEquals(
+    hook.includes("useState(false)"),
+    false,
+    "un false initial peindrait panel puis mobile",
+  );
+  assertEquals(
+    hook.includes("setCoarse(query.matches)"),
+    false,
+    "la lecture initiale ne doit plus vivre dans l'effet",
+  );
+});


### PR DESCRIPTION
Auditing the viewer layout templates against this implementation turned up four discrepancies. **Three are defects and are fixed here. The fourth is an error in the design document**, and the code is left alone.

## The three fixes

**An opened detail panel is brought into view.** A row near the bottom of the scroll container expanded a panel that was entirely off-screen, with nothing to signal it — the row stayed visible, its detail did not. `block: "nearest"` moves nothing when the panel already fits in frame; `prefers-reduced-motion` drops the smooth behaviour.

**The container is measured before the first paint.** `useContainerWidth` started at `null`, with a comment saying that rendering wide by default would make the narrow view flash. But downstream `isNarrow(null)` is `false`, and `useViewerLayout` maps that to `"wide"` — so a narrow container rendered wide for exactly one frame. Two functions each correct on their own, with the meaning lost at the joint. `useLayoutEffect` plus a synchronous measurement closes it in the hook that owns the measurement, touching neither `isNarrow` nor `useViewerLayout`.

That measurement reads the **content box**, the same one the `ResizeObserver` reports. The shell carries a 1px border on each side (`ui.tsx:51`), so reading the border box would decide 2px too wide and correct itself after the paint — the same flash in the other direction. This one was caught by the adversarial audit of the first version of this patch, not by the original review.

**A detail whose row disappears from the data closes.** `rows` carries the full set (`useDoclist.ts:41`), not the page (`pageRows`, `:107`), so a row missing from it is gone rather than merely on another page. The row lookup moved ahead of the already-loaded short-circuit, which previously returned early and left an invisible panel holding stale content that returning to the row would not reload.

## What is deliberately not fixed

The templates state a 40px row **in all three densities**. The wide row is a native `<tr>` whose height follows its content (`DoclistTable.tsx:346`, `truncate py-2`), around 36px; only mobile and panel enforce `min-h-10` (`:483`, `:576`). Making wide match would change the density of every wide table in all eight viewers — a design decision, not a defect. The document is what is wrong here, and it should read "40px in mobile and panel".

## Verification

`deno task check` passes, **822 tests pass**, **all eight ERPNext UIs build** (vite + preact + tailwind).

The 13 `deno lint` warnings and the `deno check` errors on `.tsx` files are pre-existing and environmental — the UI is built by vite, not type-checked by deno — and are identical without these changes.

Each fix was then audited from three angles (does it work, does it regress, is it the right fix), with every risk raised put to two independent skeptics asked to refute it. The scroll fix and the vanishing-row fix came back with nothing surviving. The measurement fix surfaced the box-model mismatch above, which is corrected in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Viewer UI and doclist interaction only; no auth, data, or API contract changes beyond safer detail lifecycle and scroll behavior.
> 
> **Overview**
> **Doclist inline detail** now scrolls the list’s **internal** overflow container (via new `nearestScrollDelta` + `scrollerRef`) instead of `scrollIntoView`, with **nearest** alignment and **`prefers-reduced-motion`** respected. Scrolling re-runs when **`expanded.loading`** flips so async loads scroll again after the skeleton is replaced by the real panel.
> 
> When the open row is **not on the current page** (`pageRows`), the detail **closes** and **`expandedId` clears**—covering refresh/paging edge cases where the row still exists in full `rows` but is no longer rendered.
> 
> **Layout flash fixes:** `useContainerWidth` measures **content width** synchronously in **`useLayoutEffect`** (matching `ResizeObserver`’s box). **`useCoarsePointer`** initializes from **`matchMedia("(pointer: coarse)")`** on first render so narrow touch iframes don’t paint **`panel` then `mobile`**.
> 
> Contract/source tests lock in scroll deps, `pageRows` lookup, and coarse-pointer initialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc23bc2f700c85760a48d0ded01ada5e0c4768cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


---

## Review findings — being addressed

A four-axis review of this branch found three real defects **in this fix**, and one false claim
in this description. They are corrected in the commits that follow; this section stays so the
record is honest about what the first version got wrong.

- **The scroll targeted the loading skeleton.** The effect depends only on `expanded.id`. On the
  async path the state is set to `{ id, data: null, loading: true }` first, mounting a 144px
  skeleton; when the envelope lands `expanded.id` does not change, so nothing scrolls again and
  the real document goes back below the fold. The fixture path works, which is why the earlier
  audit passed.
- **The flash was moved, not closed.** Width is now measured before paint, but `useCoarsePointer`
  still reads `matchMedia` in a `useEffect`, after it. A narrow touch iframe with no host
  `deviceCapabilities` paints `panel` (stacked rows) and then `mobile` (a table) — a change of
  structure, not of density.
- **The close still misses a case.** The table renders `pageRows` while the close looks in `rows`.
  A refresh that keeps the row in the data but pushes it off the current page leaves `expandedId`
  set on an unmounted panel — the symptom this fix exists to remove.
- **"paging away and back still restores the open detail" was false** and has been removed above.
  `setPage` and `setFilter` both clear `expandedId` (`useDoclist.ts:172`), so pagination discards
  the detail rather than preserving it. The code change is unaffected — a row absent from the full
  set is still gone — but the justification was wrong.
