### PR TITLE
chore: prepare 3.1.0 beta 6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to `@casys/mcp-erpnext` will be documented in this file.
 
+## [3.1.0-beta.6] - 2026-09-01
+
+### Changed
+
+- **Installing the 3.1 beta follows a channel, not a pinned build.** npm/Node
+  uses `@casys/mcp-erpnext@next`; Deno uses
+  `jsr:@casys/mcp-erpnext@^3.1.0-beta`. JSR has no dist-tags, hence the range
+  there. Exact versions remain in this changelog.
+- The generic document viewer now declares its own application version
+  (`1.0.0`), like the other seven MCP Apps, instead of echoing the package
+  prerelease.
+
+### Fixed
+
+- Opening a document-list detail near the bottom of the frame now brings the
+  panel into view. The viewer scrolls only its internal container, never the
+  host iframe, waits for the loaded document rather than the loading skeleton,
+  and drops the smooth behaviour when the user prefers reduced motion.
+- Layout density is decided before the first paint from both container width and
+  pointer type, so a narrow touch iframe no longer paints the stacked panel
+  layout before settling on mobile.
+- A detail whose row leaves the current page, or disappears from the data, now
+  closes instead of leaving an unmounted panel with stale content.
+
 ## [3.1.0-beta.5] - 2026-08-30
 
 ### Added

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@casys/mcp-erpnext",
-  "version": "3.1.0-beta.5",
+  "version": "3.1.0-beta.6",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {
     "age": "PT24H",

--- a/server.ts
+++ b/server.ts
@@ -105,7 +105,7 @@ async function main() {
   // Build MCP server
   const server = new McpApp({
     name: "mcp-erpnext",
-    version: "3.1.0-beta.5",
+    version: "3.1.0-beta.6",
     transport: "stateless",
     cache: {
       ttlMs: 3_600_000,


### PR DESCRIPTION
Version bump and changelog for **3.1.0-beta.6**, shipping the two branches merged just before it.

## What this release carries

**Doclist layout (#29)** — the detail panel is brought into view when it opens below the fold, scrolling the viewer's own container and never the host iframe, and waiting for the loaded document rather than the 144px loading skeleton. Layout density is decided before the first paint from both container width **and** pointer type, so a narrow touch iframe no longer paints the stacked `panel` layout before settling on `mobile`. A detail whose row leaves the current page, or the data, closes instead of leaving an unmounted panel with stale content.

**Release hygiene (#30)** — installing the beta follows a channel instead of a pinned build: `@next` on npm, `@^3.1.0-beta` on JSR, which has no dist-tags. The document viewer declares its own application version like the other seven, instead of echoing the package prerelease — the coupling that had left it two releases behind.

## Files

Three, and only three: `deno.json`, `server.ts`, `CHANGELOG.md`. `release_guard` compares the first two, which is why they move together.

## Verification

- `deno task check` passes
- `deno task test` — **829 passed**, 0 failed
- `cd src/ui && node build-all.mjs` — **8/8 UIs**
- `release_guard` simulated under `set -euo pipefail` with `GITHUB_REF=refs/tags/v3.1.0-beta.6`: versions aligned, channel resolves to **`next`**

## After merge

Tag `v3.1.0-beta.6`, then run **Publish** from that tag with `npm_dist_tag: auto`. The prerelease suffix routes it to `next`; `latest` stays on 3.0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only change with no runtime or security logic in the diff; `release_guard` expects `deno.json` and `server.ts` to move together.
> 
> **Overview**
> **Release cut for `3.1.0-beta.6`** — aligns `deno.json` and the MCP server identity in `server.ts` with the new prerelease and documents what ships in `CHANGELOG.md`.
> 
> The changelog records work already merged on the beta line: **doclist-viewer** fixes (in-view scroll-to-detail, first-paint layout from width + pointer type, auto-close when the row leaves the page or data), plus **install/channel hygiene** (`@next` on npm, `^3.1.0-beta` on JSR) and the generic **doc-viewer** reporting its own app version (`1.0.0`) instead of the package prerelease. This PR does not change viewer or publish logic—only version strings and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e38ecc2551f57f5d3a70727013eec1b16d63b826. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->